### PR TITLE
Remove IPython dependency and extend YAML

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -43,3 +43,5 @@ neuromodulatory_system:
     emotion: "neutral"
 memory_system:
   long_term_path: "long_term_memory.pkl"
+remote_client:
+  url: "http://localhost:8001"

--- a/config_loader.py
+++ b/config_loader.py
@@ -5,6 +5,7 @@ from marble_main import MARBLE
 from neuromodulatory_system import NeuromodulatorySystem
 from meta_parameter_controller import MetaParameterController
 from marble_core import MemorySystem
+from remote_offload import RemoteBrainClient
 
 DEFAULT_CONFIG_FILE = Path(__file__).resolve().parent / "config.yaml"
 
@@ -52,11 +53,17 @@ def create_marble_from_config(path: str | None = None) -> MARBLE:
         "memory_system": memory_system,
     })
 
+    remote_client = None
+    remote_cfg = cfg.get("remote_client", {})
+    if isinstance(remote_cfg, dict) and remote_cfg.get("url"):
+        remote_client = RemoteBrainClient(remote_cfg["url"])
+
     marble = MARBLE(
         core_params,
         formula=formula,
         formula_num_neurons=formula_num_neurons,
         nb_params=nb_params,
         brain_params=brain_params,
+        remote_client=remote_client,
     )
     return marble

--- a/marble.py
+++ b/marble.py
@@ -12,7 +12,6 @@ from tqdm.notebook import tqdm  # For Jupyter-optimized progress bars
 from PIL import Image
 from io import BytesIO
 import matplotlib.pyplot as plt
-from IPython.display import clear_output
 import pickle
 import zlib
 import random
@@ -22,6 +21,11 @@ import threading
 from datetime import datetime
 import cupy as cp
 import torch.nn as nn
+
+
+def clear_output(wait: bool = True) -> None:
+    """Clear the terminal screen."""
+    os.system('cls' if os.name == 'nt' else 'clear')
 
 # -----------------------------------------------------
 # 1. Logging function

--- a/marble_base.py
+++ b/marble_base.py
@@ -1,5 +1,10 @@
 from marble_imports import *
 
+
+def clear_output(wait: bool = True) -> None:
+    """Clear the terminal screen."""
+    os.system('cls' if os.name == 'nt' else 'clear')
+
 def log_metrics(epoch, tar_idx, loss, vram_usage):
     with open('training_log.txt', 'a') as f:
         f.write(f"Epoch {epoch}, Tar {tar_idx}: Loss={loss:.4f}, VRAM={vram_usage:.2f}MB\n")

--- a/marble_imports.py
+++ b/marble_imports.py
@@ -12,7 +12,6 @@ from tqdm.notebook import tqdm
 from PIL import Image
 from io import BytesIO
 import matplotlib.pyplot as plt
-from IPython.display import clear_output
 import pickle
 import zlib
 import random

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@ import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from config_loader import load_config, create_marble_from_config
 from marble_main import MARBLE
+from remote_offload import RemoteBrainClient
 
 
 def test_load_config_defaults():
@@ -12,9 +13,11 @@ def test_load_config_defaults():
     assert cfg['brain']['save_threshold'] == 0.05
     assert cfg['meta_controller']['history_length'] == 5
     assert cfg['neuromodulatory_system']['initial']['emotion'] == "neutral"
+    assert cfg['remote_client']['url'] == "http://localhost:8001"
 
 
 def test_create_marble_from_config():
     marble = create_marble_from_config()
     assert isinstance(marble, MARBLE)
     assert marble.brain.meta_controller.history_length == 5
+    assert isinstance(marble.brain.remote_client, RemoteBrainClient)


### PR DESCRIPTION
## Summary
- provide custom `clear_output` to drop IPython requirement
- configure optional remote client via YAML
- update example YAML and tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a745e73008327a0aef8c3bae20e6a