### PR TITLE
Improve compression utilities

### DIFF
--- a/data_compressor.py
+++ b/data_compressor.py
@@ -1,5 +1,7 @@
 import numpy as np
 import zlib
+import struct
+import pickle
 
 class DataCompressor:
     """Full transparent transitive binary compressor."""
@@ -29,3 +31,21 @@ class DataCompressor:
         bits = np.frombuffer(bits_bytes, dtype=np.uint8)
         original_bytes = self.bits_to_bytes(bits)
         return original_bytes
+
+    def compress_array(self, array: np.ndarray) -> bytes:
+        """Compress a NumPy array with metadata for lossless recovery."""
+        metadata = {"shape": array.shape, "dtype": str(array.dtype)}
+        meta_bytes = pickle.dumps(metadata)
+        header = struct.pack("<I", len(meta_bytes))
+        payload = header + meta_bytes + array.tobytes()
+        return self.compress(payload)
+
+    def decompress_array(self, compressed: bytes) -> np.ndarray:
+        """Decompress bytes into a NumPy array using stored metadata."""
+        payload = self.decompress(compressed)
+        meta_len = struct.unpack("<I", payload[:4])[0]
+        meta_bytes = payload[4 : 4 + meta_len]
+        metadata = pickle.loads(meta_bytes)
+        array_bytes = payload[4 + meta_len :]
+        arr = np.frombuffer(array_bytes, dtype=np.dtype(metadata["dtype"]))
+        return arr.reshape(metadata["shape"])

--- a/marble_core.py
+++ b/marble_core.py
@@ -109,6 +109,16 @@ class DataLoader:
         data = pickle.loads(serialized)
         return data
 
+    def encode_array(self, array: np.ndarray) -> np.ndarray:
+        """Encode a NumPy array into a uint8 tensor using compression."""
+        compressed = self.compressor.compress_array(array)
+        return np.frombuffer(compressed, dtype=np.uint8)
+
+    def decode_array(self, tensor: np.ndarray) -> np.ndarray:
+        """Decode a tensor created by ``encode_array`` back to a NumPy array."""
+        compressed = tensor.tobytes()
+        return self.compressor.decompress_array(compressed)
+
 class Core:
     def __init__(self, params, formula=None, formula_num_neurons=100):
         print("Initializing MARBLE Core...")

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -38,6 +38,14 @@ def test_dataloader_roundtrip():
     assert out == data
 
 
+def test_dataloader_array_roundtrip():
+    dl = DataLoader()
+    arr = np.arange(9, dtype=np.int32).reshape(3, 3)
+    tensor = dl.encode_array(arr)
+    restored = dl.decode_array(tensor)
+    assert np.array_equal(restored, arr)
+
+
 def test_core_expand_adds_neurons():
     random.seed(0)
     params = minimal_params()

--- a/tests/test_data_compressor.py
+++ b/tests/test_data_compressor.py
@@ -1,5 +1,6 @@
 import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import numpy as np
 
 from data_compressor import DataCompressor
 
@@ -10,3 +11,11 @@ def test_compression_roundtrip():
     compressed = dc.compress(original)
     decompressed = dc.decompress(compressed)
     assert decompressed == original
+
+
+def test_array_compression_roundtrip():
+    dc = DataCompressor()
+    arr = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32)
+    compressed = dc.compress_array(arr)
+    restored = dc.decompress_array(compressed)
+    assert np.array_equal(restored, arr)


### PR DESCRIPTION
## Summary
- extend `DataCompressor` with `compress_array` and `decompress_array`
- expose array helpers in `DataLoader`
- test round‑trip compression for arrays
- ensure array encoding/decoding works via `DataLoader`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a3742f46083278ed42817bd567bcb