### PR TITLE
Improve YAML configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,7 @@ core:
   vram_limit_mb: 0.5
   ram_limit_mb: 1.0
   disk_limit_mb: 10
+  file_tier_path: "data/marble_file_tier.dat"
 neuronenblitz:
   backtrack_probability: 0.3
   consolidation_probability: 0.2
@@ -34,6 +35,8 @@ brain:
   prune_threshold: 0.01
   dream_num_cycles: 10
   dream_interval: 5
+  neurogenesis_base_neurons: 5
+  neurogenesis_base_synapses: 10
   tier_decision_params:
     vram_usage_threshold: 0.9
     ram_usage_threshold: 0.9

--- a/config_loader.py
+++ b/config_loader.py
@@ -28,6 +28,8 @@ def create_marble_from_config(path: str | None = None) -> MARBLE:
     initial_neurogenesis_factor = brain_params.pop("initial_neurogenesis_factor", 1.0)
     dream_num_cycles = brain_params.pop("dream_num_cycles", 10)
     dream_interval = brain_params.pop("dream_interval", 5)
+    neuro_base_neurons = brain_params.pop("neurogenesis_base_neurons", 5)
+    neuro_base_synapses = brain_params.pop("neurogenesis_base_synapses", 10)
 
     formula = cfg.get("formula")
     formula_num_neurons = cfg.get("formula_num_neurons", 100)
@@ -63,6 +65,8 @@ def create_marble_from_config(path: str | None = None) -> MARBLE:
         "initial_neurogenesis_factor": initial_neurogenesis_factor,
         "dream_num_cycles": dream_num_cycles,
         "dream_interval": dream_interval,
+        "neurogenesis_base_neurons": neuro_base_neurons,
+        "neurogenesis_base_synapses": neuro_base_synapses,
     })
 
     remote_client = None

--- a/marble_brain.py
+++ b/marble_brain.py
@@ -14,7 +14,9 @@ class Brain:
                  offload_enabled: bool = False, torrent_offload_enabled: bool = False,
                  mutation_rate: float = 0.01, mutation_strength: float = 0.05,
                  prune_threshold: float = 0.01,
-                 dream_num_cycles: int = 10, dream_interval: int = 5):
+                 dream_num_cycles: int = 10, dream_interval: int = 5,
+                 neurogenesis_base_neurons: int = 5,
+                 neurogenesis_base_synapses: int = 10):
         self.core = core
         self.neuronenblitz = neuronenblitz
         self.dataloader = dataloader
@@ -42,6 +44,8 @@ class Brain:
         self.torrent_offload_enabled = torrent_offload_enabled
         self.dream_num_cycles = dream_num_cycles
         self.dream_interval = dream_interval
+        self.neurogenesis_base_neurons = neurogenesis_base_neurons
+        self.neurogenesis_base_synapses = neurogenesis_base_synapses
         self.last_val_loss = None
         self.tier_decision_params = tier_decision_params if tier_decision_params is not None else {
             'vram_usage_threshold': 0.9,
@@ -94,8 +98,12 @@ class Brain:
         print(f"[Brain] Growth decision: '{chosen}' tier (VRAM: {vram_usage:.2f}MB/{vram_limit}MB, age: {vram_neuron_age:.1f}s)")
         return chosen
 
-    def perform_neurogenesis(self, base_neurons=5, base_synapses=10):
+    def perform_neurogenesis(self, base_neurons=None, base_synapses=None):
         """Grow new neurons and synapses based on neuromodulatory context."""
+        if base_neurons is None:
+            base_neurons = self.neurogenesis_base_neurons
+        if base_synapses is None:
+            base_synapses = self.neurogenesis_base_synapses
         ctx = self.neuromodulatory_system.get_context()
         factor = 1.0 + max(ctx.get('arousal', 0.0), ctx.get('reward', 0.0))
         factor *= self.neurogenesis_factor

--- a/marble_core.py
+++ b/marble_core.py
@@ -243,6 +243,11 @@ class Core:
     def __init__(self, params, formula=None, formula_num_neurons=100):
         print("Initializing MARBLE Core...")
         self.params = params
+        if 'file' in TIER_REGISTRY:
+            fpath = params.get('file_tier_path')
+            if fpath is not None:
+                TIER_REGISTRY['file'].file_path = fpath
+                os.makedirs(os.path.dirname(fpath), exist_ok=True)
         rep_size = params.get('representation_size', _REP_SIZE)
         configure_representation_size(rep_size)
         self.rep_size = rep_size

--- a/marble_main.py
+++ b/marble_main.py
@@ -50,7 +50,9 @@ class MARBLE:
             'mutation_strength': 0.05,
             'prune_threshold': 0.01,
             'dream_num_cycles': 10,
-            'dream_interval': 5
+            'dream_interval': 5,
+            'neurogenesis_base_neurons': 5,
+            'neurogenesis_base_synapses': 10
         }
         if brain_params is not None:
             brain_defaults.update(brain_params)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+Jinja2==3.1.4
+MarkupSafe==2.1.5
+PyYAML==6.0.2
+Pygments==2.19.2
 aiohappyeyeballs==2.6.1
 aiohttp==3.12.14
 aiosignal==1.4.0
@@ -21,9 +25,7 @@ idna==3.10
 importlib_metadata==8.7.0
 iniconfig==2.1.0
 isort==6.0.1
