### PR TITLE
Enhance MARBLE neurogenesis and plasticity

### DIFF
--- a/marble_brain.py
+++ b/marble_brain.py
@@ -58,10 +58,20 @@ class Brain:
         print(f"[Brain] Growth decision: '{chosen}' tier (VRAM: {vram_usage:.2f}MB/{vram_limit}MB, age: {vram_neuron_age:.1f}s)")
         return chosen
 
+    def perform_neurogenesis(self, base_neurons=5, base_synapses=10):
+        """Grow new neurons and synapses based on neuromodulatory context."""
+        ctx = self.neuromodulatory_system.get_context()
+        factor = 1.0 + max(ctx.get('arousal', 0.0), ctx.get('reward', 0.0))
+        num_neurons = int(base_neurons * factor)
+        num_synapses = int(base_synapses * factor)
+        self.core.expand(num_new_neurons=num_neurons, num_new_synapses=num_synapses)
+        return num_neurons, num_synapses
+
     def train(self, train_examples, epochs=1, validation_examples=None):
         pbar = tqdm(range(epochs), desc="Epochs", ncols=100)
         for epoch in pbar:
             self.neuronenblitz.train(train_examples, epochs=1)
+            self.neuronenblitz.modulate_plasticity(self.neuromodulatory_system.get_context())
             if validation_examples is not None:
                 val_loss = self.validate(validation_examples)
             else:

--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -35,6 +35,13 @@ class Neuronenblitz:
         self.training_history = []
         self.global_activation_count = 0
 
+    def modulate_plasticity(self, context):
+        """Adjust plasticity_threshold based on neuromodulatory context."""
+        reward = context.get('reward', 0.0)
+        stress = context.get('stress', 0.0)
+        adjustment = reward - stress
+        self.plasticity_threshold = max(0.5, self.plasticity_threshold - adjustment)
+
     def reset_neuron_values(self):
         for neuron in self.core.neurons:
             neuron.value = None

--- a/tests/test_neurogenesis_plasticity.py
+++ b/tests/test_neurogenesis_plasticity.py
@@ -1,0 +1,31 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from marble_core import Core, DataLoader
+from marble_neuronenblitz import Neuronenblitz
+from marble_brain import Brain
+from neuromodulatory_system import NeuromodulatorySystem
+from tests.test_core_functions import minimal_params
+
+
+def test_modulate_plasticity_changes_threshold():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core, plasticity_threshold=5.0)
+    nb.modulate_plasticity({'reward': 0.4, 'stress': 0.1})
+    assert nb.plasticity_threshold < 5.0
+    prev = nb.plasticity_threshold
+    nb.modulate_plasticity({'reward': 0.0, 'stress': 0.6})
+    assert nb.plasticity_threshold > prev
+
+
+def test_brain_perform_neurogenesis():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    ns = NeuromodulatorySystem()
+    brain = Brain(core, nb, DataLoader(), neuromodulatory_system=ns)
+    initial_neurons = len(core.neurons)
+    ns.update_signals(arousal=0.5)
+    added_neurons, _ = brain.perform_neurogenesis(base_neurons=2, base_synapses=2)
+    assert len(core.neurons) >= initial_neurons + added_neurons


### PR DESCRIPTION
## Summary
- add `perform_neurogenesis` method in `Brain` and integrate plasticity modulation into training
- introduce `modulate_plasticity` helper in `Neuronenblitz`
- create tests covering new neurogenesis and plasticity features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a493976948327a0af3b76f6b3ffb9