### PR TITLE
Add DataCompressor for binary compression

### DIFF
--- a/data_compressor.py
+++ b/data_compressor.py
@@ -1,0 +1,31 @@
+import numpy as np
+import zlib
+
+class DataCompressor:
+    """Full transparent transitive binary compressor."""
+
+    @staticmethod
+    def bytes_to_bits(data: bytes) -> np.ndarray:
+        """Convert bytes to an array of binary bits."""
+        byte_array = np.frombuffer(data, dtype=np.uint8)
+        bits = np.unpackbits(byte_array)
+        return bits
+
+    @staticmethod
+    def bits_to_bytes(bits: np.ndarray) -> bytes:
+        """Convert an array of binary bits back to bytes."""
+        byte_array = np.packbits(bits.astype(np.uint8))
+        return byte_array.tobytes()
+
+    def compress(self, data: bytes) -> bytes:
+        """Compress bytes after converting to a binary representation."""
+        bits = self.bytes_to_bits(data)
+        compressed = zlib.compress(bits.tobytes())
+        return compressed
+
+    def decompress(self, compressed: bytes) -> bytes:
+        """Decompress and convert the binary representation back to bytes."""
+        bits_bytes = zlib.decompress(compressed)
+        bits = np.frombuffer(bits_bytes, dtype=np.uint8)
+        original_bytes = self.bits_to_bytes(bits)
+        return original_bytes

--- a/marble_core.py
+++ b/marble_core.py
@@ -90,16 +90,22 @@ def compute_mandelbrot(xmin, xmax, ymin, ymax, width, height, max_iter=256):
         mandelbrot[mask] = i
     return mandelbrot
 
+from data_compressor import DataCompressor
+
+
 class DataLoader:
+    def __init__(self, compressor: DataCompressor | None = None):
+        self.compressor = compressor if compressor is not None else DataCompressor()
+
     def encode(self, data):
         serialized = pickle.dumps(data)
-        compressed = zlib.compress(serialized)
+        compressed = self.compressor.compress(serialized)
         tensor = np.frombuffer(compressed, dtype=np.uint8)
         return tensor
 
     def decode(self, tensor):
         compressed = tensor.tobytes()
-        serialized = zlib.decompress(compressed)
+        serialized = self.compressor.decompress(compressed)
         data = pickle.loads(serialized)
         return data
 

--- a/tests/test_data_compressor.py
+++ b/tests/test_data_compressor.py
@@ -1,0 +1,12 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from data_compressor import DataCompressor
+
+
+def test_compression_roundtrip():
+    dc = DataCompressor()
+    original = b"example data bytes"
+    compressed = dc.compress(original)
+    decompressed = dc.decompress(compressed)
+    assert decompressed == original


### PR DESCRIPTION
## Summary
- implement `DataCompressor` for full binary compression
- integrate `DataCompressor` into `DataLoader`
- test compression roundtrip

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a2d6eab608327b5fd6c6dca6c5735