-Jinja2==3.1.4
 kiwisolver==1.4.8
-MarkupSafe==2.1.5
 matplotlib==3.10.3
 mpmath==1.3.0
 multidict==6.6.3
@@ -37,17 +39,16 @@ packaging==25.0
 pandas==2.3.1
 pathspec==0.12.1
 pillow==11.0.0
+pip==25.1.1
 platformdirs==4.3.8
 pluggy==1.6.0
 propcache==0.3.2
 pyarrow==21.0.0
-Pygments==2.19.2
 pyparsing==3.2.3
 pyright==1.1.403
 pytest==8.4.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
-PyYAML==6.0.2
 regex==2024.11.6
 requests==2.32.4
 ruff==0.12.2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ def test_load_config_defaults():
     assert 'core' in cfg
     assert cfg['core']['width'] == 30
     assert cfg['core']['representation_size'] == 4
+    assert cfg['core']['file_tier_path'] == 'data/marble_file_tier.dat'
     assert 'neuronenblitz' in cfg
     assert cfg['brain']['save_threshold'] == 0.05
     assert cfg['meta_controller']['history_length'] == 5
@@ -27,6 +28,8 @@ def test_load_config_defaults():
     assert cfg['brain']['prune_threshold'] == 0.01
     assert cfg['brain']['dream_num_cycles'] == 10
     assert cfg['brain']['dream_interval'] == 5
+    assert cfg['brain']['neurogenesis_base_neurons'] == 5
+    assert cfg['brain']['neurogenesis_base_synapses'] == 10
     assert cfg['memory_system']['threshold'] == 0.5
     assert cfg['data_compressor']['compression_level'] == 6
 
@@ -38,6 +41,8 @@ def test_create_marble_from_config():
     assert isinstance(marble.brain.remote_client, RemoteBrainClient)
     assert isinstance(marble.brain.torrent_client, BrainTorrentClient)
     assert marble.brain.neurogenesis_factor == 1.0
+    assert marble.brain.neurogenesis_base_neurons == 5
+    assert marble.brain.neurogenesis_base_synapses == 10
     assert marble.brain.offload_enabled is False
     assert marble.brain.torrent_offload_enabled is False
     assert marble.brain.mutation_rate == 0.01

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -3,6 +3,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import numpy as np
 import random
 from marble_imports import cp
+import marble_core
 from marble_core import compute_mandelbrot, DataLoader, Core
 from marble_neuronenblitz import Neuronenblitz
 from marble_brain import Brain
@@ -62,6 +63,16 @@ def test_core_expand_assigns_types():
     core.expand(num_new_neurons=3, num_new_synapses=0, neuron_types=['excitatory'])
     types = {n.neuron_type for n in core.neurons[-3:]}
     assert types == {'excitatory'}
+
+
+def test_file_tier_path_configurable(tmp_path):
+    params = minimal_params()
+    custom_path = tmp_path / "tier.dat"
+    params['file_tier_path'] = str(custom_path)
+    original = marble_core.TIER_REGISTRY['file'].file_path
+    core = Core(params)
+    assert marble_core.TIER_REGISTRY['file'].file_path == str(custom_path)
+    marble_core.TIER_REGISTRY['file'].file_path = original
 
 
 def test_neuronenblitz_train_example_updates_history():

--- a/tests/test_neurogenesis_plasticity.py
+++ b/tests/test_neurogenesis_plasticity.py
@@ -80,3 +80,13 @@ def test_brain_neurogenesis_returns_type():
     added, _, ntype = brain.perform_neurogenesis(base_neurons=1, base_synapses=0)
     assert added >= 1
     assert ntype == 'excitatory'
+
+
+def test_neurogenesis_uses_default_base_values():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader(), neurogenesis_base_neurons=2, neurogenesis_base_synapses=3)
+    added, syns, _ = brain.perform_neurogenesis()
+    assert added >= 2
+    assert syns >= 3

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -21,6 +21,9 @@ core:
     CUDA is unavailable this limit is merged into RAM.
   ram_limit_mb: Maximum megabytes of system memory used for RAM tiers.
   disk_limit_mb: Maximum megabytes for disk-based neuron tiers.
+  file_tier_path: Path to the file used by the ``FileTier`` for persisting
+    modified data. The directory is created automatically if it does not
+    exist.
 
 neuronenblitz:
   backtrack_probability: Probability between 0 and 1 that the wandering
@@ -70,6 +73,11 @@ brain:
   dream_interval: Seconds to wait between consecutive dreaming sessions when
     ``start_dreaming`` runs in the background. Short intervals keep memory
     consolidation frequent but consume more processing time.
+  neurogenesis_base_neurons: Base number of neurons grown during each
+    neurogenesis event when no explicit value is provided to
+    ``perform_neurogenesis``.
+  neurogenesis_base_synapses: Base number of synapses introduced alongside new
+    neurons during neurogenesis when defaults are used.
   tier_decision_params:
     vram_usage_threshold: Fraction of VRAM usage that triggers migration of
       neurons to a lower tier.


### PR DESCRIPTION
## Summary
- allow configuring the file tier path and neurogenesis base counts
- update MARBLE components to honour new settings
- document options in YAML manual
- expand configuration tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a8cf8612c8327b39f4ed2189c89c0