### PR TITLE
Add evolutionary mechanisms to brain

### DIFF
--- a/marble_brain.py
+++ b/marble_brain.py
@@ -120,6 +120,7 @@ class Brain:
             self.lobe_manager.organize()
             self.lobe_manager.self_attention(val_loss)
             self.consolidate_memory()
+            self.evolve()
         pbar.close()
 
     def validate(self, validation_examples):
@@ -240,6 +241,31 @@ class Brain:
         if self.dream_thread is not None:
             self.dream_thread.join()
         print("Dreaming stopped.")
+
+    def mutate_synapses(self, mutation_rate=0.01, mutation_strength=0.05):
+        """Randomly adjust synapse weights to introduce variation."""
+        mutated = 0
+        for syn in self.core.synapses:
+            if random.random() < mutation_rate:
+                syn.weight += random.uniform(-mutation_strength, mutation_strength)
+                mutated += 1
+        return mutated
+
+    def prune_weak_synapses(self, threshold=0.01):
+        """Remove synapses with very small absolute weights."""
+        pruned = 0
+        self.core.synapses = [s for s in self.core.synapses if abs(s.weight) >= threshold]
+        for neuron in self.core.neurons:
+            before = len(neuron.synapses)
+            neuron.synapses = [s for s in neuron.synapses if abs(s.weight) >= threshold]
+            pruned += before - len(neuron.synapses)
+        return pruned
+
+    def evolve(self, mutation_rate=0.01, mutation_strength=0.05, prune_threshold=0.01):
+        """Apply evolutionary operators like mutation and pruning."""
+        mutated = self.mutate_synapses(mutation_rate, mutation_strength)
+        pruned = self.prune_weak_synapses(prune_threshold)
+        return mutated, pruned
 
     def get_lobe_manager(self):
         """Return the lobe manager instance."""

--- a/tests/test_evolutionary_mechanisms.py
+++ b/tests/test_evolutionary_mechanisms.py
@@ -1,0 +1,48 @@
+import random
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from marble_core import Core, DataLoader
+from marble_neuronenblitz import Neuronenblitz
+from marble_brain import Brain
+from tests.test_core_functions import minimal_params
+
+
+def test_mutate_synapses_changes_weights():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader())
+    random.seed(0)
+    weights_before = [s.weight for s in core.synapses]
+    mutated = brain.mutate_synapses(mutation_rate=1.0, mutation_strength=0.1)
+    weights_after = [s.weight for s in core.synapses]
+    assert mutated == len(core.synapses)
+    assert weights_before != weights_after
+
+
+def test_prune_weak_synapses_removes_small_weights():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader())
+    for syn in core.synapses:
+        syn.weight = 0.001
+    initial_count = len(core.synapses)
+    pruned = brain.prune_weak_synapses(threshold=0.01)
+    assert pruned == initial_count
+    assert len(core.synapses) == 0
+
+
+def test_evolve_combines_mutation_and_prune():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader())
+    for syn in core.synapses:
+        syn.weight = 0.0
+    initial_count = len(core.synapses)
+    mutated, pruned = brain.evolve(mutation_rate=1.0, mutation_strength=0.0, prune_threshold=0.01)
+    assert mutated == initial_count
+    assert pruned == initial_count
+    assert len(core.synapses) == 0


### PR DESCRIPTION
## Summary
- expand Brain.train with an evolutionary step
- implement mutate_synapses and prune_weak_synapses
- add new evolve method combining mutation and pruning
- test the new evolutionary mechanisms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a638fdde88327b61c2b5942dd91d3