### PR TITLE
Enable async torrent processing with buffering

### DIFF
--- a/tests/test_torrent_offload.py
+++ b/tests/test_torrent_offload.py
@@ -2,6 +2,7 @@ import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from torrent_offload import BrainTorrentTracker, BrainTorrentClient
+import pytest
 
 
 def test_torrent_tracker_distribution_and_redistribution():
@@ -43,6 +44,17 @@ def test_torrent_client_offload_process():
     part = client_main.offload(core)
     assigned = tracker.part_to_client[part]
     target_client = tracker.clients[assigned]
+    # simulate unstable connection by stopping its worker
+    target_client._stop_worker()
+
+    # simulate unstable connection by stopping its worker
+    target_client._stop_worker()
+
+    # simulate unstable connection by stopping its worker
+    target_client._stop_worker()
+
+    # simulate unstable connection by stopping its worker
+    target_client._stop_worker()
     out = target_client.process(0.5, part)
     assert isinstance(out, float)
 
@@ -68,4 +80,48 @@ def test_torrent_offload_dynamic_wander():
 
     out, _ = nb.dynamic_wander(0.2)
     assert isinstance(out, float)
+
+
+def test_torrent_async_and_buffering():
+    from marble_core import Core
+    from tests.test_core_functions import minimal_params
+    import time
+
+    tracker = BrainTorrentTracker()
+    client_main = BrainTorrentClient('main', tracker, buffer_size=2)
+    client_peer = BrainTorrentClient('peer', tracker, buffer_size=2)
+
+    client_main.connect()
+    client_peer.connect()
+
+    core = Core(minimal_params())
+    part = client_main.offload(core)
+    assigned = tracker.part_to_client[part]
+    target_client = tracker.clients[assigned]
+    # simulate unstable connection by stopping its worker
+    target_client._stop_worker()
+
+    # slow down processing to trigger queue usage
+    original = target_client.process
+
+    def slow_process(value, p):
+        time.sleep(0.2)
+        return original(value, p)
+
+    target_client.process = slow_process
+
+    fut1 = target_client.process_async(0.1, part)
+    fut2 = target_client.process_async(0.2, part)
+    with pytest.raises(BufferError):
+        target_client.process_async(0.3, part, timeout=0.1)
+
+    # restart worker to process buffered tasks
+    target_client._start_worker()
+
+    out1 = fut1.result(timeout=2)
+    out2 = fut2.result(timeout=2)
+    assert isinstance(out1, float)
+    assert isinstance(out2, float)
+
+    target_client.process = original
 


### PR DESCRIPTION
## Summary
- add asynchronous queue-based worker to `BrainTorrentClient`
- incorporate start/stop worker into client lifecycle
- implement `process_async` with buffer overflow protection
- test async processing and buffering behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6f2a60a88327b882cc43007d8113