### PR TITLE
Add torrent offloading client mode

### DIFF
--- a/marble_main.py
+++ b/marble_main.py
@@ -4,7 +4,7 @@ from marble_neuronenblitz import Neuronenblitz
 from marble_brain import Brain, BenchmarkManager
 
 class MARBLE:
-    def __init__(self, params, formula=None, formula_num_neurons=100, converter_model=None, nb_params=None, brain_params=None, init_from_weights=False, remote_client=None):
+    def __init__(self, params, formula=None, formula_num_neurons=100, converter_model=None, nb_params=None, brain_params=None, init_from_weights=False, remote_client=None, torrent_client=None):
         if converter_model is not None:
             self.core = MarbleConverter.convert(converter_model, mode='sequential', core_params=params, init_from_weights=init_from_weights)
         else:
@@ -29,7 +29,11 @@ class MARBLE:
         }
         if nb_params is not None:
             nb_defaults.update(nb_params)
-        self.neuronenblitz = Neuronenblitz(self.core, remote_client=remote_client, **nb_defaults)
+        self.torrent_map = {}
+        self.neuronenblitz = Neuronenblitz(self.core, remote_client=remote_client,
+                                           torrent_client=torrent_client,
+                                           torrent_map=self.torrent_map,
+                                           **nb_defaults)
         
         brain_defaults = {
             'save_threshold': 0.05,
@@ -39,7 +43,11 @@ class MARBLE:
         }
         if brain_params is not None:
             brain_defaults.update(brain_params)
-        self.brain = Brain(self.core, self.neuronenblitz, self.dataloader, remote_client=remote_client, **brain_defaults)
+        self.brain = Brain(self.core, self.neuronenblitz, self.dataloader,
+                           remote_client=remote_client,
+                           torrent_client=torrent_client,
+                           torrent_map=self.torrent_map,
+                           **brain_defaults)
         
         self.metrics_visualizer = MetricsVisualizer()
         self.benchmark_manager = BenchmarkManager(self)

--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -16,7 +16,9 @@ class Neuronenblitz:
                  loss_fn=None,
                  weight_update_fn=None,
                  plasticity_threshold=10.0,
-                 remote_client=None):
+                 remote_client=None,
+                 torrent_client=None,
+                 torrent_map=None):
         self.core = core
         self.backtrack_probability = backtrack_probability
         self.consolidation_probability = consolidation_probability
@@ -38,6 +40,8 @@ class Neuronenblitz:
         self.last_context = {}
         self.type_attention = {nt: 0.0 for nt in NEURON_TYPES}
         self.remote_client = remote_client
+        self.torrent_client = torrent_client
+        self.torrent_map = torrent_map if torrent_map is not None else {}
 
     def modulate_plasticity(self, context):
         """Adjust plasticity_threshold based on neuromodulatory context."""
@@ -77,6 +81,11 @@ class Neuronenblitz:
                     remote_out = self.remote_client.process(transmitted_value)
                     next_neuron.value = remote_out
                     results.append((next_neuron, new_path))
+                elif next_neuron.tier == 'torrent' and self.torrent_client is not None:
+                    part = self.torrent_map.get(next_neuron.id)
+                    remote_out = self.torrent_client.process(transmitted_value, part)
+                    next_neuron.value = remote_out
+                    results.append((next_neuron, new_path))
                 else:
                     results.extend(self._wander(next_neuron, new_path, new_continue_prob))
         else:
@@ -88,6 +97,11 @@ class Neuronenblitz:
             new_continue_prob = current_continue_prob * 0.85
             if next_neuron.tier == 'remote' and self.remote_client is not None:
                 remote_out = self.remote_client.process(transmitted_value)
+                next_neuron.value = remote_out
+                results.append((next_neuron, new_path))
+            elif next_neuron.tier == 'torrent' and self.torrent_client is not None:
+                part = self.torrent_map.get(next_neuron.id)
+                remote_out = self.torrent_client.process(transmitted_value, part)
                 next_neuron.value = remote_out
                 results.append((next_neuron, new_path))
             else:

--- a/tests/test_torrent_offload.py
+++ b/tests/test_torrent_offload.py
@@ -27,3 +27,45 @@ def test_torrent_tracker_distribution_and_redistribution():
         assert tracker.part_to_client[i] == 'A'
         assert i in client_a.parts
 
+
+def test_torrent_client_offload_process():
+    from marble_core import Core
+    from tests.test_core_functions import minimal_params
+
+    tracker = BrainTorrentTracker()
+    client_main = BrainTorrentClient('main', tracker)
+    client_peer = BrainTorrentClient('peer', tracker)
+
+    client_main.connect()
+    client_peer.connect()
+
+    core = Core(minimal_params())
+    part = client_main.offload(core)
+    assigned = tracker.part_to_client[part]
+    target_client = tracker.clients[assigned]
+    out = target_client.process(0.5, part)
+    assert isinstance(out, float)
+
+
+def test_torrent_offload_dynamic_wander():
+    from marble_core import Core, DataLoader
+    from marble_neuronenblitz import Neuronenblitz
+    from marble_brain import Brain
+    from tests.test_core_functions import minimal_params
+
+    tracker = BrainTorrentTracker()
+    client_main = BrainTorrentClient('main', tracker)
+    client_peer = BrainTorrentClient('peer', tracker)
+    client_main.connect()
+    client_peer.connect()
+
+    torrent_map = {}
+    core = Core(minimal_params())
+    nb = Neuronenblitz(core, torrent_client=client_main, torrent_map=torrent_map)
+    brain = Brain(core, nb, DataLoader(), torrent_client=client_main, torrent_map=torrent_map)
+    brain.lobe_manager.genesis(range(len(core.neurons)))
+    brain.offload_high_attention_torrent(threshold=-1.0)
+
+    out, _ = nb.dynamic_wander(0.2)
+    assert isinstance(out, float)
+


### PR DESCRIPTION
## Summary
- support torrent client distribution of brain parts
- allow Neuronenblitz and Brain to interact with a torrent client
- make MARBLE optionally accept a torrent client
- test torrent offloading round trip and integration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a6cdd3e90832786b28114caee27c9