### PR TITLE
Enhance YAML config and update example

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,6 +25,7 @@ brain:
   max_saved_models: 5
   save_dir: "saved_models"
   firing_interval_ms: 500
+  initial_neurogenesis_factor: 1.0
   tier_decision_params:
     vram_usage_threshold: 0.9
     ram_usage_threshold: 0.9
@@ -45,3 +46,7 @@ memory_system:
   long_term_path: "long_term_memory.pkl"
 remote_client:
   url: "http://localhost:8001"
+  timeout: 5.0
+torrent_client:
+  client_id: "main"
+  buffer_size: 10

--- a/marble_brain.py
+++ b/marble_brain.py
@@ -10,7 +10,7 @@ class Brain:
                  max_saved_models=5, save_dir="saved_models", firing_interval_ms=500,
                  neuromodulatory_system=None, meta_controller=None, memory_system=None,
                  remote_client=None, torrent_client=None, torrent_map=None,
-                 tier_decision_params=None):
+                 tier_decision_params=None, initial_neurogenesis_factor: float = 1.0):
         self.core = core
         self.neuronenblitz = neuronenblitz
         self.dataloader = dataloader
@@ -30,7 +30,7 @@ class Brain:
         self.meta_controller = meta_controller if meta_controller is not None else MetaParameterController()
         self.memory_system = memory_system if memory_system is not None else MemorySystem()
         self.lobe_manager = LobeManager(core)
-        self.neurogenesis_factor = 1.0
+        self.neurogenesis_factor = initial_neurogenesis_factor
         self.remote_client = remote_client
         self.torrent_client = torrent_client
         self.torrent_map = torrent_map if torrent_map is not None else {}

--- a/remote_offload.py
+++ b/remote_offload.py
@@ -63,14 +63,16 @@ class RemoteBrainServer:
 
 class RemoteBrainClient:
     """Client used by the main brain to interact with a remote brain."""
-    def __init__(self, url):
+
+    def __init__(self, url, timeout: float = 5.0):
         self.url = url.rstrip('/')
+        self.timeout = timeout
 
     def offload(self, core):
         payload = {'core': json.loads(core_to_json(core))}
-        requests.post(self.url + '/offload', json=payload)
+        requests.post(self.url + '/offload', json=payload, timeout=self.timeout)
 
     def process(self, value):
-        resp = requests.post(self.url + '/process', json={'value': value})
+        resp = requests.post(self.url + '/process', json={'value': value}, timeout=self.timeout)
         data = resp.json()
         return data['output']

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from config_loader import load_config, create_marble_from_config
 from marble_main import MARBLE
 from remote_offload import RemoteBrainClient
+from torrent_offload import BrainTorrentClient
 
 
 def test_load_config_defaults():
@@ -14,6 +15,10 @@ def test_load_config_defaults():
     assert cfg['meta_controller']['history_length'] == 5
     assert cfg['neuromodulatory_system']['initial']['emotion'] == "neutral"
     assert cfg['remote_client']['url'] == "http://localhost:8001"
+    assert cfg['remote_client']['timeout'] == 5.0
+    assert cfg['torrent_client']['client_id'] == 'main'
+    assert cfg['torrent_client']['buffer_size'] == 10
+    assert cfg['brain']['initial_neurogenesis_factor'] == 1.0
 
 
 def test_create_marble_from_config():
@@ -21,3 +26,5 @@ def test_create_marble_from_config():
     assert isinstance(marble, MARBLE)
     assert marble.brain.meta_controller.history_length == 5
     assert isinstance(marble.brain.remote_client, RemoteBrainClient)
+    assert isinstance(marble.brain.torrent_client, BrainTorrentClient)
+    assert marble.brain.neurogenesis_factor == 1.0


### PR DESCRIPTION
## Summary
- allow configuring remote client timeout
- support torrent client creation via YAML
- expose brain initial neurogenesis factor in config
- update example `config.yaml`
- cover new config options in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a765a3cb88327931c05381a56dcc5