### PR TITLE
Implement Plotly Dash metrics dashboard

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -201,6 +201,11 @@ Each entry is listed under its section heading.
 - color_scheme
 - show_neuron_ids
 - dpi
+## metrics_dashboard
+- enabled
+- host
+- port
+- update_interval
 
 ## lobe_manager
 - attention_increase_factor

--- a/config.yaml
+++ b/config.yaml
@@ -192,3 +192,8 @@ metrics_visualizer:
   color_scheme: "default"
   show_neuron_ids: false
   dpi: 100
+metrics_dashboard:
+  enabled: false
+  host: "localhost"
+  port: 8050
+  update_interval: 1000

--- a/config_loader.py
+++ b/config_loader.py
@@ -104,6 +104,7 @@ def create_marble_from_config(path: str | None = None) -> MARBLE:
         torrent_client.connect()
 
     mv_params = cfg.get("metrics_visualizer", {})
+    dashboard_params = cfg.get("metrics_dashboard", {})
 
     marble = MARBLE(
         core_params,
@@ -115,6 +116,7 @@ def create_marble_from_config(path: str | None = None) -> MARBLE:
         remote_client=remote_client,
         torrent_client=torrent_client,
         mv_params=mv_params,
+        dashboard_params=dashboard_params,
     )
     if remote_server is not None:
         marble.remote_server = remote_server

--- a/marble_main.py
+++ b/marble_main.py
@@ -18,6 +18,7 @@ class MARBLE:
         remote_client=None,
         torrent_client=None,
         mv_params=None,
+        dashboard_params=None,
     ):
         if converter_model is not None:
             self.core = MarbleConverter.convert(converter_model, mode='sequential', core_params=params, init_from_weights=init_from_weights)
@@ -31,6 +32,16 @@ class MARBLE:
             fig_width=mv_defaults["fig_width"],
             fig_height=mv_defaults["fig_height"],
         )
+        self.metrics_dashboard = None
+        if dashboard_params is not None and dashboard_params.get("enabled", False):
+            from metrics_dashboard import MetricsDashboard
+            self.metrics_dashboard = MetricsDashboard(
+                self.metrics_visualizer,
+                host=dashboard_params.get("host", "localhost"),
+                port=dashboard_params.get("port", 8050),
+                update_interval=dashboard_params.get("update_interval", 1000),
+            )
+            self.metrics_dashboard.start()
         
         dl_level = 6
         if dataloader_params is not None:

--- a/metrics_dashboard.py
+++ b/metrics_dashboard.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import threading
+from typing import Dict, Any
+
+from dash import Dash, dcc, html
+from dash.dependencies import Input, Output
+import plotly.graph_objs as go
+
+
+class MetricsDashboard:
+    """Simple Plotly Dash dashboard to visualize metrics live."""
+
+    def __init__(
+        self,
+        metrics_source: "MetricsVisualizer",
+        host: str = "localhost",
+        port: int = 8050,
+        update_interval: int = 1000,
+    ) -> None:
+        self.metrics_source = metrics_source
+        self.host = host
+        self.port = port
+        self.update_interval = update_interval
+        self.app = Dash(__name__)
+        self.thread: threading.Thread | None = None
+        self._setup_layout()
+
+    def _setup_layout(self) -> None:
+        self.app.layout = html.Div(
+            [
+                dcc.Graph(id="metrics-graph"),
+                dcc.Interval(id="interval", interval=self.update_interval, n_intervals=0),
+            ]
+        )
+
+        @self.app.callback(Output("metrics-graph", "figure"), Input("interval", "n_intervals"))
+        def update_graph(n: int) -> Dict[str, Any]:
+            metrics = self.metrics_source.metrics
+            fig = go.Figure()
+            if metrics.get("loss"):
+                fig.add_scatter(y=metrics["loss"], mode="lines", name="Loss")
+            if metrics.get("vram_usage"):
+                fig.add_scatter(y=metrics["vram_usage"], mode="lines", name="VRAM Usage")
+            if metrics.get("arousal"):
+                fig.add_scatter(y=metrics["arousal"], mode="lines", name="Arousal")
+            if metrics.get("stress"):
+                fig.add_scatter(y=metrics["stress"], mode="lines", name="Stress")
+            if metrics.get("reward"):
+                fig.add_scatter(y=metrics["reward"], mode="lines", name="Reward")
+            if metrics.get("plasticity_threshold"):
+                fig.add_scatter(y=metrics["plasticity_threshold"], mode="lines", name="Plasticity")
+            if metrics.get("message_passing_change"):
+                fig.add_scatter(y=metrics["message_passing_change"], mode="lines", name="MsgPass")
+            if metrics.get("compression_ratio"):
+                fig.add_scatter(y=metrics["compression_ratio"], mode="lines", name="Compression")
+            fig.update_layout(xaxis_title="Updates", yaxis_title="Value")
+            return fig
+
+    def start(self) -> None:
+        if self.thread is None:
+            self.thread = threading.Thread(
+                target=self.app.run,
+                kwargs={"host": self.host, "port": self.port, "debug": False},
+                daemon=True,
+            )
+            self.thread.start()
+
+    def stop(self) -> None:
+        # Dash doesn't provide a direct stop method; thread ends when server stops
+        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,3 +65,5 @@ urllib3==2.5.0
 xxhash==3.5.0
 yarl==1.20.1
 zipp==3.23.0
+dash==3.1.1
+plotly==6.2.0

--- a/tests/test_metrics_dashboard.py
+++ b/tests/test_metrics_dashboard.py
@@ -1,0 +1,14 @@
+import time
+from marble_base import MetricsVisualizer
+from metrics_dashboard import MetricsDashboard
+
+
+def test_dashboard_start_stop():
+    mv = MetricsVisualizer()
+    dashboard = MetricsDashboard(mv, port=8060, update_interval=200)
+    dashboard.start()
+    # allow server thread to start
+    time.sleep(0.5)
+    assert dashboard.thread is not None and dashboard.thread.is_alive()
+    # Stopping simply terminates when main thread exits
+    dashboard.stop()

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -394,6 +394,17 @@ metrics_visualizer:
     points.
   dpi: Resolution of the output figure in dots per inch.
 
+metrics_dashboard:
+  # Optional web dashboard built with Plotly Dash for real-time monitoring.
+  # When enabled a small HTTP server serves a page that visualizes the same
+  # metrics collected by ``MetricsVisualizer`` but updates automatically in the
+  # browser. This is useful when running training remotely and you still want
+  # to monitor progress live.
+  enabled: Set to ``true`` to start the dashboard in a background thread.
+  host: Interface address for the Dash server, usually ``"localhost"``.
+  port: TCP port used by the dashboard. Ensure this port is free.
+  update_interval: Milliseconds between refreshes of the dashboard graphs.
+
 lobe_manager:
   # Parameters controlling how strongly neuron attention is adjusted when the
   # ``LobeManager`` performs self-attention.


### PR DESCRIPTION
## Summary
- add optional `MetricsDashboard` with Plotly Dash
- expose dashboard configuration in config loader and YAML
- document dashboard parameters
- update requirements
- test MetricsDashboard startup

## Testing
- `pip install --break-system-packages torch==2.3.1` *(fails: Package(s) not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687aab099eac83279003a3b0535b2880