### PR TITLE
Implement message passing with attention

### DIFF
--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -1,5 +1,5 @@
 from marble_imports import *
-from marble_core import Neuron, Synapse, NEURON_TYPES
+from marble_core import Neuron, Synapse, NEURON_TYPES, perform_message_passing
 
 class Neuronenblitz:
     def __init__(self, core,
@@ -198,6 +198,7 @@ class Neuronenblitz:
             if avg_error > 0.1:
                 self.core.expand(num_new_neurons=10, num_new_synapses=15, alternative_connection_prob=self.alternative_connection_prob)
             self.core.synapses = [s for s in self.core.synapses if abs(s.weight) >= 0.05]
+            perform_message_passing(self.core)
 
     def get_training_history(self):
         return self.training_history

--- a/tests/test_message_passing.py
+++ b/tests/test_message_passing.py
@@ -1,0 +1,17 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import numpy as np
+from marble_core import Core, perform_message_passing
+from tests.test_core_functions import minimal_params
+
+
+def test_message_passing_updates_representation():
+    np.random.seed(0)
+    params = minimal_params()
+    core = Core(params)
+    for n in core.neurons:
+        n.representation = np.random.rand(4)
+    before = [n.representation.copy() for n in core.neurons]
+    perform_message_passing(core)
+    changed = any(not np.allclose(n.representation, before[i]) for i, n in enumerate(core.neurons))
+    assert changed


### PR DESCRIPTION
## Summary
- augment `Neuron` with representation vector
- add simple MLP and `perform_message_passing` in `marble_core`
- invoke message passing in `Neuronenblitz.train`
- test the new message passing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a5ff318588327a39762564024666e