### PR TITLE
Update agent guidelines and fix wandering path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,11 @@
 1. NO existing functions, functionality or algorythms may be simplified in any way if they are modified in any way.
 2. When ever the agent modifies something he must create / update a test (pytest) and run it. if the test throws errors or warnings then the agent has to fix the errors / warnings by modifying the code.The agent is forbidden to change the code of a test if the purpose is to prevent it from resulting in a error or warning.
 3. The must be tests for all functions and algorythims...each seperately AND ALL OF IT IN CONCERT
+4. The agent must update `requirements.txt` automatically after all changes.
+5. Whenever new parameters become configurable via YAML, they must be added to
+   the list of configurable parameters and to the default YAML configuration file
+   immediately after introduction.
+6. The agent must maintain a `yaml-manual.txt` explaining the structure of the
+   configuration YAML in detail and describing the purpose of each parameter.
+   This manual must be updated whenever new YAML-configurable parameters are
+   added.

--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -137,6 +137,8 @@ class Neuronenblitz:
         initial_path = [(entry_neuron, None)]
         results = self._wander(entry_neuron, initial_path, 1.0)
         final_neuron, final_path = self._merge_results(results)
+        if not final_path:
+            final_path = initial_path
         self.global_activation_count += 1
         if self.global_activation_count % self.route_visit_decay_interval == 0:
             for syn in self.core.synapses:


### PR DESCRIPTION
## Summary
- update `AGENTS.md` with requirements, YAML, and manual update procedures
- ensure `dynamic_wander` returns a non-empty path

## Testing
- `pytest -q`
- `pytest tests/test_async_training.py::test_training_and_inference_simultaneous -vv`


------
https://chatgpt.com/codex/tasks/task_e_687a79e92fd883279e58bd36b806c596