### PR TITLE
Add dynamic synapse types

### DIFF
--- a/marble.py
+++ b/marble.py
@@ -211,7 +211,12 @@ class Core:
         num_neurons = len(self.neurons)
         for i in range(num_neurons - 1):
             weight = random.uniform(0.5, 1.5)
-            syn = Synapse(self.neurons[i].id, self.neurons[i+1].id, weight)
+            syn = Synapse(
+                self.neurons[i].id,
+                self.neurons[i + 1].id,
+                weight,
+                synapse_type="standard",
+            )
             self.neurons[i].synapses.append(syn)
             self.synapses.append(syn)
         self.check_memory_usage()
@@ -251,7 +256,12 @@ class Core:
             src = random.choice(self.neurons).id
             tgt = random.choice(self.neurons).id
             if src != tgt:
-                syn = Synapse(src, tgt, weight=random.uniform(0.1, 1.0))
+                syn = Synapse(
+                    src,
+                    tgt,
+                    weight=random.uniform(0.1, 1.0),
+                    synapse_type="standard",
+                )
                 self.neurons[src].synapses.append(syn)
                 self.synapses.append(syn)
         print(f"Core expanded: {num_new_neurons} new neurons in {new_tier} and {num_new_synapses} new synapses added.")
@@ -439,11 +449,21 @@ class Neuronenblitz:
                 new_neuron = Neuron(new_id, value=target.value, tier=new_tier)
                 self.core.neurons.append(new_neuron)
                 new_weight1 = syn.weight * 1.5
-                new_syn1 = Synapse(source.id, new_id, weight=new_weight1)
+                new_syn1 = Synapse(
+                    source.id,
+                    new_id,
+                    weight=new_weight1,
+                    synapse_type="standard",
+                )
                 source.synapses.append(new_syn1)
                 self.core.synapses.append(new_syn1)
                 new_weight2 = syn.weight * 1.2
-                new_syn2 = Synapse(new_id, target.id, weight=new_weight2)
+                new_syn2 = Synapse(
+                    new_id,
+                    target.id,
+                    weight=new_weight2,
+                    synapse_type="standard",
+                )
                 new_neuron.synapses.append(new_syn2)
                 self.core.synapses.append(new_syn2)
                 source.synapses = [s for s in source.synapses if s != syn]
@@ -707,7 +727,12 @@ class MarbleConverter:
                 for j, out_id in enumerate(output_ids):
                     for i, in_id in enumerate(prev_neuron_ids):
                         weight_val = float(weight_matrix[j, i])
-                        syn = Synapse(in_id, out_id, weight=weight_val)
+                        syn = Synapse(
+                            in_id,
+                            out_id,
+                            weight=weight_val,
+                            synapse_type="standard",
+                        )
                         new_core.neurons[in_id].synapses.append(syn)
                         new_core.synapses.append(syn)
                 prev_neuron_ids = output_ids

--- a/marble_utils.py
+++ b/marble_utils.py
@@ -20,6 +20,7 @@ def core_to_json(core: Core) -> str:
                 "target": s.target,
                 "weight": s.weight,
                 "potential": s.potential,
+                "synapse_type": s.synapse_type,
             }
             for s in core.synapses
         ],
@@ -51,7 +52,12 @@ def core_from_json(json_str: str) -> Core:
             neuron.formula = n["formula"]
         core.neurons.append(neuron)
     for s in payload.get("synapses", []):
-        syn = Synapse(s["source"], s["target"], weight=s["weight"])
+        syn = Synapse(
+            s["source"],
+            s["target"],
+            weight=s["weight"],
+            synapse_type=s.get("synapse_type", "standard"),
+        )
         syn.potential = s.get("potential", 1.0)
         core.synapses.append(syn)
         core.neurons[syn.source].synapses.append(syn)

--- a/tests/test_synapse_types.py
+++ b/tests/test_synapse_types.py
@@ -1,0 +1,27 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from marble_core import Core, SYNAPSE_TYPES
+from marble_neuronenblitz import Neuronenblitz
+from tests.test_core_functions import minimal_params
+
+
+def test_add_synapse_with_type():
+    params = minimal_params()
+    core = Core(params)
+    syn = core.add_synapse(0, 1, weight=1.0, synapse_type="mirror")
+    assert syn.synapse_type == "mirror"
+    assert syn in core.synapses
+    assert syn in core.neurons[0].synapses
+
+
+def test_decide_synapse_action_creates_or_removes():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    nb.synapse_loss_attention["mirror"] = 1.0
+    nb.synapse_size_attention["standard"] = 1.0
+    initial_count = len(core.synapses)
+    nb.decide_synapse_action()
+    assert len(core.synapses) != initial_count


### PR DESCRIPTION
## Summary
- introduce `SYNAPSE_TYPES` and extend `Synapse` with a `synapse_type` attribute
- add `add_synapse` helper to Core and use it in expansion/structural plasticity
- track synapse type attentions in Neuronenblitz and autonomously add/remove synapses
- test adding and managing synapse types

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bb7c79b208327ae88e7f877c0a7cb