### PR TITLE
Add neuron clustering and relocation mechanisms

### DIFF
--- a/marble_brain.py
+++ b/marble_brain.py
@@ -108,6 +108,8 @@ class Brain:
                 self.core.expand(num_new_neurons=10, num_new_synapses=15,
                                alternative_connection_prob=0.1, target_tier=new_tier)
                 self.perform_neurogenesis()
+            self.core.cluster_neurons(k=3)
+            self.core.relocate_clusters()
         pbar.close()
 
     def validate(self, validation_examples):

--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -155,6 +155,11 @@ class Neuronenblitz:
             syn.weight += delta
             if random.random() < self.consolidation_probability:
                 syn.weight *= self.consolidation_strength
+            score = abs(error) * abs(syn.weight) / max(path_length, 1)
+            self.core.neurons[syn.target].attention_score += score
+        if path:
+            last_neuron = self.core.neurons[path[-1].target]
+            last_neuron.attention_score += abs(error)
         self.training_history.append({
             'input': input_value,
             'target': target_value,

--- a/tests/test_neuron_clustering.py
+++ b/tests/test_neuron_clustering.py
@@ -1,0 +1,38 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from marble_brain import Brain
+from tests.test_core_functions import minimal_params
+
+
+def test_core_cluster_assigns_ids():
+    params = minimal_params()
+    core = Core(params)
+    core.cluster_neurons(k=2)
+    clusters = {n.cluster_id for n in core.neurons}
+    assert None not in clusters
+    assert len(clusters) <= 2
+
+
+def test_relocate_clusters_changes_tiers():
+    params = minimal_params()
+    core = Core(params)
+    for n in core.neurons[:3]:
+        n.cluster_id = 0
+        n.attention_score = 1.5
+    core.relocate_clusters(high=1.0, medium=0.5)
+    tiers = {n.tier for n in core.neurons[:3]}
+    assert tiers == {"vram"} or tiers == {"ram", "vram"} or tiers == {"ram"}
+
+
+def test_clustering_during_training():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, None)
+    train_examples = [(0.1, 0.2), (0.2, 0.3)]
+    brain.train(train_examples, epochs=1, validation_examples=None)
+    has_cluster = any(n.cluster_id is not None for n in core.neurons)
+    assert has_cluster


### PR DESCRIPTION
## Summary
- track attention score per neuron
- implement neuron clustering and relocation in `Core`
- update training to compute attention and trigger clustering/relocation
- add tests for clustering behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4c7b9f0083278586e6326af4ed1a