### PR TITLE
Add configurable compression and dream parameters

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -31,6 +31,8 @@ brain:
   mutation_rate: 0.01
   mutation_strength: 0.05
   prune_threshold: 0.01
+  dream_num_cycles: 10
+  dream_interval: 5
   tier_decision_params:
     vram_usage_threshold: 0.9
     ram_usage_threshold: 0.9
@@ -56,3 +58,5 @@ remote_client:
 torrent_client:
   client_id: "main"
   buffer_size: 10
+data_compressor:
+  compression_level: 6

--- a/config_loader.py
+++ b/config_loader.py
@@ -26,6 +26,8 @@ def create_marble_from_config(path: str | None = None) -> MARBLE:
     nb_params = cfg.get("neuronenblitz", {})
     brain_params = cfg.get("brain", {})
     initial_neurogenesis_factor = brain_params.pop("initial_neurogenesis_factor", 1.0)
+    dream_num_cycles = brain_params.pop("dream_num_cycles", 10)
+    dream_interval = brain_params.pop("dream_interval", 5)
 
     formula = cfg.get("formula")
     formula_num_neurons = cfg.get("formula_num_neurons", 100)
@@ -49,11 +51,18 @@ def create_marble_from_config(path: str | None = None) -> MARBLE:
     threshold = memory_cfg.get("threshold", 0.5)
     memory_system = MemorySystem(long_term_path, threshold=threshold)
 
+    # Data compressor
+    compressor_cfg = cfg.get("data_compressor", {})
+    compression_level = compressor_cfg.get("compression_level", 6)
+    dataloader_params = {"compression_level": compression_level}
+
     brain_params.update({
         "neuromodulatory_system": neuromod_system,
         "meta_controller": meta_controller,
         "memory_system": memory_system,
         "initial_neurogenesis_factor": initial_neurogenesis_factor,
+        "dream_num_cycles": dream_num_cycles,
+        "dream_interval": dream_interval,
     })
 
     remote_client = None
@@ -81,6 +90,7 @@ def create_marble_from_config(path: str | None = None) -> MARBLE:
         formula_num_neurons=formula_num_neurons,
         nb_params=nb_params,
         brain_params=brain_params,
+        dataloader_params=dataloader_params,
         remote_client=remote_client,
         torrent_client=torrent_client,
     )

--- a/data_compressor.py
+++ b/data_compressor.py
@@ -4,7 +4,17 @@ import struct
 import pickle
 
 class DataCompressor:
-    """Full transparent transitive binary compressor."""
+    """Full transparent transitive binary compressor.
+
+    Parameters
+    ----------
+    level : int, optional
+        Compression level passed to :func:`zlib.compress`. ``0`` disables
+        compression while ``9`` yields maximum compression. Defaults to ``6``.
+    """
+
+    def __init__(self, level: int = 6) -> None:
+        self.level = level
 
     @staticmethod
     def bytes_to_bits(data: bytes) -> np.ndarray:
@@ -22,7 +32,7 @@ class DataCompressor:
     def compress(self, data: bytes) -> bytes:
         """Compress bytes after converting to a binary representation."""
         bits = self.bytes_to_bits(data)
-        compressed = zlib.compress(bits.tobytes())
+        compressed = zlib.compress(bits.tobytes(), self.level)
         return compressed
 
     def decompress(self, compressed: bytes) -> bytes:

--- a/marble_brain.py
+++ b/marble_brain.py
@@ -13,7 +13,8 @@ class Brain:
                  tier_decision_params=None, initial_neurogenesis_factor: float = 1.0,
                  offload_enabled: bool = False, torrent_offload_enabled: bool = False,
                  mutation_rate: float = 0.01, mutation_strength: float = 0.05,
-                 prune_threshold: float = 0.01):
+                 prune_threshold: float = 0.01,
+                 dream_num_cycles: int = 10, dream_interval: int = 5):
         self.core = core
         self.neuronenblitz = neuronenblitz
         self.dataloader = dataloader
@@ -39,6 +40,8 @@ class Brain:
         self.torrent_map = torrent_map if torrent_map is not None else {}
         self.offload_enabled = offload_enabled
         self.torrent_offload_enabled = torrent_offload_enabled
