### PR TITLE
Update super evolution benchmark to use self-adjusting parameters

### DIFF
--- a/benchmark_super_evolution.py
+++ b/benchmark_super_evolution.py
@@ -22,10 +22,8 @@ def train_super_evolution(train_data, val_data, epochs: int = 20, seed: int | No
     core = Core(params)
     nb = Neuronenblitz(core)
     brain = Brain(core, nb, DataLoader(), super_evolution_mode=True)
-    brain.core.neurons[0].cluster_id = 0
+    brain.core.cluster_neurons(k=3)
     brain.lobe_manager.organize()
-    brain.core.neurons[0].attention_score = 1.0
-    brain.lobe_manager.update_attention()
 
     logs: List[Dict] = []
     change_idx = 0
@@ -34,12 +32,6 @@ def train_super_evolution(train_data, val_data, epochs: int = 20, seed: int | No
         brain.train(train_data, epochs=1, validation_examples=val_data)
         val_loss = brain.validate(val_data)
         epoch_time = time.time() - start
-        # Trigger a manual adjustment to ensure change logging
-        old = brain.mutation_rate
-        brain.mutation_rate *= 1.01
-        brain.super_evo_controller.change_log.append(
-            {"parameter": "brain.mutation_rate", "old": old, "new": brain.mutation_rate}
-        )
         brain.super_evo_controller.record_metrics(val_loss, epoch_time)
         new_changes = brain.super_evo_controller.change_log[change_idx:]
         change_idx = len(brain.super_evo_controller.change_log)

--- a/marble_core.py
+++ b/marble_core.py
@@ -466,7 +466,7 @@ class Core:
         if not self.neurons:
             return
         values = np.array([n.value for n in self.neurons], dtype=float)
-        k = min(k, len(values))
+        k = int(min(k, len(values)))
         centers = np.random.choice(values, k, replace=False)
         for _ in range(5):
             assignments = [int(np.argmin([abs(v - c) for c in centers])) for v in values]
@@ -495,7 +495,6 @@ class Core:
             for neuron in self.neurons:
                 if neuron.cluster_id == cid:
                     neuron.tier = new_tier
-                    neuron.attention_score = 0.0
 
     def extract_subcore(self, neuron_ids):
         params = {

--- a/tests/test_neuron_clustering.py
+++ b/tests/test_neuron_clustering.py
@@ -29,6 +29,17 @@ def test_relocate_clusters_changes_tiers():
     assert tiers == {"vram"} or tiers == {"ram", "vram"} or tiers == {"ram"}
 
 
+def test_relocate_clusters_preserves_attention():
+    params = minimal_params()
+    core = Core(params)
+    for n in core.neurons[:2]:
+        n.cluster_id = 0
+        n.attention_score = 1.5
+    core.relocate_clusters(high=1.0, medium=0.5)
+    scores = [n.attention_score for n in core.neurons[:2]]
+    assert all(s > 0 for s in scores)
+
+
 def test_clustering_during_training():
     params = minimal_params()
     core = Core(params)


### PR DESCRIPTION
## Summary
- rely on automatic clustering and attention in `benchmark_super_evolution`
- remove manual mutation tweaking
- keep neuron attention when relocating clusters
- make neuron clustering robust to float `k`
- test that relocate_clusters no longer clears attention

## Testing
- `pytest -k benchmark_super_evolution -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b5fcfa6a88327ba03ca3f7e5d118c