### PR TITLE
Add configurable offload toggles

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,6 +26,8 @@ brain:
   save_dir: "saved_models"
   firing_interval_ms: 500
   initial_neurogenesis_factor: 1.0
+  offload_enabled: false
+  torrent_offload_enabled: false
   tier_decision_params:
     vram_usage_threshold: 0.9
     ram_usage_threshold: 0.9

--- a/marble.py
+++ b/marble.py
@@ -724,7 +724,9 @@ class MARBLE:
             'save_threshold': 0.05,
             'max_saved_models': 5,
             'save_dir': "saved_models",
-            'firing_interval_ms': 500
+            'firing_interval_ms': 500,
+            'offload_enabled': False,
+            'torrent_offload_enabled': False
         }
         if brain_params is not None:
             brain_defaults.update(brain_params)

--- a/marble_main.py
+++ b/marble_main.py
@@ -40,7 +40,9 @@ class MARBLE:
             'save_threshold': 0.05,
             'max_saved_models': 5,
             'save_dir': "saved_models",
-            'firing_interval_ms': 500
+            'firing_interval_ms': 500,
+            'offload_enabled': False,
+            'torrent_offload_enabled': False
         }
         if brain_params is not None:
             brain_defaults.update(brain_params)

--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -137,8 +137,14 @@ class Neuronenblitz:
         initial_path = [(entry_neuron, None)]
         results = self._wander(entry_neuron, initial_path, 1.0)
         final_neuron, final_path = self._merge_results(results)
-        if not final_path:
-            final_path = initial_path
+        if not final_path or all(s is None for _, s in final_path):
+            if entry_neuron.synapses:
+                syn = self.weighted_choice(entry_neuron.synapses)
+                next_neuron = self.core.neurons[syn.target]
+                next_neuron.value = self.combine_fn(entry_neuron.value, syn.weight)
+                final_path = [(entry_neuron, None), (next_neuron, syn)]
+            else:
+                final_path = initial_path
         self.global_activation_count += 1
         if self.global_activation_count % self.route_visit_decay_interval == 0:
             for syn in self.core.synapses:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,6 +19,8 @@ def test_load_config_defaults():
     assert cfg['torrent_client']['client_id'] == 'main'
     assert cfg['torrent_client']['buffer_size'] == 10
     assert cfg['brain']['initial_neurogenesis_factor'] == 1.0
+    assert cfg['brain']['offload_enabled'] is False
+    assert cfg['brain']['torrent_offload_enabled'] is False
 
 
 def test_create_marble_from_config():
@@ -28,3 +30,5 @@ def test_create_marble_from_config():
     assert isinstance(marble.brain.remote_client, RemoteBrainClient)
     assert isinstance(marble.brain.torrent_client, BrainTorrentClient)
     assert marble.brain.neurogenesis_factor == 1.0
+    assert marble.brain.offload_enabled is False
+    assert marble.brain.torrent_offload_enabled is False

--- a/tests/test_remote_offloading.py
+++ b/tests/test_remote_offloading.py
@@ -16,7 +16,7 @@ def test_remote_offload_roundtrip():
     params = minimal_params()
     core = Core(params)
     nb = Neuronenblitz(core, remote_client=client)
-    brain = Brain(core, nb, DataLoader(), remote_client=client)
+    brain = Brain(core, nb, DataLoader(), remote_client=client, offload_enabled=True)
 
     # offload all neurons
     brain.lobe_manager.genesis(range(len(core.neurons)))
@@ -40,12 +40,13 @@ def test_remote_brain_offload_chain():
     params = minimal_params()
     core = Core(params)
     nb = Neuronenblitz(core, remote_client=client1)
-    brain = Brain(core, nb, DataLoader(), remote_client=client1)
+    brain = Brain(core, nb, DataLoader(), remote_client=client1, offload_enabled=True)
 
     brain.lobe_manager.genesis(range(len(core.neurons)))
     brain.offload_high_attention(threshold=-1.0)
 
     server1.brain.remote_client = client2
+    server1.brain.offload_enabled = True
     server1.brain.lobe_manager.genesis(range(len(server1.core.neurons)))
     server1.brain.offload_high_attention(threshold=-1.0)
 

--- a/tests/test_torrent_offload.py
+++ b/tests/test_torrent_offload.py
@@ -74,7 +74,7 @@ def test_torrent_offload_dynamic_wander():
     torrent_map = {}
     core = Core(minimal_params())
     nb = Neuronenblitz(core, torrent_client=client_main, torrent_map=torrent_map)
-    brain = Brain(core, nb, DataLoader(), torrent_client=client_main, torrent_map=torrent_map)
+    brain = Brain(core, nb, DataLoader(), torrent_client=client_main, torrent_map=torrent_map, torrent_offload_enabled=True)
     brain.lobe_manager.genesis(range(len(core.neurons)))
     brain.offload_high_attention_torrent(threshold=-1.0)
 

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -1,0 +1,50 @@
+The configuration YAML controls various aspects of the MARBLE system. The file is structured in a set of top-level sections, each containing parameters for a specific subsystem.
+
+core:
+  xmin, xmax, ymin, ymax: Bounds for the simulated space.
+  width, height: Resolution of the core grid.
+  max_iter: Maximum iterations for Mandelbrot calculations.
+  vram_limit_mb, ram_limit_mb, disk_limit_mb: Resource limits for neuron tiers.
+
+neuronenblitz:
+  backtrack_probability, consolidation_probability,
+  consolidation_strength, route_potential_increase,
+  route_potential_decay, route_visit_decay_interval,
+  alternative_connection_prob, split_probability,
+  merge_tolerance, plasticity_threshold: Parameters that
+  influence neuron routing and plasticity.
+
+brain:
+  save_threshold: Validation loss required before saving a model.
+  max_saved_models: Number of saved checkpoints to keep.
+  save_dir: Directory used to store checkpoints.
+  firing_interval_ms: Interval between automatic firing cycles.
+  initial_neurogenesis_factor: Starting multiplier for neurogenesis.
+  offload_enabled: When true the brain will offload high
+    attention lobes to a remote brain via HTTP.
+  torrent_offload_enabled: When true the brain distributes lobes
+    via the torrent offloading system.
+  tier_decision_params:
+    vram_usage_threshold, ram_usage_threshold: Thresholds used when
+    selecting a growth tier.
+
+formula: Optional formula used when constructing the core.
+formula_num_neurons: Number of neurons used if the formula is provided.
+
+meta_controller:
+  history_length, adjustment, min_threshold, max_threshold: Parameters
+  controlling adaptive thresholding.
+
+neuromodulatory_system:
+  initial: Starting values for arousal, stress, reward and emotion.
+
+memory_system:
+  long_term_path: File path used for persistent storage of memories.
+
+remote_client:
+  url: Base URL of a remote brain server.
+  timeout: Request timeout in seconds.
+
+torrent_client:
+  client_id: Identifier for the torrent client.
+  buffer_size: Maximum tasks buffered for asynchronous processing.


### PR DESCRIPTION
## Summary
- make offloading features optional via `offload_enabled` and `torrent_offload_enabled`
- update `Brain` to respect these options
- expose options in `config.yaml` and document in `yaml-manual.txt`
- adapt config loader tests and offload tests
- ensure dynamic_wander always returns a path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a7b03d14c8327be0aff0289019d8e