+        self.dream_num_cycles = dream_num_cycles
+        self.dream_interval = dream_interval
         self.last_val_loss = None
         self.tier_decision_params = tier_decision_params if tier_decision_params is not None else {
             'vram_usage_threshold': 0.9,
@@ -246,7 +249,11 @@ class Brain:
             time.sleep(0.1)
         print("Dreaming completed.")
 
-    def start_dreaming(self, num_cycles=10, interval=5):
+    def start_dreaming(self, num_cycles=None, interval=None):
+        if num_cycles is None:
+            num_cycles = self.dream_num_cycles
+        if interval is None:
+            interval = self.dream_interval
         self.dreaming_active = True
         def dream_loop():
             while self.dreaming_active:

--- a/marble_core.py
+++ b/marble_core.py
@@ -202,8 +202,8 @@ class MemorySystem:
 
 
 class DataLoader:
-    def __init__(self, compressor: DataCompressor | None = None):
-        self.compressor = compressor if compressor is not None else DataCompressor()
+    def __init__(self, compressor: DataCompressor | None = None, compression_level: int = 6):
+        self.compressor = compressor if compressor is not None else DataCompressor(level=compression_level)
 
     def encode(self, data):
         serialized = pickle.dumps(data)

--- a/marble_main.py
+++ b/marble_main.py
@@ -5,13 +5,16 @@ from marble_brain import Brain, BenchmarkManager
 from marble_base import MetricsVisualizer
 
 class MARBLE:
-    def __init__(self, params, formula=None, formula_num_neurons=100, converter_model=None, nb_params=None, brain_params=None, init_from_weights=False, remote_client=None, torrent_client=None):
+    def __init__(self, params, formula=None, formula_num_neurons=100, converter_model=None, nb_params=None, brain_params=None, dataloader_params=None, init_from_weights=False, remote_client=None, torrent_client=None):
         if converter_model is not None:
             self.core = MarbleConverter.convert(converter_model, mode='sequential', core_params=params, init_from_weights=init_from_weights)
         else:
             self.core = Core(params, formula, formula_num_neurons)
         
-        self.dataloader = DataLoader()
+        dl_level = 6
+        if dataloader_params is not None:
+            dl_level = dataloader_params.get("compression_level", dl_level)
+        self.dataloader = DataLoader(compression_level=dl_level)
         
         nb_defaults = {
             'backtrack_probability': 0.3,
@@ -45,7 +48,9 @@ class MARBLE:
             'torrent_offload_enabled': False,
             'mutation_rate': 0.01,
             'mutation_strength': 0.05,
-            'prune_threshold': 0.01
+            'prune_threshold': 0.01,
+            'dream_num_cycles': 10,
+            'dream_interval': 5
         }
         if brain_params is not None:
             brain_defaults.update(brain_params)

--- a/tests/test_brain_io.py
+++ b/tests/test_brain_io.py
@@ -59,3 +59,12 @@ def test_brain_neuromodulatory_system_integration():
     brain = Brain(core, nb, DataLoader(), neuromodulatory_system=ns, save_dir="saved_models")
     ns.update_signals(arousal=0.2)
     assert brain.neuromodulatory_system.get_context()['arousal'] == 0.2
+
+
+def test_brain_dream_defaults():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader(), dream_num_cycles=3, dream_interval=2)
+    assert brain.dream_num_cycles == 3
+    assert brain.dream_interval == 2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,7 +24,10 @@ def test_load_config_defaults():
     assert cfg['brain']['mutation_rate'] == 0.01
     assert cfg['brain']['mutation_strength'] == 0.05
     assert cfg['brain']['prune_threshold'] == 0.01
+    assert cfg['brain']['dream_num_cycles'] == 10
+    assert cfg['brain']['dream_interval'] == 5
     assert cfg['memory_system']['threshold'] == 0.5
+    assert cfg['data_compressor']['compression_level'] == 6
 
 
 def test_create_marble_from_config():
@@ -40,3 +43,6 @@ def test_create_marble_from_config():
     assert marble.brain.mutation_strength == 0.05
     assert marble.brain.prune_threshold == 0.01
     assert marble.brain.memory_system.threshold == 0.5
+    assert marble.brain.dream_num_cycles == 10
+    assert marble.brain.dream_interval == 5
+    assert marble.dataloader.compressor.level == 6

--- a/tests/test_data_compressor.py
+++ b/tests/test_data_compressor.py
@@ -19,3 +19,12 @@ def test_array_compression_roundtrip():
     compressed = dc.compress_array(arr)
     restored = dc.decompress_array(compressed)
     assert np.array_equal(restored, arr)
+
+
+def test_custom_compression_level():
+    low = DataCompressor(level=1)
+    high = DataCompressor(level=9)
+    data = b"data" * 100
+    size_low = len(low.compress(data))
+    size_high = len(high.compress(data))
+    assert size_high <= size_low

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -61,6 +61,12 @@ brain:
     weight. Typical values range from 0.01 to 0.1.
   prune_threshold: Synapses with absolute weight below this value are removed
     during pruning, keeping the network efficient.
+  dream_num_cycles: Default number of cycles executed each time the brain
+    performs a background dreaming session. Values between 1 and 20 are common
+    depending on how much consolidation is desired.
+  dream_interval: Seconds to wait between consecutive dreaming sessions when
+    ``start_dreaming`` runs in the background. Short intervals keep memory
+    consolidation frequent but consume more processing time.
   tier_decision_params:
     vram_usage_threshold: Fraction of VRAM usage that triggers migration of
       neurons to a lower tier.
@@ -128,3 +134,10 @@ torrent_client:
     unique across participating clients.
   buffer_size: Maximum number of asynchronous tasks queued for a torrent
     client. Larger values allow more parallel requests but use more memory.
+
+data_compressor:
+  # Controls how strongly the DataCompressor reduces data size before it is
+  # stored or transmitted.
+  compression_level: Integer from 0 to 9 passed directly to ``zlib.compress``.
+    Higher levels yield smaller output but require more CPU time. The default of
+    6 balances speed and ratio for general use.


### PR DESCRIPTION
## Summary
- add compression level support to `DataCompressor` and `DataLoader`
- allow configuring dream cycles and interval in `Brain`
- pass new settings from `config_loader`
- extend YAML configuration and manual accordingly
- test new configuration options

## Testing
- `pip install --break-system-packages -r requirements.txt` *(fails: Could not find a matching distribution for torch==2.7.1+cpu)*
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a880c35088327bcec828370ea55d8