### PR TITLE
Introduce lobes with self-attention

### DIFF
--- a/marble_brain.py
+++ b/marble_brain.py
@@ -3,6 +3,7 @@ from marble_core import Core, TIER_REGISTRY
 from marble_neuronenblitz import Neuronenblitz
 from neuromodulatory_system import NeuromodulatorySystem
 from meta_parameter_controller import MetaParameterController
+from marble_lobes import LobeManager
 
 class Brain:
     def __init__(self, core, neuronenblitz, dataloader, save_threshold=0.05,
@@ -23,6 +24,7 @@ class Brain:
         self.saved_model_paths = []
         self.neuromodulatory_system = neuromodulatory_system if neuromodulatory_system is not None else NeuromodulatorySystem()
         self.meta_controller = meta_controller if meta_controller is not None else MetaParameterController()
+        self.lobe_manager = LobeManager(core)
         self.neurogenesis_factor = 1.0
         self.last_val_loss = None
         self.tier_decision_params = {
@@ -112,6 +114,8 @@ class Brain:
                 self.perform_neurogenesis()
             self.core.cluster_neurons(k=3)
             self.core.relocate_clusters()
+            self.lobe_manager.organize()
+            self.lobe_manager.self_attention(val_loss)
         pbar.close()
 
     def validate(self, validation_examples):
@@ -197,6 +201,10 @@ class Brain:
         if self.dream_thread is not None:
             self.dream_thread.join()
         print("Dreaming stopped.")
+
+    def get_lobe_manager(self):
+        """Return the lobe manager instance."""
+        return self.lobe_manager
 
     def display_live_status(self, validation_examples):
         status = self.core.get_detailed_status()

--- a/marble_lobes.py
+++ b/marble_lobes.py
@@ -1,0 +1,52 @@
+from marble_imports import *
+
+class Lobe:
+    def __init__(self, lid, neuron_ids=None):
+        self.id = lid
+        self.neuron_ids = neuron_ids if neuron_ids is not None else []
+        self.attention_score = 0.0
+
+class LobeManager:
+    """Manages lobes and performs self-attention based optimizations."""
+
+    def __init__(self, core):
+        self.core = core
+        self.lobes = []
+
+    def genesis(self, neuron_ids):
+        """Create a new lobe containing ``neuron_ids``."""
+        lobe = Lobe(len(self.lobes), list(neuron_ids))
+        self.lobes.append(lobe)
+        return lobe
+
+    def organize(self):
+        """Organize neurons into lobes based on their cluster IDs."""
+        clusters = {}
+        for idx, neuron in enumerate(self.core.neurons):
+            if neuron.cluster_id is not None:
+                clusters.setdefault(neuron.cluster_id, []).append(idx)
+        self.lobes = []
+        for ids in clusters.values():
+            self.genesis(ids)
+
+    def update_attention(self):
+        for lobe in self.lobes:
+            lobe.attention_score = sum(self.core.neurons[n].attention_score for n in lobe.neuron_ids)
+
+    def self_attention(self, loss):
+        """Adjust neuron attention based on lobe-level attention and loss."""
+        if not self.lobes:
+            return
+        self.update_attention()
+        avg_att = sum(l.attention_score for l in self.lobes) / len(self.lobes)
+        for lobe in self.lobes:
+            if loss is None:
+                continue
+            if loss > 0 and lobe.attention_score < avg_att:
+                factor = 1.05
+            elif loss <= 0 and lobe.attention_score > avg_att:
+                factor = 0.95
+            else:
+                factor = 1.0
+            for nid in lobe.neuron_ids:
+                self.core.neurons[nid].attention_score *= factor

--- a/tests/test_lobe_manager.py
+++ b/tests/test_lobe_manager.py
@@ -1,0 +1,44 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from marble_lobes import LobeManager
+from marble_core import Core
+from marble_brain import Brain
+from marble_neuronenblitz import Neuronenblitz
+from marble_core import DataLoader
+from tests.test_core_functions import minimal_params
+
+
+def test_lobe_genesis_and_attention():
+    params = minimal_params()
+    core = Core(params)
+    manager = LobeManager(core)
+    manager.genesis([0, 1])
+    assert len(manager.lobes) == 1
+    core.neurons[0].attention_score = 1.0
+    core.neurons[1].attention_score = 2.0
+    manager.update_attention()
+    assert manager.lobes[0].attention_score == 3.0
+
+
+def test_lobe_self_attention():
+    params = minimal_params()
+    core = Core(params)
+    manager = LobeManager(core)
+    manager.genesis([0, 1])
+    manager.genesis([2])
+    core.neurons[0].attention_score = 0.5
+    core.neurons[1].attention_score = 0.5
+    core.neurons[2].attention_score = 2.0
+    manager.self_attention(loss=1.0)
+    assert core.neurons[0].attention_score > 0.5
+
+
+def test_brain_lobe_integration():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader())
+    core.cluster_neurons(k=2)
+    brain.lobe_manager.organize()
+    assert brain.lobe_manager.lobes


### PR DESCRIPTION
## Summary
- implement `Lobe` and `LobeManager` with self-attention
- integrate `LobeManager` into `Brain`
- organize lobes and apply self-attention during training
- expose lobe manager via `Brain.get_lobe_manager`
- add tests for lobe manager functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a5200b5dc8327b34925c0f149727a