### PR TITLE
Replace GPT torch code with numpy version

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -225,3 +225,13 @@ Each entry is listed under its section heading.
 - loss_penalty
 - speed_penalty
 - size_penalty
+
+## gpt
+- enabled
+- vocab_size
+- block_size
+- num_layers
+- num_heads
+- hidden_dim
+- learning_rate
+- num_train_steps

--- a/config.yaml
+++ b/config.yaml
@@ -206,3 +206,12 @@ pytorch_challenge:
   loss_penalty: 0.1
   speed_penalty: 0.1
   size_penalty: 0.1
+gpt:
+  enabled: false
+  vocab_size: 50
+  block_size: 8
+  num_layers: 2
+  num_heads: 2
+  hidden_dim: 64
+  learning_rate: 0.001
+  num_train_steps: 50

--- a/implementationplan.txt
+++ b/implementationplan.txt
@@ -12,7 +12,7 @@ Below is an updated, step‐by‐step implementation plan that incorporates all 
 ──────────────────────────── Step 2. Add FULL TRANSPARENT TRANSITIVE BINARY DATA COMPRESSION / DECOMPRESSION
 ──────────────────────────── A. Design a Data Compression Module
  • Create a new module (e.g., data_compressor.py or add within marble_base.py) that implements:
-  – Conversion of incoming data (e.g., images, text) into tensors using standard libraries (PyTorch, NumPy).
+– Conversion of incoming data (e.g., images, text) into tensors using PyTorch, NumPy.
   – Conversion from tensors into a “real binary representation” (an array of 0s and 1s).
   – Lossless binary compression using a fast, efficient algorithm (e.g., custom implementation based on well‑known techniques such as Huffman coding, LZ77/LZ78 variants, or zstd if allowed—but with full transparency: every transformation is visible and fully invertible).
   – A corresponding decompression and reverse transformation to retrieve the original tensor from the compressed binary format. B. Explain and Ensure “Transitivity”
@@ -33,7 +33,7 @@ Below is an updated, step‐by‐step implementation plan that incorporates all 
   – Inversion Accuracy: Any errors in the invertible transformations may corrupt the data.
  • Workarounds/Minimization Strategies:
   – Thorough unit testing of every transformation step ensures perfect inversion.
-  – Use vectorized operations (NumPy/PyTorch) to minimize performance overhead.
+– Use vectorized operations (NumPy/PyTorch) to minimize performance overhead.
   – Profile and optimize the compression algorithm to ensure it remains fast relative to the overall processing time.
   – Maintain extensive logging during early iterations to confirm that the “transitive” property holds (i.e., decompress(compress(input)) equals input exactly).
 
@@ -53,7 +53,7 @@ Below is an updated, step‐by‐step implementation plan that incorporates all 
  • Write functions (e.g., perform_message_passing() in marble_core.py) that iterate over neurons to exchange information:   – For each neuron, aggregate messages from neighbors weighted by synaptic strength.   – Compute attention scores (using a softmax over explicit dot products) to weight neighbor contributions.
   – Update the neuron’s representation using a formula such as:
    new_rep = α * current_rep + (1 – α) * f(sum(neighbor_msg))
-  – Develop ‘f’ as a small custom MLP (implemented from scratch using NumPy or basic PyTorch operations) with non-linear activation. C. Integration with Structural Plasticity:
+– Develop ‘f’ as a small custom MLP (implemented from scratch using NumPy or basic PyTorch operations) with non-linear activation. C. Integration with Structural Plasticity:
  • Integrate the updated representations in structural adjustments and conceptual refinement.  • When attention or message-passing indicates maladaptive convergence, trigger synaptic pruning or neuron splitting/merging (integrated into apply_structural_plasticity).
 
 ──────────────────────────── Step 7. Refine Structural Plasticity with Context-Driven Remodeling
@@ -100,3 +100,12 @@ Step 10B:
 
 By following these steps, MARBLE will evolve into a system that not only captures statistical patterns but also deeply understands and adapts to conceptual relationships—all while ensuring data is processed, compressed, and decompressed in a rigorously transparent and transitive manner.
 ──────────────────────────── Future Improvements
