### PR TITLE
Add chain-of-thought ability

### DIFF
--- a/marble_brain.py
+++ b/marble_brain.py
@@ -95,6 +95,7 @@ class Brain:
         self.dream_thread = None
         self.best_validation_loss = float("inf")
         self.saved_model_paths = []
+        self.last_chain_of_thought = []
         self.neuromodulatory_system = (
             neuromodulatory_system
             if neuromodulatory_system is not None
@@ -357,6 +358,26 @@ class Brain:
             self.core = data["core"]
             self.neuronenblitz = data["neuronenblitz"]
         print(f"Model loaded from {filepath}")
+
+    def generate_chain_of_thought(self, input_value):
+        """Return output and a chain of reasoning steps for the given input."""
+        output, path = self.neuronenblitz.dynamic_wander(input_value)
+        chain = []
+        prev_val = input_value
+        for syn in path:
+            to_val = self.core.neurons[syn.target].value
+            chain.append(
+                {
+                    "from": syn.source,
+                    "to": syn.target,
+                    "weight": syn.weight,
+                    "input": prev_val,
+                    "output": to_val,
+                }
+            )
+            prev_val = to_val
+        self.last_chain_of_thought = chain
+        return output, chain
 
     def store_memory(self, key, value):
         layer = self.memory_system.choose_layer(

--- a/tests/test_chain_of_thought.py
+++ b/tests/test_chain_of_thought.py
@@ -1,0 +1,20 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import random
+from marble_core import Core, DataLoader
+from marble_neuronenblitz import Neuronenblitz
+from marble_brain import Brain
+from tests.test_core_functions import minimal_params
+
+
+def test_generate_chain_of_thought():
+    random.seed(0)
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader())
+    output, chain = brain.generate_chain_of_thought(0.1)
+    assert isinstance(output, float)
+    assert isinstance(chain, list) and chain
+    first = chain[0]
+    assert {"from", "to", "weight", "input", "output"}.issubset(first.keys())


### PR DESCRIPTION
## Summary
- add `last_chain_of_thought` tracking to `Brain`
- implement `generate_chain_of_thought` that exposes intermediate steps
- test chain-of-thought generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa6cfc7188327a227cc272fe9f53d