### PR TITLE
Add super evolution mode

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -207,3 +207,4 @@ Each entry is listed under its section heading.
 ## brain (additional)
 - loss_growth_threshold
 - dream_cycle_sleep
+- super_evolution_mode

--- a/config.yaml
+++ b/config.yaml
@@ -137,6 +137,7 @@ brain:
   default_activation_function: "tanh"
   neuron_reservoir_size: 1000
   lobe_decay_rate: 0.98
+  super_evolution_mode: false
 lobe_manager:
   attention_increase_factor: 1.05
   attention_decrease_factor: 0.95

--- a/config_loader.py
+++ b/config_loader.py
@@ -30,6 +30,7 @@ def create_marble_from_config(path: str | None = None) -> MARBLE:
     dream_interval = brain_params.pop("dream_interval", 5)
     neuro_base_neurons = brain_params.pop("neurogenesis_base_neurons", 5)
     neuro_base_synapses = brain_params.pop("neurogenesis_base_synapses", 10)
+    super_evolution_mode = brain_params.pop("super_evolution_mode", False)
 
     formula = cfg.get("formula")
     formula_num_neurons = cfg.get("formula_num_neurons", 100)
@@ -68,6 +69,7 @@ def create_marble_from_config(path: str | None = None) -> MARBLE:
         "dream_interval": dream_interval,
         "neurogenesis_base_neurons": neuro_base_neurons,
         "neurogenesis_base_synapses": neuro_base_synapses,
+        "super_evolution_mode": super_evolution_mode,
     })
 
     remote_client = None

--- a/marble_main.py
+++ b/marble_main.py
@@ -115,6 +115,7 @@ class MARBLE:
             , 'default_activation_function': 'tanh'
             , 'neuron_reservoir_size': 1000
             , 'lobe_decay_rate': 0.98
+            , 'super_evolution_mode': False
         }
         if brain_params is not None:
             brain_defaults.update(brain_params)

--- a/super_evolution_controller.py
+++ b/super_evolution_controller.py
@@ -1,0 +1,71 @@
+class SuperEvolutionController:
+    """Adjusts all configurable parameters using self-attention feedback."""
+
+    def __init__(self, brain):
+        self.brain = brain
+        self.prev_loss = None
+        self.prev_speed = None
+        self.prev_complexity = None
+        self.prev_resources = None
+        self.history = []
+
+    def record_metrics(self, loss, epoch_time):
+        complexity = len(self.brain.core.neurons) + len(self.brain.core.synapses)
+        resources = (
+            self.brain.core.get_usage_by_tier("vram")
+            + self.brain.core.get_usage_by_tier("ram")
+            + self.brain.core.get_usage_by_tier("disk")
+        )
+        entry = {
+            "loss": loss,
+            "speed": epoch_time,
+            "complexity": complexity,
+            "resources": resources,
+        }
+        self.history.append(entry)
+        if self.prev_loss is not None:
+            self._adjust_parameters(loss, epoch_time, complexity, resources)
+        self.prev_loss = loss
+        self.prev_speed = epoch_time
+        self.prev_complexity = complexity
+        self.prev_resources = resources
+
+    def _apply_factor(self, obj, attr, factor):
+        val = getattr(obj, attr)
+        if isinstance(val, (int, float)):
+            setattr(obj, attr, val * factor)
+
+    def _adjust_parameters(self, loss, speed, complexity, resources):
+        lobes = self.brain.lobe_manager.lobes
+        if not lobes:
+            return
+        total = sum(l.attention_score for l in lobes) or 1.0
+        attention = sum(l.attention_score for l in lobes) / total
+        factor = 1.0
+        if loss > self.prev_loss:
+            factor = 1 + attention * 0.01
+        elif speed > self.prev_speed:
+            factor = 1 - attention * 0.01
+        elif complexity > self.prev_complexity:
+            factor = 1 - attention * 0.01
+        elif resources > self.prev_resources:
+            factor = 1 - attention * 0.01
+        if factor == 1.0:
+            return
+        for key in list(self.brain.core.params.keys()):
+            if isinstance(self.brain.core.params[key], (int, float)):
+                self.brain.core.params[key] *= factor
+                if hasattr(self.brain.core, key):
+                    setattr(self.brain.core, key, self.brain.core.params[key])
+        for attr in vars(self.brain.neuronenblitz):
+            if attr.startswith("_"):
+                continue
+            val = getattr(self.brain.neuronenblitz, attr)
+            if isinstance(val, (int, float)):
+                setattr(self.brain.neuronenblitz, attr, val * factor)
+        for attr in vars(self.brain):
+            if attr.startswith("_") or attr in ("core", "neuronenblitz", "dataloader", "lobe_manager", "super_evo_controller"):
+                continue
+            val = getattr(self.brain, attr)
+            if isinstance(val, (int, float)):
+                setattr(self.brain, attr, val * factor)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -91,6 +91,7 @@ def test_load_config_defaults():
     assert cfg["remote_server"]["enabled"] is False
     assert cfg["metrics_visualizer"]["fig_width"] == 10
     assert cfg["metrics_visualizer"]["fig_height"] == 6
