### PR TITLE
Expand YAML configurability

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,5 +25,21 @@ brain:
   max_saved_models: 5
   save_dir: "saved_models"
   firing_interval_ms: 500
+  tier_decision_params:
+    vram_usage_threshold: 0.9
+    ram_usage_threshold: 0.9
 formula: "log(1+T)/log(1+I)"
 formula_num_neurons: 100
+meta_controller:
+  history_length: 5
+  adjustment: 0.5
+  min_threshold: 1.0
+  max_threshold: 20.0
+neuromodulatory_system:
+  initial:
+    arousal: 0.0
+    stress: 0.0
+    reward: 0.0
+    emotion: "neutral"
+memory_system:
+  long_term_path: "long_term_memory.pkl"

--- a/config_loader.py
+++ b/config_loader.py
@@ -1,6 +1,11 @@
 from pathlib import Path
 import yaml
 
+from marble_main import MARBLE
+from neuromodulatory_system import NeuromodulatorySystem
+from meta_parameter_controller import MetaParameterController
+from marble_core import MemorySystem
+
 DEFAULT_CONFIG_FILE = Path(__file__).resolve().parent / "config.yaml"
 
 def load_config(path: str | None = None) -> dict:
@@ -9,3 +14,49 @@ def load_config(path: str | None = None) -> dict:
     with open(cfg_path, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
     return data
+
+
+def create_marble_from_config(path: str | None = None) -> MARBLE:
+    """Create a :class:`MARBLE` instance from a YAML configuration."""
+    cfg = load_config(path)
+
+    core_params = cfg.get("core", {})
+    nb_params = cfg.get("neuronenblitz", {})
+    brain_params = cfg.get("brain", {})
+
+    formula = cfg.get("formula")
+    formula_num_neurons = cfg.get("formula_num_neurons", 100)
+
+    # Meta-parameter controller
+    mc_cfg = cfg.get("meta_controller", {})
+    meta_controller = MetaParameterController(
+        history_length=mc_cfg.get("history_length", 5),
+        adjustment=mc_cfg.get("adjustment", 0.5),
+        min_threshold=mc_cfg.get("min_threshold", 1.0),
+        max_threshold=mc_cfg.get("max_threshold", 20.0),
+    )
+
+    # Neuromodulatory system
+    ns_init = cfg.get("neuromodulatory_system", {}).get("initial", {})
+    neuromod_system = NeuromodulatorySystem(initial=ns_init)
+
+    # Memory system
+    long_term_path = cfg.get("memory_system", {}).get(
+        "long_term_path", "long_term_memory.pkl"
+    )
+    memory_system = MemorySystem(long_term_path)
+
+    brain_params.update({
+        "neuromodulatory_system": neuromod_system,
+        "meta_controller": meta_controller,
+        "memory_system": memory_system,
+    })
+
+    marble = MARBLE(
+        core_params,
+        formula=formula,
+        formula_num_neurons=formula_num_neurons,
+        nb_params=nb_params,
+        brain_params=brain_params,
+    )
+    return marble

--- a/marble_brain.py
+++ b/marble_brain.py
@@ -9,7 +9,8 @@ class Brain:
     def __init__(self, core, neuronenblitz, dataloader, save_threshold=0.05,
                  max_saved_models=5, save_dir="saved_models", firing_interval_ms=500,
                  neuromodulatory_system=None, meta_controller=None, memory_system=None,
-                 remote_client=None, torrent_client=None, torrent_map=None):
+                 remote_client=None, torrent_client=None, torrent_map=None,
+                 tier_decision_params=None):
         self.core = core
         self.neuronenblitz = neuronenblitz
         self.dataloader = dataloader
@@ -34,7 +35,7 @@ class Brain:
         self.torrent_client = torrent_client
         self.torrent_map = torrent_map if torrent_map is not None else {}
         self.last_val_loss = None
-        self.tier_decision_params = {
+        self.tier_decision_params = tier_decision_params if tier_decision_params is not None else {
             'vram_usage_threshold': 0.9,
             'ram_usage_threshold': 0.9
         }

--- a/marble_main.py
+++ b/marble_main.py
@@ -2,6 +2,7 @@ from marble_imports import *
 from marble_core import Core, DataLoader, TIER_REGISTRY
 from marble_neuronenblitz import Neuronenblitz
 from marble_brain import Brain, BenchmarkManager
+from marble_base import MetricsVisualizer
 
 class MARBLE:
     def __init__(self, params, formula=None, formula_num_neurons=100, converter_model=None, nb_params=None, brain_params=None, init_from_weights=False, remote_client=None, torrent_client=None):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,7 @@
-from config_loader import load_config
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from config_loader import load_config, create_marble_from_config
+from marble_main import MARBLE
 
 
 def test_load_config_defaults():
@@ -7,3 +10,11 @@ def test_load_config_defaults():
     assert cfg['core']['width'] == 30
     assert 'neuronenblitz' in cfg
     assert cfg['brain']['save_threshold'] == 0.05
+    assert cfg['meta_controller']['history_length'] == 5
+    assert cfg['neuromodulatory_system']['initial']['emotion'] == "neutral"
+
+
+def test_create_marble_from_config():
+    marble = create_marble_from_config()
+    assert isinstance(marble, MARBLE)
+    assert marble.brain.meta_controller.history_length == 5


### PR DESCRIPTION
## Summary
- add ability to instantiate MARBLE from YAML configuration
- extend YAML file with brain tier thresholds, meta controller, neuromodulatory system and memory path
- allow Brain to accept tier decision params
- import MetricsVisualizer in `marble_main`
- test new configuration features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a727b068c83279ee437a9e07930bf