### PR TITLE
Add CPU fallback when CUDA missing

### DIFF
--- a/exampletrain.py
+++ b/exampletrain.py
@@ -16,12 +16,16 @@ if __name__ == '__main__':
         'ram_limit_mb': 1.0,
         'disk_limit_mb': 10
     }
+    if not torch.cuda.is_available():
+        params['ram_limit_mb'] += params.get('vram_limit_mb', 0)
+        params['vram_limit_mb'] = 0
     formula = "log(1+T)/log(1+I)"
     from diffusers import StableDiffusionPipeline
+    device = "cuda" if torch.cuda.is_available() else "cpu"
     pipe = StableDiffusionPipeline.from_pretrained(
         "stabilityai/stable-diffusion-3.5-large",
         torch_dtype=torch.bfloat16
-    ).to("cuda")
+    ).to(device)
     # Instantiate the MARBLE system with the option to initialize from weights.
     marble_system = MARBLE(params, formula=formula, formula_num_neurons=100, converter_model=pipe.text_encoder, init_from_weights=True)
     core = marble_system.get_core()

--- a/marble.py
+++ b/marble.py
@@ -137,7 +137,7 @@ class MetricsVisualizer:
         plt.show()
 
 # -----------------------------------------------------
-# 4. MARBLE System – internal modules
+# 4. MARBLE System Â– internal modules
 # -----------------------------------------------------
 
 # 4.1 Neuron and Synapse
@@ -170,7 +170,7 @@ def compute_mandelbrot(xmin, xmax, ymin, ymax, width, height, max_iter=256):
         mandelbrot[mask] = i
     return mandelbrot
 
-# 4.3 Core – Build the neural core (supports multiple worlds: VRAM, RAM, disk)
+# 4.3 Core Â– Build the neural core (supports multiple worlds: VRAM, RAM, disk)
 class Core:
     def __init__(self, params, formula=None, formula_num_neurons=100):
         print("Initializing MARBLE Core...")
@@ -252,7 +252,7 @@ class Core:
         print(f"Core expanded: {num_new_neurons} new neurons in {new_tier} and {num_new_synapses} new synapses added.")
         self.check_memory_usage()
 
-# 4.4 DataLoader – Serialization and Compression
+# 4.4 DataLoader Â– Serialization and Compression
 class DataLoader:
     def encode(self, data):
         serialized = pickle.dumps(data)
@@ -266,7 +266,7 @@ class DataLoader:
         data = pickle.loads(serialized)
         return data
 