+    assert cfg["brain"]["super_evolution_mode"] is False
 def test_create_marble_from_config():
     marble = create_marble_from_config()
     assert isinstance(marble, MARBLE)
@@ -140,6 +141,8 @@ def test_create_marble_from_config():
     assert marble.brain.dream_cycle_sleep == 0.1
     assert marble.brain.lobe_manager.attention_increase_factor == 1.05
     assert marble.brain.lobe_manager.attention_decrease_factor == 0.95
+    assert marble.brain.super_evolution_mode is False
+    assert marble.brain.super_evo_controller is None
     assert hasattr(marble, "remote_server") is False
 
 

--- a/tests/test_config_additional.py
+++ b/tests/test_config_additional.py
@@ -11,3 +11,4 @@ def test_extended_config_parameters():
     assert cfg["remote_client"]["auth_token"] is None
     assert cfg["remote_server"]["ssl_enabled"] is False
     assert cfg["metrics_visualizer"]["refresh_rate"] == 1
+    assert cfg["brain"]["super_evolution_mode"] is False

--- a/tests/test_super_evolution.py
+++ b/tests/test_super_evolution.py
@@ -1,0 +1,21 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from marble_core import Core, DataLoader
+from marble_neuronenblitz import Neuronenblitz
+from marble_brain import Brain
+from tests.test_core_functions import minimal_params
+from tqdm import tqdm as std_tqdm
+
+
+def test_super_evolution_records_metrics():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    import marble_brain as mb
+    mb.tqdm = std_tqdm
+    brain = Brain(core, nb, DataLoader(), super_evolution_mode=True)
+    examples = [(0.1, 0.2), (0.2, 0.3)]
+    brain.train(examples, epochs=1, validation_examples=examples)
+    assert brain.super_evo_controller.history
+

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -271,6 +271,10 @@ brain:
     sampling replacements during pruning.
   lobe_decay_rate: Fraction by which lobe attention decays each epoch without
     activity.
+  super_evolution_mode: When true, a controller records loss, speed, complexity
+    and resource metrics each epoch and adjusts all configurable parameters via
+    self-attention. This prioritizes minimising loss, then maximising speed,
+    reducing complexity and finally conserving resources.
 
 formula: Mathematical expression used to compute initial neuron values instead
   of the Mandelbrot seed. If omitted the Mandelbrot algorithm is used.


### PR DESCRIPTION
## Summary
- add optional super evolution controller that adjusts all parameters via self‑attention
- record loss, speed, complexity and resource usage every epoch
- support new `super_evolution_mode` config option
- document new option in manual and parameter list
- update tests for new feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a9eb8252083279f4bfd2cb27e6044