### PR TITLE
Implement remote brain offloading

### DIFF
--- a/marble_lobes.py
+++ b/marble_lobes.py
@@ -50,3 +50,12 @@ class LobeManager:
                 factor = 1.0
             for nid in lobe.neuron_ids:
                 self.core.neurons[nid].attention_score *= factor
+
+    def select_high_attention(self, threshold=1.0):
+        """Return neuron IDs belonging to lobes with attention above ``threshold``."""
+        self.update_attention()
+        selected = []
+        for lobe in self.lobes:
+            if lobe.attention_score > threshold:
+                selected.extend(lobe.neuron_ids)
+        return selected

--- a/marble_main.py
+++ b/marble_main.py
@@ -4,7 +4,7 @@ from marble_neuronenblitz import Neuronenblitz
 from marble_brain import Brain, BenchmarkManager
 
 class MARBLE:
-    def __init__(self, params, formula=None, formula_num_neurons=100, converter_model=None, nb_params=None, brain_params=None, init_from_weights=False):
+    def __init__(self, params, formula=None, formula_num_neurons=100, converter_model=None, nb_params=None, brain_params=None, init_from_weights=False, remote_client=None):
         if converter_model is not None:
             self.core = MarbleConverter.convert(converter_model, mode='sequential', core_params=params, init_from_weights=init_from_weights)
         else:
@@ -29,7 +29,7 @@ class MARBLE:
         }
         if nb_params is not None:
             nb_defaults.update(nb_params)
-        self.neuronenblitz = Neuronenblitz(self.core, **nb_defaults)
+        self.neuronenblitz = Neuronenblitz(self.core, remote_client=remote_client, **nb_defaults)
         
         brain_defaults = {
             'save_threshold': 0.05,
@@ -39,7 +39,7 @@ class MARBLE:
         }
         if brain_params is not None:
             brain_defaults.update(brain_params)
-        self.brain = Brain(self.core, self.neuronenblitz, self.dataloader, **brain_defaults)
+        self.brain = Brain(self.core, self.neuronenblitz, self.dataloader, remote_client=remote_client, **brain_defaults)
         
         self.metrics_visualizer = MetricsVisualizer()
         self.benchmark_manager = BenchmarkManager(self)

--- a/remote_offload.py
+++ b/remote_offload.py
@@ -1,0 +1,71 @@
+from marble_utils import core_to_json, core_from_json
+from marble_neuronenblitz import Neuronenblitz
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import requests
+
+class RemoteBrainServer:
+    """Simple HTTP server hosting a remote brain."""
+    def __init__(self, host="localhost", port=8000):
+        self.host = host
+        self.port = port
+        self.core = None
+        self.neuronenblitz = None
+        self.httpd = None
+        self.thread = None
+
+    def start(self):
+        server = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def _set_headers(self):
+                self.send_response(200)
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+
+            def do_POST(self):
+                length = int(self.headers.get('Content-Length', 0))
+                data = self.rfile.read(length).decode()
+                payload = json.loads(data or '{}')
+                if self.path == '/offload':
+                    server.core = core_from_json(json.dumps(payload['core']))
+                    server.neuronenblitz = Neuronenblitz(server.core)
+                    self._set_headers()
+                    self.wfile.write(b'{}')
+                elif self.path == '/process':
+                    if server.neuronenblitz is None:
+                        self.send_response(400)
+                        self.end_headers()
+                        return
+                    value = float(payload.get('value', 0.0))
+                    output, _ = server.neuronenblitz.dynamic_wander(value)
+                    self._set_headers()
+                    self.wfile.write(json.dumps({'output': output}).encode())
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+
+        self.httpd = HTTPServer((self.host, self.port), Handler)
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+
+    def stop(self):
+        if self.httpd:
+            self.httpd.shutdown()
+        if self.thread:
+            self.thread.join()
+
+class RemoteBrainClient:
+    """Client used by the main brain to interact with a remote brain."""
+    def __init__(self, url):
+        self.url = url.rstrip('/')
+
+    def offload(self, core):
+        payload = {'core': json.loads(core_to_json(core))}
+        requests.post(self.url + '/offload', json=payload)
+
+    def process(self, value):
+        resp = requests.post(self.url + '/process', json={'value': value})
+        data = resp.json()
+        return data['output']

--- a/tests/test_remote_offloading.py
+++ b/tests/test_remote_offloading.py
@@ -1,0 +1,27 @@
+import os, sys, time
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from marble_core import Core, DataLoader
+from marble_neuronenblitz import Neuronenblitz
+from marble_brain import Brain
+from remote_offload import RemoteBrainServer, RemoteBrainClient
+from tests.test_core_functions import minimal_params
+
+
+def test_remote_offload_roundtrip():
+    server = RemoteBrainServer(port=8001)
+    server.start()
+    client = RemoteBrainClient("http://localhost:8001")
+
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core, remote_client=client)
+    brain = Brain(core, nb, DataLoader(), remote_client=client)
+
+    # offload all neurons
+    brain.lobe_manager.genesis(range(len(core.neurons)))
+    brain.offload_high_attention(threshold=-1.0)
+
+    out, path = nb.dynamic_wander(0.5)
+    assert isinstance(out, float)
+    server.stop()


### PR DESCRIPTION
## Summary
- add `RemoteBrainServer` and `RemoteBrainClient` to move neuron groups to another machine via HTTP
- support new `remote` tier and subcore extraction utilities
- enable `Neuronenblitz` and `Brain` to work with offloaded neurons
- integrate offloading through lobe self‑attention
- create `test_remote_offloading` to verify remote execution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a66443acc8327b4e8149180bb41ba