### PR TITLE
Enhance Neuronenblitz mechanism

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -85,6 +85,10 @@ Each entry is listed under its section heading.
 - max_learning_rate
 - top_k_paths
 - parallel_wanderers
+- synaptic_fatigue_enabled
+- fatigue_increase
+- fatigue_decay
+- lr_adjustment_factor
 
 ## brain
 - save_threshold

--- a/config.yaml
+++ b/config.yaml
@@ -79,6 +79,10 @@ neuronenblitz:
   max_learning_rate: 0.1
   top_k_paths: 5
   parallel_wanderers: 1
+  synaptic_fatigue_enabled: true
+  fatigue_increase: 0.05
+  fatigue_decay: 0.95
+  lr_adjustment_factor: 0.1
 brain:
   save_threshold: 0.05
   max_saved_models: 5

--- a/marble_core.py
+++ b/marble_core.py
@@ -200,7 +200,7 @@ class Neuron:
         self.representation = np.zeros(rep_size, dtype=float)
 
 class Synapse:
-    def __init__(self, source, target, weight=1.0, synapse_type="standard"):
+    def __init__(self, source, target, weight=1.0, synapse_type="standard", fatigue=0.0):
         self.source = source
         self.target = target
         self.weight = weight
@@ -209,6 +209,11 @@ class Synapse:
             synapse_type if synapse_type in SYNAPSE_TYPES else "standard"
         )
         self.created_at = datetime.now()
+        self.fatigue = float(fatigue)
+
+    def update_fatigue(self, increase: float, decay: float) -> None:
+        """Update fatigue using a decay factor and additive increase."""
+        self.fatigue = max(0.0, min(1.0, self.fatigue * decay + increase))
 
     def effective_weight(self, context=None):
         """Return the weight modified according to ``synapse_type`` and context."""
@@ -222,6 +227,7 @@ class Synapse:
         elif self.synapse_type == "modulatory":
             mod = 1.0 + context.get("reward", 0.0) - context.get("stress", 0.0)
             w *= mod
+        w *= max(0.0, 1.0 - self.fatigue)
         return w
 
     def apply_side_effects(self, core, source_value):

--- a/tests/test_neuronenblitz_enhancements.py
+++ b/tests/test_neuronenblitz_enhancements.py
@@ -1,0 +1,59 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import random
+import numpy as np
+from marble_core import Core, Neuron
+from marble_neuronenblitz import Neuronenblitz
+from tests.test_core_functions import minimal_params
+
+
+def create_simple_core():
+    params = minimal_params()
+    core = Core(params)
+    core.neurons = [Neuron(0, value=0.0), Neuron(1, value=0.0)]
+    core.synapses = []
+    syn = core.add_synapse(0, 1, weight=1.0)
+    return core, syn
+
+
+def test_synaptic_fatigue_accumulates():
+    random.seed(0)
+    np.random.seed(0)
+    core, syn = create_simple_core()
+    nb = Neuronenblitz(
+        core,
+        synaptic_fatigue_enabled=True,
+        fatigue_increase=0.5,
+        fatigue_decay=0.9,
+        split_probability=0.0,
+        alternative_connection_prob=0.0,
+        plasticity_threshold=100.0,
+    )
+    nb.dynamic_wander(1.0)
+    first = syn.fatigue
+    nb.dynamic_wander(1.0)
+    second = syn.fatigue
+    assert first > 0
+    assert second > first
+
+
+def test_learning_rate_adjustment_bounds():
+    random.seed(0)
+    core, _ = create_simple_core()
+    nb = Neuronenblitz(
+        core,
+        lr_adjustment_factor=0.5,
+        min_learning_rate=0.01,
+        max_learning_rate=1.0,
+    )
+    nb.learning_rate = 0.1
+    nb.error_history.extend([0.2] * 5 + [0.3] * 5)
+    nb.adjust_learning_rate()
+    assert nb.learning_rate > 0.1
+    prev = nb.learning_rate
+    nb.error_history.extend([0.1] * 5)
+    nb.adjust_learning_rate()
+    assert nb.learning_rate < prev
+    assert nb.min_learning_rate <= nb.learning_rate <= nb.max_learning_rate
+

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -172,6 +172,19 @@ neuronenblitz:
     achieves the greatest loss reduction, path speed improvement and model size
     decrease is replayed in the main process to apply its weight updates and
     structural plasticity.
+  synaptic_fatigue_enabled: When true each synapse maintains a temporary
+    fatigue value that reduces its effective weight after repeated use. This
+    models biological short-term depression and can help prevent domination by
+    a few highly active connections.
+  fatigue_increase: Amount added to a synapse's fatigue every time it is
+    traversed. Larger values cause quicker weakening. ``0.0`` disables new
+    fatigue accumulation.
+  fatigue_decay: Multiplicative factor applied to all fatigue values at the
+    start of each ``dynamic_wander`` call. Values near ``1.0`` make fatigue
+    persist for many steps while lower values allow faster recovery.
+  lr_adjustment_factor: Fractional step used by ``adjust_learning_rate`` when
+    increasing or decreasing ``learning_rate`` in response to recent error
+    trends.
 
 brain:
   save_threshold: Minimum improvement in validation loss required before the


### PR DESCRIPTION
## Summary
- introduce synaptic fatigue modeling in `Synapse`
- add adaptive learning-rate scheduling and fatigue decay in `Neuronenblitz`
- expose new parameters in config and documentation
- document configuration options in manual and parameter listing
- test new fatigue and learning-rate features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc7a0eba083278b3ee546f0d4cdb1