### PR TITLE
Extend metrics with meta loss average

### DIFF
--- a/marble_base.py
+++ b/marble_base.py
@@ -3,18 +3,24 @@ from marble_imports import *
 
 def clear_output(wait: bool = True) -> None:
     """Clear the terminal screen."""
-    os.system('cls' if os.name == 'nt' else 'clear')
+    os.system("cls" if os.name == "nt" else "clear")
+
 
 def log_metrics(epoch, tar_idx, loss, vram_usage):
-    with open('training_log.txt', 'a') as f:
-        f.write(f"Epoch {epoch}, Tar {tar_idx}: Loss={loss:.4f}, VRAM={vram_usage:.2f}MB\n")
+    with open("training_log.txt", "a") as f:
+        f.write(
+            f"Epoch {epoch}, Tar {tar_idx}: Loss={loss:.4f}, VRAM={vram_usage:.2f}MB\n"
+        )
+
 
 def download_and_process_tar(url, temp_dir):
     print(f"Starting download from {url}")
     headers = {
-        'User-Agent': ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
-                       'AppleWebKit/537.36 (KHTML, like Gecko) '
-                       'Chrome/91.0.4472.124 Safari/537.36')
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/91.0.4472.124 Safari/537.36"
+        )
     }
     response = requests.get(url, stream=True, headers=headers, allow_redirects=True)
     response.raise_for_status()
@@ -26,26 +32,40 @@ def download_and_process_tar(url, temp_dir):
         oid_line = next(line for line in lfs_info if line.startswith("oid sha256:"))
         oid = oid_line.split(":")[1].strip()
         lfs_url = f"https://huggingface.co/datasets/jackyhate/text-to-image-2M/resolve/main/data_512_2M/data_{url.split('data_')[-1]}"
-        response = requests.get(lfs_url, stream=True, headers=headers, allow_redirects=True)
+        response = requests.get(
+            lfs_url, stream=True, headers=headers, allow_redirects=True
+        )
         response.raise_for_status()
-        total_size = int(response.headers.get('content-length', 0))
+        total_size = int(response.headers.get("content-length", 0))
         tar_path = Path(temp_dir) / "current.tar"
-        with open(tar_path, 'wb') as f:
-            with tqdm(total=total_size, desc="Downloading tar (LFS)", unit='iB', unit_scale=True, position=1) as pbar:
+        with open(tar_path, "wb") as f:
+            with tqdm(
+                total=total_size,
+                desc="Downloading tar (LFS)",
+                unit="iB",
+                unit_scale=True,
+                position=1,
+            ) as pbar:
                 for chunk in response.iter_content(chunk_size=8192):
                     if chunk:
                         f.write(chunk)
                         pbar.update(len(chunk))
     else:
-        total_size = int(response.headers.get('content-length', 0))
+        total_size = int(response.headers.get("content-length", 0))
         tar_path = Path(temp_dir) / "current.tar"
-        with open(tar_path, 'wb') as f:
-            with tqdm(total=total_size, desc="Downloading tar", unit='iB', unit_scale=True, position=1) as pbar:
+        with open(tar_path, "wb") as f:
+            with tqdm(
+                total=total_size,
+                desc="Downloading tar",
+                unit="iB",
+                unit_scale=True,
+                position=1,
+            ) as pbar:
                 for chunk in response.iter_content(chunk_size=8192):
                     if chunk:
                         f.write(chunk)
                         pbar.update(len(chunk))
-                        
+
     extract_dir = Path(temp_dir) / "extracted"
     extract_dir.mkdir(exist_ok=True)
     try:
@@ -53,7 +73,7 @@ def download_and_process_tar(url, temp_dir):
             tar.extractall(path=extract_dir)
     except tarfile.ReadError as e:
         raise ValueError(f"Failed to extract tar file: {e}")
-    
+
     samples = []
     for root, dirs, files in os.walk(extract_dir):
         images = {}
@@ -61,9 +81,9 @@ def download_and_process_tar(url, temp_dir):
         for file in files:
             base, ext = os.path.splitext(file)
             full_path = Path(root) / file
-            if ext.lower() in ['.png', '.jpg', '.jpeg']:
+            if ext.lower() in [".png", ".jpg", ".jpeg"]:
                 images[base] = full_path
-            elif ext.lower() == '.json':
+            elif ext.lower() == ".json":
                 jsons[base] = full_path
         for base in images:
             if base in jsons:
@@ -71,21 +91,30 @@ def download_and_process_tar(url, temp_dir):
     samples.sort()
     return samples
 
+
 class MetricsVisualizer:
