### PR TITLE
Make representation size configurable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,7 @@ core:
   width: 30
   height: 30
   max_iter: 50
+  representation_size: 4
   vram_limit_mb: 0.5
   ram_limit_mb: 1.0
   disk_limit_mb: 10

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,7 @@ def test_load_config_defaults():
     cfg = load_config()
     assert 'core' in cfg
     assert cfg['core']['width'] == 30
+    assert cfg['core']['representation_size'] == 4
     assert 'neuronenblitz' in cfg
     assert cfg['brain']['save_threshold'] == 0.05
     assert cfg['meta_controller']['history_length'] == 5
@@ -46,3 +47,4 @@ def test_create_marble_from_config():
     assert marble.brain.dream_num_cycles == 10
     assert marble.brain.dream_interval == 5
     assert marble.dataloader.compressor.level == 6
+    assert marble.core.rep_size == 4

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -17,6 +17,7 @@ def minimal_params():
         'width': 3,
         'height': 3,
         'max_iter': 5,
+        'representation_size': 4,
         'vram_limit_mb': 0.1,
         'ram_limit_mb': 0.1,
         'disk_limit_mb': 0.1,

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -14,6 +14,9 @@ core:
   height: Vertical resolution of the seed grid.
   max_iter: Number of Mandelbrot iterations to run. A higher count yields more
     detailed values. Must be greater than zero.
+  representation_size: Length of the representation vector attached to each
+    neuron. Larger values allow richer message passing but increase memory and
+    computation.
   vram_limit_mb: Maximum megabytes of GPU memory dedicated to VRAM tiers. If
     CUDA is unavailable this limit is merged into RAM.
   ram_limit_mb: Maximum megabytes of system memory used for RAM tiers.


### PR DESCRIPTION
## Summary
- add `representation_size` option in `core` section
- allow MARBLE core to configure representation vector length
- update config loader tests for new option
- describe option in yaml manual

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a8b0a4c008327a6872bb1eecdc54e