+
+──────────────────────────── Step 12. Advanced GPT Training Component
+──────────────────────────── • Build a dedicated module (e.g., advanced_gpt.py) implementing a full transformer decoder stack using only MARBLE’s components with NumPy and CuPy.
+• Provide configuration options for model depth, width, attention heads, feed‑forward size, dropout and activation functions so the complexity can scale from tiny experiments to very large models.
+• Implement a tokenisation and dataset ingestion pipeline that reads raw text files specified in YAML (dataset_path) and converts them into training sequences using a configurable vocabulary.
+• Add a training routine that supports batching, GPU utilisation and checkpointing. Training should rely on MARBLE’s CuPy-based automatic differentiation rather than external libraries or manual gradient calculations.
+• Integrate this component into MARBLE by enabling it when `gpt.enabled` is true and exposing all hyperparameters through the `gpt` configuration section.
+• Write unit tests covering dataset preparation, model initialisation and a short training loop verifying loss decreases.
+• Document each parameter in CONFIGURABLE_PARAMETERS.md and yaml-manual.txt, expanding the manual with detailed explanations of dataset_path, batch_size and optimizer settings when those are added.

--- a/tests/test_gpt_training.py
+++ b/tests/test_gpt_training.py
@@ -1,0 +1,25 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from gpt_training import generate_dataset, train_gpt
+
+
+def test_dataset_generation():
+    data = generate_dataset(vocab_size=10, num_samples=5, block_size=4, seed=0)
+    assert len(data) == 5
+    assert data[0].shape[0] == 5
+
+
+def test_gpt_training_reduces_loss():
+    data = generate_dataset(vocab_size=20, num_samples=8, block_size=4, seed=0)
+    _, losses = train_gpt(
+        data,
+        vocab_size=20,
+        block_size=4,
+        num_layers=1,
+        num_heads=2,
+        hidden_dim=32,
+        epochs=3,
+        lr=0.01,
+        seed=0,
+    )
+    assert losses[-1] <= losses[0]

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -430,3 +430,22 @@ pytorch_challenge:
   loss_penalty: Amount of stress added when MARBLE's loss is worse than the PyTorch baseline. Values around 0.1 provide noticeable pressure without overwhelming the system.
   speed_penalty: Stress increment applied when MARBLE's inference time is slower than the baseline model. Setting this near 0.1 encourages optimisations to execution paths.
   size_penalty: Stress increment when MARBLE grows larger than the baseline model in megabytes. This guides synaptic pruning and structural plasticity to favour compactness.
+
+gpt:
+  # The GPT component enables MARBLE to build and train a transformer-based language model entirely from scratch. When
+  # `enabled` is true a small GPT architecture is initialised using the parameters below and trained on token sequences
+  # provided by the user. This allows experimentation with generative text models without relying on any pretrained weights.
+  enabled: Set to true to activate GPT training within MARBLE.
+  vocab_size: Size of the discrete token vocabulary used when constructing the embedding layers. Must be greater than one.
+  block_size: Number of tokens processed at once. Sequences longer than this are split into blocks. Typical values range
+    from 8 to 128 for lightweight experiments.
+  num_layers: Number of transformer encoder layers stacked in the GPT. Increasing this improves modelling power but also
+    memory and compute requirements. Values between 2 and 8 are common for small models.
+  num_heads: Quantity of attention heads per layer. More heads allow the model to capture diverse relationships between
+    tokens. Small configurations often use 2 to 8 heads.
+  hidden_dim: Dimensionality of the token and positional embeddings as well as the hidden size of each transformer layer.
+    Higher values provide more capacity but also increase memory usage.
+  learning_rate: Step size for the Adam optimiser when training the GPT model. Start with around 0.001 and adjust based
+    on observed convergence.
+  num_train_steps: Number of update steps performed during GPT training. Keeping this low (tens to hundreds) ensures test
+    runs complete quickly while still demonstrating learning behaviour.


### PR DESCRIPTION
## Summary
- undo non-GPT plan changes
- drop unused transformers requirement
- implement GPT trainer using custom NumPy autograd
- keep GPT configuration notes and tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b96cfb6c0832791c4d39de1dff45c