### PR TITLE
Add YAML configuration support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,29 @@
+core:
+  xmin: -2.0
+  xmax: 1.0
+  ymin: -1.5
+  ymax: 1.5
+  width: 30
+  height: 30
+  max_iter: 50
+  vram_limit_mb: 0.5
+  ram_limit_mb: 1.0
+  disk_limit_mb: 10
+neuronenblitz:
+  backtrack_probability: 0.3
+  consolidation_probability: 0.2
+  consolidation_strength: 1.1
+  route_potential_increase: 0.5
+  route_potential_decay: 0.9
+  route_visit_decay_interval: 10
+  alternative_connection_prob: 0.1
+  split_probability: 0.2
+  merge_tolerance: 0.01
+  plasticity_threshold: 10.0
+brain:
+  save_threshold: 0.05
+  max_saved_models: 5
+  save_dir: "saved_models"
+  firing_interval_ms: 500
+formula: "log(1+T)/log(1+I)"
+formula_num_neurons: 100

--- a/config_loader.py
+++ b/config_loader.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import yaml
+
+DEFAULT_CONFIG_FILE = Path(__file__).resolve().parent / "config.yaml"
+
+def load_config(path: str | None = None) -> dict:
+    """Load configuration from a YAML file."""
+    cfg_path = Path(path) if path is not None else DEFAULT_CONFIG_FILE
+    with open(cfg_path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return data

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,9 @@
+from config_loader import load_config
+
+
+def test_load_config_defaults():
+    cfg = load_config()
+    assert 'core' in cfg
+    assert cfg['core']['width'] == 30
+    assert 'neuronenblitz' in cfg
+    assert cfg['brain']['save_threshold'] == 0.05


### PR DESCRIPTION
## Summary
- add default configuration in `config.yaml`
- implement `load_config` helper for YAML parsing
- provide tests for configuration loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a7119b03c832780ad78b84026dee4