-    def __init__(self, fig_width=10, fig_height=6, refresh_rate=1,
-                 color_scheme="default", show_neuron_ids=False, dpi=100):
+    def __init__(
+        self,
+        fig_width=10,
+        fig_height=6,
+        refresh_rate=1,
+        color_scheme="default",
+        show_neuron_ids=False,
+        dpi=100,
+    ):
         self.metrics = {
-            'loss': [],
-            'vram_usage': [],
-            'batch_processing_time': [],
-            'learning_efficiency': [],
-            'memory_efficiency': [],
-            'arousal': [],
-            'stress': [],
-            'reward': [],
-            'plasticity_threshold': [],
-            'message_passing_change': [],
-            'compression_ratio': [],
+            "loss": [],
+            "vram_usage": [],
+            "batch_processing_time": [],
+            "learning_efficiency": [],
+            "memory_efficiency": [],
+            "arousal": [],
+            "stress": [],
+            "reward": [],
+            "plasticity_threshold": [],
+            "message_passing_change": [],
+            "compression_ratio": [],
+            "meta_loss_avg": [],
         }
         self.fig_width = fig_width
         self.fig_height = fig_height
@@ -94,14 +123,14 @@ class MetricsVisualizer:
         self.show_neuron_ids = show_neuron_ids
         self.dpi = dpi
         self.setup_plot()
-    
+
     def setup_plot(self):
         self.fig, self.ax = plt.subplots(figsize=(self.fig_width, self.fig_height))
-        self.ax.set_title('MARBLE Training Metrics Live View')
-        self.ax.set_xlabel('Batches')
-        self.ax.set_ylabel('Loss / VRAM Usage')
+        self.ax.set_title("MARBLE Training Metrics Live View")
+        self.ax.set_xlabel("Batches")
+        self.ax.set_ylabel("Loss / VRAM Usage")
         self.ax.grid(True)
-    
+
     def update(self, new_metrics):
         for key, value in new_metrics.items():
             if key not in self.metrics:
@@ -109,22 +138,24 @@ class MetricsVisualizer:
             self.metrics[key].append(value)
         clear_output(wait=True)
         self.plot_metrics()
-    
+
     def plot_metrics(self):
         self.ax.clear()
-        self.ax.plot(self.metrics['loss'], 'b-', label='Loss')
+        self.ax.plot(self.metrics["loss"], "b-", label="Loss")
         self.ax_twin = self.ax.twinx()
-        self.ax_twin.plot(self.metrics['vram_usage'], 'r-', label='VRAM (MB)')
-        if self.metrics['arousal']:
-            self.ax_twin.plot(self.metrics['arousal'], 'g--', label='Arousal')
-        if self.metrics['stress']:
-            self.ax_twin.plot(self.metrics['stress'], 'm--', label='Stress')
-        if self.metrics['reward']:
-            self.ax_twin.plot(self.metrics['reward'], 'c--', label='Reward')
-        self.ax.set_xlabel('Batches')
-        self.ax.set_title('Training Metrics')
+        self.ax_twin.plot(self.metrics["vram_usage"], "r-", label="VRAM (MB)")
+        if self.metrics["arousal"]:
+            self.ax_twin.plot(self.metrics["arousal"], "g--", label="Arousal")
+        if self.metrics["stress"]:
+            self.ax_twin.plot(self.metrics["stress"], "m--", label="Stress")
+        if self.metrics["reward"]:
+            self.ax_twin.plot(self.metrics["reward"], "c--", label="Reward")
+        if self.metrics["meta_loss_avg"]:
+            self.ax.plot(self.metrics["meta_loss_avg"], "y-", label="MetaLossAvg")
+        self.ax.set_xlabel("Batches")
+        self.ax.set_title("Training Metrics")
         self.ax.grid(True)
-        self.ax.legend(loc='upper left')
-        self.ax_twin.legend(loc='upper right')
+        self.ax.legend(loc="upper left")
+        self.ax_twin.legend(loc="upper right")
         plt.tight_layout()
         plt.show()

--- a/marble_brain.py
+++ b/marble_brain.py
@@ -330,6 +330,12 @@ class Brain:
                         "reward": ctx.get("reward", 0.0),
                         "plasticity_threshold": self.neuronenblitz.plasticity_threshold,
                         "message_passing_change": self.neuronenblitz.last_message_passing_change,
+                        "meta_loss_avg": (
+                            sum(self.meta_controller.loss_history)
+                            / len(self.meta_controller.loss_history)
+                            if self.meta_controller.loss_history
+                            else 0.0
+                        ),
                     }
                 )
 
