### PR TITLE
Add evolution parameters to YAML config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,6 +28,9 @@ brain:
   initial_neurogenesis_factor: 1.0
   offload_enabled: false
   torrent_offload_enabled: false
+  mutation_rate: 0.01
+  mutation_strength: 0.05
+  prune_threshold: 0.01
   tier_decision_params:
     vram_usage_threshold: 0.9
     ram_usage_threshold: 0.9

--- a/marble_brain.py
+++ b/marble_brain.py
@@ -11,7 +11,9 @@ class Brain:
                  neuromodulatory_system=None, meta_controller=None, memory_system=None,
                  remote_client=None, torrent_client=None, torrent_map=None,
                  tier_decision_params=None, initial_neurogenesis_factor: float = 1.0,
-                 offload_enabled: bool = False, torrent_offload_enabled: bool = False):
+                 offload_enabled: bool = False, torrent_offload_enabled: bool = False,
+                 mutation_rate: float = 0.01, mutation_strength: float = 0.05,
+                 prune_threshold: float = 0.01):
         self.core = core
         self.neuronenblitz = neuronenblitz
         self.dataloader = dataloader
@@ -42,6 +44,9 @@ class Brain:
             'vram_usage_threshold': 0.9,
             'ram_usage_threshold': 0.9
         }
+        self.mutation_rate = mutation_rate
+        self.mutation_strength = mutation_strength
+        self.prune_threshold = prune_threshold
         os.makedirs(self.save_dir, exist_ok=True)
 
     def update_neurogenesis_factor(self, val_loss):
@@ -275,8 +280,14 @@ class Brain:
             pruned += before - len(neuron.synapses)
         return pruned
 
-    def evolve(self, mutation_rate=0.01, mutation_strength=0.05, prune_threshold=0.01):
+    def evolve(self, mutation_rate=None, mutation_strength=None, prune_threshold=None):
         """Apply evolutionary operators like mutation and pruning."""
+        if mutation_rate is None:
+            mutation_rate = self.mutation_rate
+        if mutation_strength is None:
+            mutation_strength = self.mutation_strength
+        if prune_threshold is None:
+            prune_threshold = self.prune_threshold
         mutated = self.mutate_synapses(mutation_rate, mutation_strength)
         pruned = self.prune_weak_synapses(prune_threshold)
         return mutated, pruned

--- a/marble_main.py
+++ b/marble_main.py
@@ -42,7 +42,10 @@ class MARBLE:
             'save_dir': "saved_models",
             'firing_interval_ms': 500,
             'offload_enabled': False,
-            'torrent_offload_enabled': False
+            'torrent_offload_enabled': False,
+            'mutation_rate': 0.01,
+            'mutation_strength': 0.05,
+            'prune_threshold': 0.01
         }
         if brain_params is not None:
             brain_defaults.update(brain_params)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,9 @@ def test_load_config_defaults():
     assert cfg['brain']['initial_neurogenesis_factor'] == 1.0
     assert cfg['brain']['offload_enabled'] is False
     assert cfg['brain']['torrent_offload_enabled'] is False
+    assert cfg['brain']['mutation_rate'] == 0.01
+    assert cfg['brain']['mutation_strength'] == 0.05
+    assert cfg['brain']['prune_threshold'] == 0.01
 
 
 def test_create_marble_from_config():
@@ -32,3 +35,6 @@ def test_create_marble_from_config():
     assert marble.brain.neurogenesis_factor == 1.0
     assert marble.brain.offload_enabled is False
     assert marble.brain.torrent_offload_enabled is False
+    assert marble.brain.mutation_rate == 0.01
+    assert marble.brain.mutation_strength == 0.05
+    assert marble.brain.prune_threshold == 0.01

--- a/tests/test_evolutionary_mechanisms.py
+++ b/tests/test_evolutionary_mechanisms.py
@@ -46,3 +46,21 @@ def test_evolve_combines_mutation_and_prune():
     assert mutated == initial_count
     assert pruned == initial_count
     assert len(core.synapses) == 0
+
+
+def test_evolve_uses_config_defaults():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    for syn in core.synapses:
+        syn.weight = 0.0
+    random.seed(0)
+    brain = Brain(core, nb, DataLoader(),
+                  mutation_rate=1.0,
+                  mutation_strength=0.0,
+                  prune_threshold=0.01)
+    initial = len(core.synapses)
+    mutated, pruned = brain.evolve()
+    assert mutated == initial
+    assert pruned == initial
+    assert len(core.synapses) == 0

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -55,6 +55,12 @@ brain:
     server for processing.
   torrent_offload_enabled: When true, lobes may be distributed among torrent
     clients using the tracker system.
+  mutation_rate: Fraction of synapses to mutate during each evolutionary step.
+    Higher values introduce more variation but may destabilize learning.
+  mutation_strength: Maximum absolute change applied to a mutated synapse's
+    weight. Typical values range from 0.01 to 0.1.
+  prune_threshold: Synapses with absolute weight below this value are removed
+    during pruning, keeping the network efficient.
   tier_decision_params:
     vram_usage_threshold: Fraction of VRAM usage that triggers migration of
       neurons to a lower tier.


### PR DESCRIPTION
## Summary
- expose mutation_rate, mutation_strength and prune_threshold for the brain
- load new parameters from YAML and document them
- update default configuration file
- test that configuration loading and brain.evolve respect new parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a84ae7cb483279bf0dad7e29b10c2