### PR TITLE
Enhance logging with detailed metrics

### DIFF
--- a/marble_base.py
+++ b/marble_base.py
@@ -79,7 +79,13 @@ class MetricsVisualizer:
             'vram_usage': [],
             'batch_processing_time': [],
             'learning_efficiency': [],
-            'memory_efficiency': []
+            'memory_efficiency': [],
+            'arousal': [],
+            'stress': [],
+            'reward': [],
+            'plasticity_threshold': [],
+            'message_passing_change': [],
+            'compression_ratio': [],
         }
         self.fig_width = fig_width
         self.fig_height = fig_height
@@ -98,8 +104,9 @@ class MetricsVisualizer:
     
     def update(self, new_metrics):
         for key, value in new_metrics.items():
-            if key in self.metrics:
-                self.metrics[key].append(value)
+            if key not in self.metrics:
+                self.metrics[key] = []
+            self.metrics[key].append(value)
         clear_output(wait=True)
         self.plot_metrics()
     
@@ -108,6 +115,12 @@ class MetricsVisualizer:
         self.ax.plot(self.metrics['loss'], 'b-', label='Loss')
         self.ax_twin = self.ax.twinx()
         self.ax_twin.plot(self.metrics['vram_usage'], 'r-', label='VRAM (MB)')
+        if self.metrics['arousal']:
+            self.ax_twin.plot(self.metrics['arousal'], 'g--', label='Arousal')
+        if self.metrics['stress']:
+            self.ax_twin.plot(self.metrics['stress'], 'm--', label='Stress')
+        if self.metrics['reward']:
+            self.ax_twin.plot(self.metrics['reward'], 'c--', label='Reward')
         self.ax.set_xlabel('Batches')
         self.ax.set_title('Training Metrics')
         self.ax.grid(True)

--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -1,5 +1,6 @@
 from marble_imports import *
 from marble_core import Neuron, Synapse, NEURON_TYPES, perform_message_passing
+from marble_base import MetricsVisualizer
 
 
 class Neuronenblitz:
@@ -54,6 +55,7 @@ class Neuronenblitz:
         remote_client=None,
         torrent_client=None,
         torrent_map=None,
+        metrics_visualizer=None,
     ):
         self.core = core
         self.backtrack_probability = backtrack_probability
@@ -118,6 +120,8 @@ class Neuronenblitz:
         self.remote_client = remote_client
         self.torrent_client = torrent_client
         self.torrent_map = torrent_map if torrent_map is not None else {}
+        self.metrics_visualizer = metrics_visualizer
+        self.last_message_passing_change = 0.0
 
     def modulate_plasticity(self, context):
         """Adjust plasticity_threshold based on neuromodulatory context."""
@@ -330,7 +334,10 @@ class Neuronenblitz:
             self.core.synapses = [
                 s for s in self.core.synapses if abs(s.weight) >= 0.05
             ]
-            perform_message_passing(self.core)
+            change = perform_message_passing(
+                self.core, metrics_visualizer=self.metrics_visualizer
+            )
+            self.last_message_passing_change = change
 
     def get_training_history(self):
         return self.training_history

--- a/tests/test_brain_io.py
+++ b/tests/test_brain_io.py
@@ -46,9 +46,15 @@ def test_brain_save_and_load(tmp_path):
 def test_metrics_visualizer_update():
     from marble_base import MetricsVisualizer
     mv = MetricsVisualizer()
-    mv.update({'loss': 0.5, 'vram_usage': 0.1})
+    mv.update({'loss': 0.5, 'vram_usage': 0.1, 'arousal': 0.2,
+               'stress': 0.1, 'reward': 0.3,
+               'plasticity_threshold': 5.0,
+               'message_passing_change': 0.05,
+               'compression_ratio': 0.8})
     assert mv.metrics['loss'][-1] == 0.5
     assert mv.metrics['vram_usage'][-1] == 0.1
+    assert mv.metrics['arousal'][-1] == 0.2
+    assert mv.metrics['plasticity_threshold'][-1] == 5.0
 
 
 def test_brain_neuromodulatory_system_integration():


### PR DESCRIPTION
## Summary
- extend `MetricsVisualizer` to track neuromodulatory and compression metrics
- report message passing change in `perform_message_passing`
- propagate metrics to `Neuronenblitz` and `Brain`
- track compression ratios in `DataLoader`
- wire metrics visualizer through `MARBLE` initialization
- update metrics visualizer test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa835c19483278b1eb547c0feae6f