### PR TITLE
Add JSON export utilities for Core

### DIFF
--- a/marble_utils.py
+++ b/marble_utils.py
@@ -1,0 +1,58 @@
+import json
+from marble_core import Core, Neuron, Synapse
+
+
+def core_to_json(core: Core) -> str:
+    """Serialize a Core instance to a JSON string."""
+    data = {
+        "neurons": [
+            {
+                "id": n.id,
+                "value": n.value,
+                "tier": n.tier,
+                "formula": str(n.formula) if n.formula is not None else None,
+            }
+            for n in core.neurons
+        ],
+        "synapses": [
+            {
+                "source": s.source,
+                "target": s.target,
+                "weight": s.weight,
+                "potential": s.potential,
+            }
+            for s in core.synapses
+        ],
+    }
+    return json.dumps(data)
+
+
+def core_from_json(json_str: str) -> Core:
+    """Create a Core instance from a JSON string."""
+    payload = json.loads(json_str)
+    params = {
+        'xmin': -2.0,
+        'xmax': 1.0,
+        'ymin': -1.5,
+        'ymax': 1.5,
+        'width': 1,
+        'height': 1,
+        'max_iter': 1,
+        'vram_limit_mb': 0.1,
+        'ram_limit_mb': 0.1,
+        'disk_limit_mb': 0.1,
+    }
+    core = Core(params, formula=None, formula_num_neurons=0)
+    core.neurons = []
+    core.synapses = []
+    for n in payload.get("neurons", []):
+        neuron = Neuron(n["id"], value=n["value"], tier=n.get("tier", "vram"))
+        if n.get("formula"):
+            neuron.formula = n["formula"]
+        core.neurons.append(neuron)
+    for s in payload.get("synapses", []):
+        syn = Synapse(s["source"], s["target"], weight=s["weight"])
+        syn.potential = s.get("potential", 1.0)
+        core.synapses.append(syn)
+        core.neurons[syn.source].synapses.append(syn)
+    return core

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,18 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import json
+from marble_core import Core
+from marble_utils import core_to_json, core_from_json
+from tests.test_core_functions import minimal_params
+
+
+def test_core_json_roundtrip():
+    params = minimal_params()
+    core = Core(params)
+    json_str = core_to_json(core)
+    assert isinstance(json_str, str)
+    new_core = core_from_json(json_str)
+    assert len(new_core.neurons) == len(core.neurons)
+    assert len(new_core.synapses) == len(core.synapses)
+    # Compare a few attributes
+    assert new_core.neurons[0].value == core.neurons[0].value


### PR DESCRIPTION
## Summary
- add `core_to_json` and `core_from_json` helpers for serializing `Core`
- test round-trip conversion of Core structures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a2ac6e3708327aef070911d93e519