### PR TITLE
Integrate compressor with marble DataLoader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,15 +3,18 @@ aiohttp==3.12.14
 aiosignal==1.4.0
 attrs==25.3.0
 black==25.1.0
+blinker==1.9.0
 certifi==2025.7.14
 charset-normalizer==3.4.2
 click==8.2.1
 contourpy==1.3.2
 cycler==0.12.1
+dash==3.1.1
 datasets==4.0.0
 diffusers==0.34.0
 dill==0.3.8
 filelock==3.13.1
+Flask==3.1.1
 fonttools==4.59.0
 frozenlist==1.7.0
 fsspec==2024.6.1
@@ -21,6 +24,7 @@ idna==3.10
 importlib_metadata==8.7.0
 iniconfig==2.1.0
 isort==6.0.1
+itsdangerous==2.2.0
 Jinja2==3.1.4
 kiwisolver==1.4.8
 MarkupSafe==2.1.5
@@ -30,6 +34,8 @@ multidict==6.6.3
 multiprocess==0.70.16
 mypy==1.16.1
 mypy_extensions==1.1.0
+narwhals==1.47.1
+nest-asyncio==1.6.0
 networkx==3.3
 nodeenv==1.9.1
 numpy==2.1.2
@@ -38,6 +44,7 @@ pandas==2.3.1
 pathspec==0.12.1
 pillow==11.0.0
 platformdirs==4.3.8
+plotly==6.2.0
 pluggy==1.6.0
 propcache==0.3.2
 pyarrow==21.0.0
@@ -50,6 +57,7 @@ pytz==2025.2
 PyYAML==6.0.2
 regex==2024.11.6
 requests==2.32.4
+retrying==1.4.0
 ruff==0.12.2
 safetensors==0.5.3
 setuptools==70.2.0
@@ -62,8 +70,7 @@ tqdm==4.67.1
 typing_extensions==4.14.1
 tzdata==2025.2
 urllib3==2.5.0
+Werkzeug==3.1.3
 xxhash==3.5.0
 yarl==1.20.1
 zipp==3.23.0
-dash==3.1.1
-plotly==6.2.0

--- a/tests/test_marble_dataloader.py
+++ b/tests/test_marble_dataloader.py
@@ -1,0 +1,20 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import numpy as np
+from marble import DataLoader
+
+
+def test_marble_dataloader_roundtrip():
+    dl = DataLoader()
+    data = {"a": 1, "b": [1, 2, 3]}
+    tensor = dl.encode(data)
+    restored = dl.decode(tensor)
+    assert restored == data
+
+
+def test_marble_dataloader_array_roundtrip():
+    dl = DataLoader()
+    arr = np.arange(6, dtype=np.float32).reshape(2, 3)
+    tensor = dl.encode_array(arr)
+    restored = dl.decode_array(tensor)
+    assert np.array_equal(restored, arr)


### PR DESCRIPTION
## Summary
- integrate `DataCompressor` with `DataLoader` inside `marble.py`
- expose optional `metrics_visualizer` and array helpers just like the main loader
- import `cp` from `marble_imports` for compatibility without CuPy
- test the updated loader
- regenerate `requirements.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab072eef483279a030f2632e9882d