### PR TITLE
Add neuromodulatory system

### DIFF
--- a/marble_brain.py
+++ b/marble_brain.py
@@ -1,9 +1,10 @@
 from marble_imports import *
 from marble_core import Core, TIER_REGISTRY
 from marble_neuronenblitz import Neuronenblitz
+from neuromodulatory_system import NeuromodulatorySystem
 
 class Brain:
-    def __init__(self, core, neuronenblitz, dataloader, save_threshold=0.05, max_saved_models=5, save_dir="saved_models", firing_interval_ms=500):
+    def __init__(self, core, neuronenblitz, dataloader, save_threshold=0.05, max_saved_models=5, save_dir="saved_models", firing_interval_ms=500, neuromodulatory_system=None):
         self.core = core
         self.neuronenblitz = neuronenblitz
         self.dataloader = dataloader
@@ -17,6 +18,7 @@ class Brain:
         self.dream_thread = None
         self.best_validation_loss = float('inf')
         self.saved_model_paths = []
+        self.neuromodulatory_system = neuromodulatory_system if neuromodulatory_system is not None else NeuromodulatorySystem()
         self.tier_decision_params = {
             'vram_usage_threshold': 0.9,
             'ram_usage_threshold': 0.9

--- a/neuromodulatory_system.py
+++ b/neuromodulatory_system.py
@@ -1,0 +1,19 @@
+class NeuromodulatorySystem:
+    """Tracks neuromodulatory signals like arousal, stress and reward."""
+
+    def __init__(self, initial=None):
+        self.signals = {
+            "arousal": 0.0,
+            "stress": 0.0,
+            "reward": 0.0,
+            "emotion": "neutral",
+        }
+        if initial:
+            self.update_signals(**initial)
+
+    def update_signals(self, **kwargs):
+        for key, value in kwargs.items():
+            self.signals[key] = value
+
+    def get_context(self):
+        return self.signals.copy()

--- a/tests/test_brain_io.py
+++ b/tests/test_brain_io.py
@@ -6,6 +6,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from marble_core import Core, DataLoader
 from marble_neuronenblitz import Neuronenblitz
 from marble_brain import Brain
+from neuromodulatory_system import NeuromodulatorySystem
 
 from tests.test_core_functions import minimal_params
 
@@ -48,3 +49,13 @@ def test_metrics_visualizer_update():
     mv.update({'loss': 0.5, 'vram_usage': 0.1})
     assert mv.metrics['loss'][-1] == 0.5
     assert mv.metrics['vram_usage'][-1] == 0.1
+
+
+def test_brain_neuromodulatory_system_integration():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    ns = NeuromodulatorySystem()
+    brain = Brain(core, nb, DataLoader(), neuromodulatory_system=ns, save_dir="saved_models")
+    ns.update_signals(arousal=0.2)
+    assert brain.neuromodulatory_system.get_context()['arousal'] == 0.2

--- a/tests/test_neuromodulatory.py
+++ b/tests/test_neuromodulatory.py
@@ -1,0 +1,27 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from neuromodulatory_system import NeuromodulatorySystem
+from marble_core import Core, DataLoader
+from marble_neuronenblitz import Neuronenblitz
+from marble_brain import Brain
+from tests.test_core_functions import minimal_params
+
+
+def test_neuromodulatory_update_and_context():
+    ns = NeuromodulatorySystem()
+    ns.update_signals(arousal=0.7, reward=0.3)
+    ctx = ns.get_context()
+    assert ctx['arousal'] == 0.7
+    assert ctx['reward'] == 0.3
+
+
+def test_brain_uses_neuromodulatory_system():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    ns = NeuromodulatorySystem()
+    brain = Brain(core, nb, DataLoader(), neuromodulatory_system=ns, save_dir="saved_models")
+    assert brain.neuromodulatory_system is ns
+    ns.update_signals(stress=0.5)
+    assert brain.neuromodulatory_system.get_context()['stress'] == 0.5


### PR DESCRIPTION
## Summary
- implement simple `NeuromodulatorySystem` for tracking arousal, stress, reward, and emotion
- integrate the system into `Brain`
- test integration and context retrieval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a2e93b8988327aec60365839c4613