### PR TITLE
Expose message passing alpha in YAML

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,7 @@ core:
   height: 30
   max_iter: 50
   representation_size: 4
+  message_passing_alpha: 0.5
   vram_limit_mb: 0.5
   ram_limit_mb: 1.0
   disk_limit_mb: 10

--- a/marble_core.py
+++ b/marble_core.py
@@ -27,8 +27,22 @@ def _simple_mlp(x: np.ndarray) -> np.ndarray:
     return np.tanh(h @ _W2 + _B2)
 
 
-def perform_message_passing(core, alpha: float = 0.5) -> None:
-    """Propagate representations across synapses using attention."""
+def perform_message_passing(core, alpha: float | None = None) -> None:
+    """Propagate representations across synapses using attention.
+
+    Parameters
+    ----------
+    core : Core
+        The :class:`Core` instance containing neurons and synapses.
+    alpha : float, optional
+        Mixing factor between the current representation and the message-passing
+        update. If ``None`` the value is read from ``core.params`` using the
+        ``message_passing_alpha`` key (default ``0.5``).
+    """
+
+    if alpha is None:
+        alpha = core.params.get("message_passing_alpha", 0.5)
+
     new_reps = [n.representation.copy() for n in core.neurons]
     for target in core.neurons:
         incoming = [s for s in core.synapses if s.target == target.id]

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,6 @@ packaging==25.0
 pandas==2.3.1
 pathspec==0.12.1
 pillow==11.0.0
-pip==25.1.1
 platformdirs==4.3.8
 pluggy==1.6.0
 propcache==0.3.2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ def test_load_config_defaults():
     assert 'core' in cfg
     assert cfg['core']['width'] == 30
     assert cfg['core']['representation_size'] == 4
+    assert cfg['core']['message_passing_alpha'] == 0.5
     assert cfg['core']['file_tier_path'] == 'data/marble_file_tier.dat'
     assert 'neuronenblitz' in cfg
     assert cfg['brain']['save_threshold'] == 0.05
@@ -53,3 +54,4 @@ def test_create_marble_from_config():
     assert marble.brain.dream_interval == 5
     assert marble.dataloader.compressor.level == 6
     assert marble.core.rep_size == 4
+    assert marble.core.params['message_passing_alpha'] == 0.5

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -19,6 +19,7 @@ def minimal_params():
         'height': 3,
         'max_iter': 5,
         'representation_size': 4,
+        'message_passing_alpha': 0.5,
         'vram_limit_mb': 0.1,
         'ram_limit_mb': 0.1,
         'disk_limit_mb': 0.1,

--- a/tests/test_message_passing.py
+++ b/tests/test_message_passing.py
@@ -15,3 +15,17 @@ def test_message_passing_updates_representation():
     perform_message_passing(core)
     changed = any(not np.allclose(n.representation, before[i]) for i, n in enumerate(core.neurons))
     assert changed
+
+
+def test_message_passing_alpha_configurable():
+    np.random.seed(0)
+    params = minimal_params()
+    params['message_passing_alpha'] = 1.0
+    core = Core(params)
+    for n in core.neurons:
+        n.representation = np.random.rand(4)
+    before = [n.representation.copy() for n in core.neurons]
+    perform_message_passing(core)
+    after = [n.representation.copy() for n in core.neurons]
+    unchanged = all(np.allclose(b, a) for b, a in zip(before, after))
+    assert unchanged

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -17,6 +17,11 @@ core:
   representation_size: Length of the representation vector attached to each
     neuron. Larger values allow richer message passing but increase memory and
     computation.
+  message_passing_alpha: Mixing factor between each neuron's existing
+    representation and the update computed from its neighbours during message
+    passing. ``0.0`` relies entirely on new information, while ``1.0`` keeps the
+    original representation unchanged. Typical values range from 0.3 to 0.8
+    depending on how aggressively information should propagate.
   vram_limit_mb: Maximum megabytes of GPU memory dedicated to VRAM tiers. If
     CUDA is unavailable this limit is merged into RAM.
   ram_limit_mb: Maximum megabytes of system memory used for RAM tiers.


### PR DESCRIPTION
## Summary
- make `perform_message_passing` read a configurable value from `core.params`
- add `message_passing_alpha` to the YAML config and document it
- include new parameter in config loader tests and minimal params used in tests
- test that the alpha can be configured
- update dependency lock file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a8ee620b0832797e9456fa091d4d5