@@ -653,7 +659,9 @@ class Brain:
         pytorch_model.eval()
         pbar = tqdm(range(epochs), desc="ChallengeEpochs", ncols=100)
         if pytorch_inputs is None:
-            pytorch_inputs = [torch.tensor(inp, dtype=torch.float32) for inp, _ in train_examples]
+            pytorch_inputs = [
+                torch.tensor(inp, dtype=torch.float32) for inp, _ in train_examples
+            ]
         for _ in pbar:
             for (inp, tgt), p_inp in zip(train_examples, pytorch_inputs):
                 start = time.time()

--- a/metrics_dashboard.py
+++ b/metrics_dashboard.py
@@ -30,18 +30,24 @@ class MetricsDashboard:
         self.app.layout = html.Div(
             [
                 dcc.Graph(id="metrics-graph"),
-                dcc.Interval(id="interval", interval=self.update_interval, n_intervals=0),
+                dcc.Interval(
+                    id="interval", interval=self.update_interval, n_intervals=0
+                ),
             ]
         )
 
-        @self.app.callback(Output("metrics-graph", "figure"), Input("interval", "n_intervals"))
+        @self.app.callback(
+            Output("metrics-graph", "figure"), Input("interval", "n_intervals")
+        )
         def update_graph(n: int) -> Dict[str, Any]:
             metrics = self.metrics_source.metrics
             fig = go.Figure()
             if metrics.get("loss"):
                 fig.add_scatter(y=metrics["loss"], mode="lines", name="Loss")
             if metrics.get("vram_usage"):
-                fig.add_scatter(y=metrics["vram_usage"], mode="lines", name="VRAM Usage")
+                fig.add_scatter(
+                    y=metrics["vram_usage"], mode="lines", name="VRAM Usage"
+                )
             if metrics.get("arousal"):
                 fig.add_scatter(y=metrics["arousal"], mode="lines", name="Arousal")
             if metrics.get("stress"):
@@ -49,11 +55,21 @@ class MetricsDashboard:
             if metrics.get("reward"):
                 fig.add_scatter(y=metrics["reward"], mode="lines", name="Reward")
             if metrics.get("plasticity_threshold"):
-                fig.add_scatter(y=metrics["plasticity_threshold"], mode="lines", name="Plasticity")
+                fig.add_scatter(
+                    y=metrics["plasticity_threshold"], mode="lines", name="Plasticity"
+                )
             if metrics.get("message_passing_change"):
-                fig.add_scatter(y=metrics["message_passing_change"], mode="lines", name="MsgPass")
+                fig.add_scatter(
+                    y=metrics["message_passing_change"], mode="lines", name="MsgPass"
+                )
             if metrics.get("compression_ratio"):
-                fig.add_scatter(y=metrics["compression_ratio"], mode="lines", name="Compression")
+                fig.add_scatter(
+                    y=metrics["compression_ratio"], mode="lines", name="Compression"
+                )
+            if metrics.get("meta_loss_avg"):
+                fig.add_scatter(
+                    y=metrics["meta_loss_avg"], mode="lines", name="MetaLossAvg"
+                )
             fig.update_layout(xaxis_title="Updates", yaxis_title="Value")
             return fig
 

--- a/tests/test_meta_metrics.py
+++ b/tests/test_meta_metrics.py
@@ -1,0 +1,34 @@
+import os, sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from marble_core import Core, DataLoader
+from marble_neuronenblitz import Neuronenblitz
+from marble_brain import Brain
+from meta_parameter_controller import MetaParameterController
+from neuromodulatory_system import NeuromodulatorySystem
+from marble_base import MetricsVisualizer
+from tests.test_core_functions import minimal_params
+
+
+def test_meta_loss_metric_recorded():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    mpc = MetaParameterController(history_length=2)
+    mv = MetricsVisualizer()
+    ns = NeuromodulatorySystem()
+    brain = Brain(
+        core,
+        nb,
+        DataLoader(),
+        neuromodulatory_system=ns,
+        meta_controller=mpc,
+        metrics_visualizer=mv,
+    )
+
+    train_examples = [(0.1, 0.2)]
+    val_examples = [(0.1, 0.2)]
+    brain.train(train_examples, epochs=1, validation_examples=val_examples)
+
+    assert mv.metrics["meta_loss_avg"]


### PR DESCRIPTION
## Summary
- track meta controller average loss in MetricsVisualizer
- display new meta loss metric on dashboard
- expose the value during training
- test meta loss metric recording

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687baa0661748327b05ecdad6275639a