### PR TITLE
Add autograd vs marble benchmark

### DIFF
--- a/benchmark_autograd_vs_marble.py
+++ b/benchmark_autograd_vs_marble.py
@@ -1,0 +1,80 @@
+import time
+import numpy as np
+import torch
+
+from marble_core import Core, DataLoader
+from marble_neuronenblitz import Neuronenblitz
+from marble_brain import Brain
+from marble_autograd import MarbleAutogradLayer
+from tests.test_core_functions import minimal_params
+
+
+def generate_dataset(n_samples: int = 50, seed: int = 0):
+    """Generate simple (input, target) pairs using a sine function."""
+    rng = np.random.default_rng(seed)
+    xs = rng.uniform(-1.0, 1.0, size=n_samples)
+    ys = np.sin(xs * np.pi)
+    return list(zip(xs.tolist(), ys.tolist()))
+
+
+def train_marble(train_data, val_data, epochs: int = 10):
+    """Train using the pure MARBLE system."""
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader())
+
+    start = time.time()
+    for _ in range(epochs):
+        brain.train(train_data, epochs=1, validation_examples=val_data)
+    val_loss = brain.validate(val_data)
+    duration = time.time() - start
+    return val_loss, duration
+
+
+def train_autograd(train_data, val_data, epochs: int = 10, learning_rate: float = 0.01):
+    """Train using the autograd pathway."""
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader())
+    layer = MarbleAutogradLayer(brain, learning_rate=learning_rate)
+
+    start = time.time()
+    for _ in range(epochs):
+        for x, y in train_data:
+            inp = torch.tensor(x, dtype=torch.float32, requires_grad=True)
+            out = layer(inp)
+            loss = (out - torch.tensor(y, dtype=torch.float32)) ** 2
+            loss.backward()
+    with torch.no_grad():
+        errors = []
+        for x, y in val_data:
+            pred = layer(torch.tensor(x, dtype=torch.float32))
+            errors.append(float(abs(y - pred.item())))
+        val_loss = sum(errors) / len(errors) if errors else 0.0
+    duration = time.time() - start
+    return val_loss, duration
+
+
+def run_benchmark():
+    """Run both training modes and return their validation losses and durations."""
+    data = generate_dataset()
+    train_data = data[:40]
+    val_data = data[40:]
+
+    marble_loss, marble_time = train_marble(train_data, val_data)
+    autograd_loss, autograd_time = train_autograd(train_data, val_data)
+
+    results = {
+        "marble": {"loss": marble_loss, "time": marble_time},
+        "autograd": {"loss": autograd_loss, "time": autograd_time},
+    }
+    return results
+
+
+if __name__ == "__main__":
+    res = run_benchmark()
+    print("Benchmark results:")
+    for k, v in res.items():
+        print(f"{k}: loss={v['loss']:.4f}, time={v['time']:.2f}s")

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,3 +74,4 @@ Werkzeug==3.1.3
 xxhash==3.5.0
 yarl==1.20.1
 zipp==3.23.0
+ipywidgets==8.1.7

--- a/tests/test_benchmark_autograd_vs_marble.py
+++ b/tests/test_benchmark_autograd_vs_marble.py
@@ -1,0 +1,39 @@
+import pytest
+
+from benchmark_autograd_vs_marble import (
+    generate_dataset,
+    train_marble,
+    train_autograd,
+    run_benchmark,
+)
+
+
+def test_generate_dataset_size():
+    data = generate_dataset(10, seed=1)
+    assert len(data) == 10
+    assert isinstance(data[0][0], float)
+
+
+def test_train_marble_returns_floats():
+    data = generate_dataset(20)
+    train_data = data[:15]
+    val_data = data[15:]
+    loss, duration = train_marble(train_data, val_data, epochs=1)
+    assert isinstance(loss, float)
+    assert isinstance(duration, float)
+
+
+def test_train_autograd_returns_floats():
+    data = generate_dataset(20)
+    train_data = data[:15]
+    val_data = data[15:]
+    loss, duration = train_autograd(train_data, val_data, epochs=1)
+    assert isinstance(loss, float)
+    assert isinstance(duration, float)
+
+
+def test_run_benchmark_structure():
+    results = run_benchmark()
+    assert "marble" in results and "autograd" in results
+    assert set(results["marble"].keys()) == {"loss", "time"}
+    assert set(results["autograd"].keys()) == {"loss", "time"}


### PR DESCRIPTION
## Summary
- add `benchmark_autograd_vs_marble.py` to compare autograd and pure MARBLE training
- add pytest coverage for benchmark functions
- add missing dependency `ipywidgets` to requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python benchmark_autograd_vs_marble.py`

------
https://chatgpt.com/codex/tasks/task_e_687abd3761e08327bfafa7e8ce7faf42