### PR TITLE
Implement functional synapse types

### DIFF
--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -172,7 +172,9 @@ class Neuronenblitz:
         ):
             for syn in current_neuron.synapses:
                 next_neuron = self.core.neurons[syn.target]
-                transmitted_value = self.combine_fn(current_neuron.value, syn.weight)
+                w = syn.effective_weight(self.last_context)
+                transmitted_value = self.combine_fn(current_neuron.value, w)
+                syn.apply_side_effects(self.core, current_neuron.value)
                 next_neuron.value = transmitted_value
                 new_path = path + [(next_neuron, syn)]
                 new_continue_prob = current_continue_prob * self.continue_decay_rate
@@ -192,7 +194,9 @@ class Neuronenblitz:
         else:
             syn = self.weighted_choice(current_neuron.synapses)
             next_neuron = self.core.neurons[syn.target]
-            transmitted_value = self.combine_fn(current_neuron.value, syn.weight)
+            w = syn.effective_weight(self.last_context)
+            transmitted_value = self.combine_fn(current_neuron.value, w)
+            syn.apply_side_effects(self.core, current_neuron.value)
             next_neuron.value = transmitted_value
             new_path = path + [(next_neuron, syn)]
             new_continue_prob = current_continue_prob * self.continue_decay_rate
@@ -248,7 +252,9 @@ class Neuronenblitz:
                 if entry_neuron.synapses:
                     syn = self.weighted_choice(entry_neuron.synapses)
                     next_neuron = self.core.neurons[syn.target]
-                    next_neuron.value = self.combine_fn(entry_neuron.value, syn.weight)
+                    w = syn.effective_weight(self.last_context)
+                    next_neuron.value = self.combine_fn(entry_neuron.value, w)
+                    syn.apply_side_effects(self.core, entry_neuron.value)
                     final_path = [(entry_neuron, None), (next_neuron, syn)]
                 else:
                     final_path = initial_path

--- a/tests/test_synapse_types.py
+++ b/tests/test_synapse_types.py
@@ -25,3 +25,26 @@ def test_decide_synapse_action_creates_or_removes():
     initial_count = len(core.synapses)
     nb.decide_synapse_action()
     assert len(core.synapses) != initial_count
+
+
+def test_excitatory_inhibitory_modulatory():
+    params = minimal_params()
+    core = Core(params)
+    exc = core.add_synapse(0, 1, weight=-0.5, synapse_type="excitatory")
+    inh = core.add_synapse(1, 2, weight=0.5, synapse_type="inhibitory")
+    mod = core.add_synapse(2, 3, weight=1.0, synapse_type="modulatory")
+    val1 = exc.transmit(2.0, core=core, context={})
+    assert val1 > 0
+    val2 = inh.transmit(val1, core=core, context={})
+    assert val2 < 0
+    val3 = mod.transmit(1.0, core=core, context={"reward": 1.0})
+    assert val3 > 1.0
+
+
+def test_mirror_side_effect():
+    params = minimal_params()
+    core = Core(params)
+    syn = core.add_synapse(0, 1, weight=1.0, synapse_type="mirror")
+    core.neurons[0].value = 0.0
+    syn.transmit(2.0, core=core, context={})
+    assert core.neurons[0].value == 2.0


### PR DESCRIPTION
## Summary
- differentiate synapse types with `effective_weight`, `apply_side_effects` and `transmit`
- integrate new synapse behaviour into dynamic wandering and message passing
- test new behaviours for excitatory, inhibitory, modulatory and mirror synapses

## Testing
- `pytest tests/test_synapse_types.py::test_add_synapse_with_type tests/test_synapse_types.py::test_decide_synapse_action_creates_or_removes tests/test_synapse_types.py::test_excitatory_inhibitory_modulatory tests/test_synapse_types.py::test_mirror_side_effect -q`

------
https://chatgpt.com/codex/tasks/task_e_687bba1ad82c8327994d03ba9bd9a87f