-# 4.5 Neuronenblitz – Dynamic wandering, training, structural plasticity, splitting and merging of blitz processes
+# 4.5 Neuronenblitz Â– Dynamic wandering, training, structural plasticity, splitting and merging of blitz processes
 class Neuronenblitz:
     def __init__(self, core,
                  backtrack_probability=0.3,
@@ -430,7 +430,7 @@ class Neuronenblitz:
     def get_training_history(self):
         return self.training_history
 
-# 4.6 Brain – Integration of training, validation, inference, model saving, auto-firing, and dreaming
+# 4.6 Brain Â– Integration of training, validation, inference, model saving, auto-firing, and dreaming
 class Brain:
     def __init__(self, core, neuronenblitz, dataloader, save_threshold=0.05, max_saved_models=5, save_dir="saved_models", firing_interval_ms=500):
         self.core = core
@@ -559,7 +559,7 @@ class Brain:
         print(f"Global Activation Count: {self.neuronenblitz.global_activation_count}")
         print("-----------------------")
 
-# 4.7 BenchmarkManager – Compare MARBLE metrics with target metrics or a PyTorch model
+# 4.7 BenchmarkManager Â– Compare MARBLE metrics with target metrics or a PyTorch model
 class BenchmarkManager:
     def __init__(self, marble_system, target_metrics=None):
         self.marble = marble_system
@@ -602,7 +602,7 @@ class BenchmarkManager:
             if 'inference_time' in self.target_metrics:
                 print(f"Inference time diff: {current_inference_time - self.target_metrics['inference_time']:.4f}")
 
-# 4.8 MarbleConverter – Converts a PyTorch model (e.g., text-encoder) into a MARBLE Core.
+# 4.8 MarbleConverter Â– Converts a PyTorch model (e.g., text-encoder) into a MARBLE Core.
 #     Extended with an option to initialize from model weights.
 class MarbleConverter:
     @staticmethod
@@ -660,7 +660,7 @@ class MarbleConverter:
         return new_core
 
 # -----------------------------------------------------
-# 5. MARBLE Class – Container for the entire MARBLE system
+# 5. MARBLE Class Â– Container for the entire MARBLE system
 # -----------------------------------------------------
 class MARBLE:
     """
@@ -752,12 +752,12 @@ class MARBLE:
         return self.benchmark_manager
 
 # -----------------------------------------------------
-# 6. BenchmarkManager – Compare MARBLE metrics with target metrics or a PyTorch model
+# 6. BenchmarkManager Â– Compare MARBLE metrics with target metrics or a PyTorch model
 # (Already defined above inside our consolidated code.)
 # -----------------------------------------------------
 
 # -----------------------------------------------------
-# 7. MarbleConverter – Converts a PyTorch model (e.g., text-encoder) into a MARBLE Core.
+# 7. MarbleConverter Â– Converts a PyTorch model (e.g., text-encoder) into a MARBLE Core.
 # (Already defined above.)
 # -----------------------------------------------------
 
@@ -778,12 +778,16 @@ if __name__ == '__main__':
         'ram_limit_mb': 1.0,
         'disk_limit_mb': 10
     }
+    if not torch.cuda.is_available():
+        params['ram_limit_mb'] += params.get('vram_limit_mb', 0)
+        params['vram_limit_mb'] = 0
     formula = "log(1+T)/log(1+I)"
     from diffusers import StableDiffusionPipeline
+    device = "cuda" if torch.cuda.is_available() else "cpu"
     pipe = StableDiffusionPipeline.from_pretrained(
         "stabilityai/stable-diffusion-3.5-large",
         torch_dtype=torch.bfloat16
-    ).to("cuda")
+    ).to(device)
     # Instantiate the MARBLE system with the option to initialize from weights.
     marble_system = MARBLE(params, formula=formula, formula_num_neurons=100, converter_model=pipe.text_encoder, init_from_weights=True)
     core = marble_system.get_core()

--- a/marble_core.py
+++ b/marble_core.py
@@ -142,6 +142,17 @@ class Core:
             syn = Synapse(self.neurons[i].id, self.neurons[i+1].id, weight)
             self.neurons[i].synapses.append(syn)
             self.synapses.append(syn)
+
+        if not CUDA_AVAILABLE:
+            for neuron in self.neurons:
+                if neuron.tier == 'vram':
+                    neuron.tier = 'ram'
+            if 'vram' in TIER_REGISTRY and 'ram' in TIER_REGISTRY:
+                TIER_REGISTRY['ram'].limit_mb += TIER_REGISTRY['vram'].limit_mb
+                TIER_REGISTRY['vram'].limit_mb = 0
+            self.ram_limit_mb += self.vram_limit_mb
+            self.vram_limit_mb = 0
+            print("CUDA not available: migrated VRAM tiers to RAM.")
         self.check_memory_usage()
 
     def get_average_age(self, items):

--- a/marble_imports.py
+++ b/marble_imports.py
@@ -20,5 +20,17 @@ import math
 import sympy as sp
 import threading
 from datetime import datetime
-import cupy as cp
+# Determine CUDA availability and set up array module
+try:
+    import cupy as _cp
+    _cp.cuda.runtime.getDeviceCount()
+    cp = _cp
+    CUDA_AVAILABLE = torch.cuda.is_available()
+except Exception:
+    import numpy as _cp
+    cp = _cp
+    cp.asnumpy = lambda x: x
+    CUDA_AVAILABLE = False
+
+DEVICE = torch.device("cuda" if CUDA_AVAILABLE else "cpu")
 import torch.nn as nn

--- a/marble_main.py
+++ b/marble_main.py
@@ -76,14 +76,18 @@ if __name__ == '__main__':
         'ram_limit_mb': 1.0,
         'disk_limit_mb': 10
     }
+    if not torch.cuda.is_available():
+        params['ram_limit_mb'] += params.get('vram_limit_mb', 0)
+        params['vram_limit_mb'] = 0
     formula = "log(1+T)/log(1+I)"
 
     # Initialize MARBLE system
     from diffusers import StableDiffusionPipeline
+    device = "cuda" if torch.cuda.is_available() else "cpu"
     pipe = StableDiffusionPipeline.from_pretrained(
         "stabilityai/stable-diffusion-3.5-large",
         torch_dtype=torch.bfloat16
-    ).to("cuda")
+    ).to(device)
     
     marble_system = MARBLE(params, formula=formula, formula_num_neurons=100, 
                           converter_model=pipe.text_encoder, init_from_weights=True)


### PR DESCRIPTION
## Summary
- detect CUDA availability in `marble_imports`
- migrate VRAM tiers to RAM in `Core` when CUDA not available
- adapt training scripts to use CPU when CUDA is missing
- update example scripts to modify memory limits in CPU mode

## Testing
- `python -m py_compile exampletrain.py marble_main.py marble.py marble_core.py marble_neuronenblitz.py marble_brain.py marble_base.py marble_imports.py`

------
https://chatgpt.com/codex/tasks/task_e_687a1887b9908327b66e9a1194fe7f7f