### PR TITLE
Add neuron types and self-attention for neurogenesis

### DIFF
--- a/marble_brain.py
+++ b/marble_brain.py
@@ -80,8 +80,10 @@ class Brain:
         factor *= self.neurogenesis_factor
         num_neurons = int(base_neurons * factor)
         num_synapses = int(base_synapses * factor)
-        self.core.expand(num_new_neurons=num_neurons, num_new_synapses=num_synapses)
-        return num_neurons, num_synapses
+        n_type = self.neuronenblitz.get_preferred_neuron_type()
+        self.core.expand(num_new_neurons=num_neurons, num_new_synapses=num_synapses,
+                         neuron_types=n_type)
+        return num_neurons, num_synapses, n_type
 
     def train(self, train_examples, epochs=1, validation_examples=None):
         pbar = tqdm(range(epochs), desc="Epochs", ncols=100)

--- a/marble_core.py
+++ b/marble_core.py
@@ -1,5 +1,8 @@
 from marble_imports import *
 
+# List of supported neuron types
+NEURON_TYPES = ["standard", "excitatory", "inhibitory", "modulatory"]
+
 # Global registry for all tiers
 TIER_REGISTRY = {}
 
@@ -61,10 +64,11 @@ class FileTier(Tier):
         return modified_data
 
 class Neuron:
-    def __init__(self, nid, value=0.0, tier='vram'):
+    def __init__(self, nid, value=0.0, tier='vram', neuron_type='standard'):
         self.id = nid
         self.value = value
         self.tier = tier
+        self.neuron_type = neuron_type if neuron_type in NEURON_TYPES else 'standard'
         self.synapses = []
         self.formula = None
         self.created_at = datetime.now()
@@ -220,13 +224,19 @@ class Core:
                 return tier.name
         return available_tiers[-1].name
 
-    def expand(self, num_new_neurons=10, num_new_synapses=15, 
-              alternative_connection_prob=0.1, target_tier=None):
+    def expand(self, num_new_neurons=10, num_new_synapses=15,
+              alternative_connection_prob=0.1, target_tier=None,
+              neuron_types=None):
         if target_tier is None:
             target_tier = self.choose_new_tier()
         start_id = len(self.neurons)
         for i in range(num_new_neurons):
-            self.neurons.append(Neuron(start_id + i, value=0.0, tier=target_tier))
+            if isinstance(neuron_types, list):
+                n_type = random.choice(neuron_types) if neuron_types else 'standard'
+            else:
+                n_type = neuron_types if neuron_types is not None else 'standard'
+            self.neurons.append(Neuron(start_id + i, value=0.0,
+                                      tier=target_tier, neuron_type=n_type))
         for _ in range(num_new_synapses):
             src = random.choice(self.neurons).id
             tgt = random.choice(self.neurons).id

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -54,6 +54,14 @@ def test_core_expand_adds_neurons():
     core.expand(num_new_neurons=2, num_new_synapses=2)
     assert len(core.neurons) >= initial_neurons + 2
 
+def test_core_expand_assigns_types():
+    random.seed(0)
+    params = minimal_params()
+    core = Core(params)
+    core.expand(num_new_neurons=3, num_new_synapses=0, neuron_types=['excitatory'])
+    types = {n.neuron_type for n in core.neurons[-3:]}
+    assert types == {'excitatory'}
+
 
 def test_neuronenblitz_train_example_updates_history():
     random.seed(0)


### PR DESCRIPTION
## Summary
- introduce `NEURON_TYPES` and extend `Neuron` with a `neuron_type` attribute
- update `Core.expand` to assign neuron types when creating neurons
- track type attention in `Neuronenblitz` and choose neuron type during neurogenesis
- extend `Brain.perform_neurogenesis` to create neurons of the preferred type
- add tests covering neuron type expansion and attention-guided neurogenesis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4ff44f208327a51a58c41e69cadf