### PR TITLE
Implement optional autograd layer

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -215,3 +215,7 @@ Each entry is listed under its section heading.
 - loss_growth_threshold
 - dream_cycle_sleep
 - super_evolution_mode
+
+## autograd
+- enabled
+- learning_rate

--- a/config.yaml
+++ b/config.yaml
@@ -197,3 +197,6 @@ metrics_dashboard:
   host: "localhost"
   port: 8050
   update_interval: 1000
+autograd:
+  enabled: false
+  learning_rate: 0.01

--- a/config_loader.py
+++ b/config_loader.py
@@ -60,6 +60,8 @@ def create_marble_from_config(path: str | None = None) -> MARBLE:
     compression_level = compressor_cfg.get("compression_level", 6)
     dataloader_params = {"compression_level": compression_level}
 
+    autograd_params = cfg.get("autograd", {})
+
     brain_params.update({
         "neuromodulatory_system": neuromod_system,
         "meta_controller": meta_controller,
@@ -117,6 +119,7 @@ def create_marble_from_config(path: str | None = None) -> MARBLE:
         torrent_client=torrent_client,
         mv_params=mv_params,
         dashboard_params=dashboard_params,
+        autograd_params=autograd_params,
     )
     if remote_server is not None:
         marble.remote_server = remote_server

--- a/marble_autograd.py
+++ b/marble_autograd.py
@@ -1,0 +1,36 @@
+import torch
+import torch.nn as nn
+from marble_brain import Brain
+
+class MarbleAutogradFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, wrapper, input_tensor: torch.Tensor) -> torch.Tensor:
+        input_value = float(input_tensor.item())
+        output, path = wrapper.brain.neuronenblitz.dynamic_wander(input_value)
+        ctx.wrapper = wrapper
+        ctx.path = path
+        ctx.save_for_backward(input_tensor)
+        return torch.tensor(output, dtype=input_tensor.dtype)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        input_tensor, = ctx.saved_tensors
+        wrapper = ctx.wrapper
+        for syn in ctx.path:
+            source_val = wrapper.brain.core.neurons[syn.source].value
+            grad = float(grad_output) * source_val
+            syn.weight -= wrapper.learning_rate * grad
+        return None, grad_output.clone()
+
+class MarbleAutogradLayer(nn.Module):
+    """Transparent autograd wrapper for a :class:`Brain` instance."""
+
+    def __init__(self, brain: Brain, learning_rate: float = 0.01) -> None:
+        super().__init__()
+        self.brain = brain
+        self.learning_rate = learning_rate
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if not isinstance(x, torch.Tensor):
+            x = torch.tensor(x, dtype=torch.float32)
+        return MarbleAutogradFunction.apply(self, x)

--- a/marble_main.py
+++ b/marble_main.py
@@ -2,6 +2,7 @@ from marble_imports import *
 from marble_core import Core, DataLoader, TIER_REGISTRY
 from marble_neuronenblitz import Neuronenblitz
 from marble_brain import Brain, BenchmarkManager
+from marble_autograd import MarbleAutogradLayer
 from marble_base import MetricsVisualizer
 
 class MARBLE:
@@ -19,6 +20,7 @@ class MARBLE:
         torrent_client=None,
         mv_params=None,
         dashboard_params=None,
+        autograd_params=None,
     ):
         if converter_model is not None:
             self.core = MarbleConverter.convert(converter_model, mode='sequential', core_params=params, init_from_weights=init_from_weights)
@@ -157,8 +159,14 @@ class MARBLE:
             metrics_visualizer=self.metrics_visualizer,
             **brain_defaults,
         )
-        
+
         self.benchmark_manager = BenchmarkManager(self)
+
+        self.autograd_layer = None
+        if autograd_params is not None and autograd_params.get("enabled", False):
+            self.autograd_layer = MarbleAutogradLayer(
+                self.brain, learning_rate=autograd_params.get("learning_rate", 0.01)
+            )
     
     def get_core(self):
         return self.core
@@ -174,9 +182,12 @@ class MARBLE:
 
     def get_metrics_visualizer(self):
         return self.metrics_visualizer
-    
+
     def get_benchmark_manager(self):
         return self.benchmark_manager
+
+    def get_autograd_layer(self):
+        return self.autograd_layer
 
 if __name__ == '__main__':
     # Core parameters

--- a/tests/test_autograd_layer.py
+++ b/tests/test_autograd_layer.py
@@ -1,0 +1,24 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import torch
+from marble_core import Core, DataLoader
+from marble_neuronenblitz import Neuronenblitz
+from marble_brain import Brain
+from marble_autograd import MarbleAutogradLayer
+from tests.test_core_functions import minimal_params
+
+
+def test_autograd_forward_backward():
+    torch.manual_seed(0)
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader())
+    layer = MarbleAutogradLayer(brain, learning_rate=0.1)
+    inp = torch.tensor(0.5, requires_grad=True)
+    out = layer(inp)
+    loss = (out - 1.0) ** 2
+    before = [s.weight for s in core.synapses]
+    loss.backward()
+    changed = any(abs(syn.weight - before[i]) > 1e-6 for i, syn in enumerate(core.synapses))
+    assert changed

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -414,3 +414,7 @@ lobe_manager:
   attention_decrease_factor: Multiplier used when a lobe's attention is above
     average but the loss is not improving. Numbers below ``1.0`` gradually reduce
     emphasis on those lobes.
+
+autograd:
+  enabled: Set to true to wrap the Brain with a transparent PyTorch autograd layer. When enabled, gradients from PyTorch operations are applied to MARBLE synapse weights without altering the underlying architecture.
+  learning_rate: Step size used when the autograd layer applies gradient updates to synapse weights during backward passes. Typical values range from 0.001 to 0.1.


### PR DESCRIPTION
## Summary
- add `MarbleAutogradLayer` wrapper module with custom autograd function
- integrate autograd configuration in loader and MARBLE class
- expose autograd layer and config parameters
- document new YAML section and configurable parameters
- add unit test for autograd layer
- refresh `requirements.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab54071308327aadd48527f0d728b