### PR TITLE
Implement neuromodulation-driven dream decay

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -114,6 +114,8 @@ Each entry is listed under its section heading.
 - cluster_high_threshold
 - cluster_medium_threshold
 - dream_synapse_decay
+- dream_decay_arousal_scale
+- dream_decay_stress_scale
 - neurogenesis_increase_step
 - neurogenesis_decrease_step
 - max_neurogenesis_factor

--- a/config.yaml
+++ b/config.yaml
@@ -107,6 +107,8 @@ brain:
   cluster_high_threshold: 1.0
   cluster_medium_threshold: 0.1
   dream_synapse_decay: 0.995
+  dream_decay_arousal_scale: 0.0
+  dream_decay_stress_scale: 0.0
   neurogenesis_increase_step: 0.1
   neurogenesis_decrease_step: 0.05
   max_neurogenesis_factor: 3.0

--- a/marble_main.py
+++ b/marble_main.py
@@ -116,6 +116,8 @@ class MARBLE:
             , 'neuron_reservoir_size': 1000
             , 'lobe_decay_rate': 0.98
             , 'super_evolution_mode': False
+            , 'dream_decay_arousal_scale': 0.0
+            , 'dream_decay_stress_scale': 0.0
         }
         if brain_params is not None:
             brain_defaults.update(brain_params)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
-Jinja2==3.1.4
-MarkupSafe==2.1.5
-PyYAML==6.0.2
-Pygments==2.19.2
 aiohappyeyeballs==2.6.1
 aiohttp==3.12.14
 aiosignal==1.4.0
@@ -25,7 +21,9 @@ idna==3.10
 importlib_metadata==8.7.0
 iniconfig==2.1.0
 isort==6.0.1
+Jinja2==3.1.4
 kiwisolver==1.4.8
+MarkupSafe==2.1.5
 matplotlib==3.10.3
 mpmath==1.3.0
 multidict==6.6.3
@@ -43,11 +41,13 @@ platformdirs==4.3.8
 pluggy==1.6.0
 propcache==0.3.2
 pyarrow==21.0.0
+Pygments==2.19.2
 pyparsing==3.2.3
 pyright==1.1.403
 pytest==8.4.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
+PyYAML==6.0.2
 regex==2024.11.6
 requests==2.32.4
 ruff==0.12.2

--- a/tests/test_dream_modulation.py
+++ b/tests/test_dream_modulation.py
@@ -1,0 +1,56 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from marble_core import Core, DataLoader
+from marble_neuronenblitz import Neuronenblitz
+from marble_brain import Brain
+from neuromodulatory_system import NeuromodulatorySystem
+from tests.test_core_functions import minimal_params
+import pytest
+
+
+def test_compute_dream_decay():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    ns = NeuromodulatorySystem()
+    brain = Brain(
+        core,
+        nb,
+        DataLoader(),
+        neuromodulatory_system=ns,
+        dream_decay_arousal_scale=0.5,
+        dream_decay_stress_scale=0.5,
+    )
+    ns.update_signals(arousal=0.6, stress=0.2)
+    expected = brain.dream_synapse_decay
+    expected *= 1.0 + 0.5 * 0.6
+    expected *= 1.0 - 0.5 * 0.2
+    expected = max(0.0, min(expected, 1.0))
+    assert brain.compute_dream_decay() == pytest.approx(expected)
+
+
+def test_dream_uses_dynamic_decay(monkeypatch):
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    ns = NeuromodulatorySystem()
+    brain = Brain(
+        core,
+        nb,
+        DataLoader(),
+        neuromodulatory_system=ns,
+        dream_decay_arousal_scale=1.0,
+        dream_decay_stress_scale=0.0,
+    )
+    syn = core.neurons[0].synapses[0]
+    path = [syn]
+
+    def fake_wander(_):
+        return 0.0, path
+
+    monkeypatch.setattr(nb, "dynamic_wander", fake_wander)
+    ns.update_signals(arousal=1.0, stress=0.0)
+    before = syn.weight
+    decay = brain.compute_dream_decay()
+    brain.dream(num_cycles=1)
+    assert syn.weight == pytest.approx(before * decay)

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -220,6 +220,12 @@ brain:
     below the high threshold; lower scores are moved to disk tiers.
   dream_synapse_decay: Multiplicative decay applied to synapse weights during
     each dreaming cycle.
+  dream_decay_arousal_scale: Scaling factor applied to ``dream_synapse_decay``
+    proportional to current arousal. ``0.0`` disables arousal-based modulation
+    while higher values increase decay when arousal rises.
+  dream_decay_stress_scale: Scaling factor that reduces the effective decay
+    as stress grows. Values around ``0.0`` keep stress from affecting dream
+    strength, whereas ``1.0`` completely cancels decay at full stress.
   neurogenesis_increase_step: Amount added to the neurogenesis factor when
     validation loss worsens.
   neurogenesis_decrease_step: Amount subtracted from the neurogenesis factor


### PR DESCRIPTION
## Summary
- modulate dream synapse decay by neuromodulatory signals
- expose `dream_decay_arousal_scale` and `dream_decay_stress_scale` brain parameters
- document new options in YAML manual and parameter listings
- update default configuration
- add tests for dynamic dream decay
- regenerate requirements.txt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa40199d88327a1fe38d7c7399c4d