### PR TITLE
Align benchmark seeds

### DIFF
--- a/benchmark_autograd_vs_marble.py
+++ b/benchmark_autograd_vs_marble.py
@@ -1,6 +1,7 @@
 import time
 import numpy as np
 import torch
+import random
 from sklearn.datasets import load_diabetes
 
 from marble_core import Core, DataLoader
@@ -26,9 +27,14 @@ def load_real_dataset(n_samples: int = 100):
     return list(zip(xs.astype(float).tolist(), ys.astype(float).tolist()))
 
 
-def train_marble(train_data, val_data, epochs: int = 10):
+def train_marble(train_data, val_data, epochs: int = 10, seed: int | None = None):
     """Train using the pure MARBLE system."""
     params = minimal_params()
+    if seed is not None:
+        params["random_seed"] = seed
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
     core = Core(params)
     nb = Neuronenblitz(core)
     brain = Brain(core, nb, DataLoader())
@@ -41,9 +47,14 @@ def train_marble(train_data, val_data, epochs: int = 10):
     return val_loss, duration
 
 
-def train_autograd(train_data, val_data, epochs: int = 10, learning_rate: float = 0.01):
+def train_autograd(train_data, val_data, epochs: int = 10, learning_rate: float = 0.01, seed: int | None = None):
     """Train using the autograd pathway."""
     params = minimal_params()
+    if seed is not None:
+        params["random_seed"] = seed
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
     core = Core(params)
     nb = Neuronenblitz(core)
     brain = Brain(core, nb, DataLoader())
@@ -66,14 +77,14 @@ def train_autograd(train_data, val_data, epochs: int = 10, learning_rate: float 
     return val_loss, duration
 
 
-def run_benchmark():
+def run_benchmark(seed: int | None = None):
     """Run both training modes and return their validation losses and durations."""
     data = load_real_dataset()
     train_data = data[:80]
     val_data = data[80:]
 
-    marble_loss, marble_time = train_marble(train_data, val_data, epochs=10)
-    autograd_loss, autograd_time = train_autograd(train_data, val_data, epochs=10)
+    marble_loss, marble_time = train_marble(train_data, val_data, epochs=10, seed=seed)
+    autograd_loss, autograd_time = train_autograd(train_data, val_data, epochs=10, seed=seed)
 
     results = {
         "marble": {"loss": marble_loss, "time": marble_time},

--- a/marble_core.py
+++ b/marble_core.py
@@ -304,6 +304,14 @@ class DataLoader:
 class Core:
     def __init__(self, params, formula=None, formula_num_neurons=100):
         print("Initializing MARBLE Core...")
+        seed = params.get("random_seed")
+        if seed is not None:
+            random.seed(seed)
+            np.random.seed(seed)
+            try:
+                cp.random.seed(seed)
+            except Exception:
+                pass
         self.params = params
         if 'file' in TIER_REGISTRY:
             fpath = params.get('file_tier_path')

--- a/tests/test_benchmark_autograd_vs_marble.py
+++ b/tests/test_benchmark_autograd_vs_marble.py
@@ -25,7 +25,7 @@ def test_train_marble_returns_floats():
     data = generate_dataset(20)
     train_data = data[:15]
     val_data = data[15:]
-    loss, duration = train_marble(train_data, val_data, epochs=1)
+    loss, duration = train_marble(train_data, val_data, epochs=1, seed=0)
     assert isinstance(loss, float)
     assert isinstance(duration, float)
 
@@ -34,13 +34,13 @@ def test_train_autograd_returns_floats():
     data = generate_dataset(20)
     train_data = data[:15]
     val_data = data[15:]
-    loss, duration = train_autograd(train_data, val_data, epochs=1)
+    loss, duration = train_autograd(train_data, val_data, epochs=1, seed=0)
     assert isinstance(loss, float)
     assert isinstance(duration, float)
 
 
 def test_run_benchmark_structure():
-    results = run_benchmark()
+    results = run_benchmark(seed=0)
     assert "marble" in results and "autograd" in results
     assert set(results["marble"].keys()) == {"loss", "time"}
     assert set(results["autograd"].keys()) == {"loss", "time"}

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -23,6 +23,7 @@ def minimal_params():
         'vram_limit_mb': 0.1,
         'ram_limit_mb': 0.1,
         'disk_limit_mb': 0.1,
+        'random_seed': 0,
     }
 
 


### PR DESCRIPTION
## Summary
- ensure reproducible seed handling inside `Core`
- allow benchmark functions to pass a seed
- use the seed in tests and dataset generator helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `pytest -k benchmark_autograd_vs_marble -q`
- `python benchmark_autograd_vs_marble.py`


------
https://chatgpt.com/codex/tasks/task_e_687ad0f20a148327908d1e9f492abd16