### PR TITLE
Handle non-finite values in message passing

### DIFF
--- a/marble_core.py
+++ b/marble_core.py
@@ -24,6 +24,8 @@ def configure_representation_size(rep_size: int) -> None:
 
 def _simple_mlp(x: np.ndarray) -> np.ndarray:
     """Tiny MLP with one hidden layer and tanh activations."""
+    # Handle potential NaNs or infinities to avoid runtime warnings
+    x = np.nan_to_num(x, nan=0.0, posinf=0.0, neginf=0.0)
     h = np.tanh(x @ _W1 + _B1)
     return np.tanh(h @ _W2 + _B2)
 
@@ -57,7 +59,9 @@ def perform_message_passing(
         neigh_reps = [core.neurons[s.source].representation * s.weight for s in incoming]
         if not neigh_reps:
             continue
-        dots = np.array([float(np.dot(target.representation, nr)) for nr in neigh_reps])
+        target_rep = np.nan_to_num(target.representation, nan=0.0, posinf=0.0, neginf=0.0)
+        neigh_reps = [np.nan_to_num(nr, nan=0.0, posinf=0.0, neginf=0.0) for nr in neigh_reps]
+        dots = np.array([float(np.dot(target_rep, nr)) for nr in neigh_reps])
         shifted = np.clip(dots - np.max(dots), -50, 50)
         exps = np.exp(shifted)
         denom = exps.sum()

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -108,3 +108,9 @@ def test_core_init_noise_std_affects_values():
     values_noisy = [n.value for n in core_noisy.neurons]
     values_clean = [n.value for n in core_clean.neurons]
     assert values_noisy != values_clean
+
+
+def test_simple_mlp_handles_invalid_input():
+    arr = np.array([np.nan, np.inf, -np.inf, 1.0])
+    out = marble_core._simple_mlp(arr)
+    assert np.all(np.isfinite(out))


### PR DESCRIPTION
## Summary
- sanitize inputs to `_simple_mlp`
- guard message passing against NaNs and Infs
- test `_simple_mlp` behaviour on invalid inputs

## Testing
- `pytest -q`
- `python -m pytest tests/test_benchmark_autograd_vs_marble.py::test_run_benchmark_structure -s`
- `python -m pytest tests/test_brain_benchmark.py::test_benchmark_step_returns_metrics -s`
- `python benchmark_autograd_vs_marble.py`

------
https://chatgpt.com/codex/tasks/task_e_687acbf069e48327aa1e6b4635b89606