### PR TITLE
Add MARBLE backcronym list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# MARBLE
+
+**Mandelbrot Adaptive Reasoning Brain-Like Engine**
+
+The MARBLE system is a modular neural architecture that begins with a Mandelbrot-inspired seed and adapts through neuromodulatory feedback and structural plasticity. This repository contains the source code for the system along with utilities and configuration files.
+
+## Possible MARBLE Backcronyms
+
+Below is a list of ideas explored when naming the project:
+
+- Mandelbrot Adaptive Reasoning Brain-Like Engine
+- Multi-Agent Reinforcement-Based Learning Environment
+- Modular Architecture for Rapid Brain-Like Experimentation
+- Memory-Augmented Recursive Bayesian Learning Engine
+- Metaheuristic Adaptive Reinforcement-Based Learning Ecosystem
+- Multimodal Analytical Response Behavior Learning Entity
+- Machine-Augmented Reflective Belief Learning Engine
+- Morphological Adaptive Robotics Brain-Like Executor
+- Multi-sensory Associative Response and Behavior Learning Engine
+- Matrix-Accelerated Reasoning Bot with Learning Enhancements

--- a/tests/test_backcronym.py
+++ b/tests/test_backcronym.py
@@ -1,0 +1,15 @@
+import os
+import re
+
+
+def test_readme_contains_backcronyms_list():
+    readme_path = os.path.join(os.path.dirname(__file__), "..", "README.md")
+    assert os.path.exists(readme_path)
+    with open(readme_path, "r") as f:
+        text = f.read()
+    # Find lines under the backcronyms section
+    match = re.search(r"## Possible MARBLE Backcronyms\n(.*)", text, re.DOTALL)
+    assert match, "Backcronyms section missing"
+    lines = [line for line in match.group(1).splitlines() if line.startswith("-")]
+    assert len(lines) == 10, f"Expected 10 backcronyms, found {len(lines)}"
+    assert "Mandelbrot Adaptive Reasoning Brain-Like Engine" in lines[0]


### PR DESCRIPTION
## Summary
- add a list of 10 possible MARBLE backcronyms in README
- update regression test to validate the list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687aaca74f848327b65ba822bf23749f