### PR TITLE
Enhance neurons with layer-like behaviors

### DIFF
--- a/marble.py
+++ b/marble.py
@@ -388,7 +388,7 @@ class Neuronenblitz:
             for syn in current_neuron.synapses:
                 next_neuron = self.core.neurons[syn.target]
                 transmitted_value = self.combine_fn(current_neuron.value, syn.weight)
-                next_neuron.value = transmitted_value
+                next_neuron.value = next_neuron.process(transmitted_value)
                 new_path = path + [(next_neuron, syn)]
                 new_continue_prob = current_continue_prob * 0.85
                 results.extend(self._wander(next_neuron, new_path, new_continue_prob))
@@ -396,7 +396,7 @@ class Neuronenblitz:
             syn = self.weighted_choice(current_neuron.synapses)
             next_neuron = self.core.neurons[syn.target]
             transmitted_value = self.combine_fn(current_neuron.value, syn.weight)
-            next_neuron.value = transmitted_value
+            next_neuron.value = next_neuron.process(transmitted_value)
             new_path = path + [(next_neuron, syn)]
             new_continue_prob = current_continue_prob * 0.85
             results.extend(self._wander(next_neuron, new_path, new_continue_prob))

--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -234,7 +234,7 @@ class Neuronenblitz:
                 syn.apply_side_effects(self.core, current_neuron.value)
                 if self.synaptic_fatigue_enabled:
                     syn.update_fatigue(self.fatigue_increase, self.fatigue_decay)
-                next_neuron.value = transmitted_value
+                next_neuron.value = next_neuron.process(transmitted_value)
                 new_path = path + [(next_neuron, syn)]
                 new_continue_prob = current_continue_prob * self.continue_decay_rate
                 if next_neuron.tier == "remote" and self.remote_client is not None:
@@ -258,7 +258,7 @@ class Neuronenblitz:
             syn.apply_side_effects(self.core, current_neuron.value)
             if self.synaptic_fatigue_enabled:
                 syn.update_fatigue(self.fatigue_increase, self.fatigue_decay)
-            next_neuron.value = transmitted_value
+            next_neuron.value = next_neuron.process(transmitted_value)
             new_path = path + [(next_neuron, syn)]
             new_continue_prob = current_continue_prob * self.continue_decay_rate
             if next_neuron.tier == "remote" and self.remote_client is not None:
@@ -315,7 +315,8 @@ class Neuronenblitz:
                     syn = self.weighted_choice(entry_neuron.synapses)
                     next_neuron = self.core.neurons[syn.target]
                     w = syn.effective_weight(self.last_context)
-                    next_neuron.value = self.combine_fn(entry_neuron.value, w)
+                    raw_val = self.combine_fn(entry_neuron.value, w)
+                    next_neuron.value = next_neuron.process(raw_val)
                     syn.apply_side_effects(self.core, entry_neuron.value)
                     if self.synaptic_fatigue_enabled:
                         syn.update_fatigue(self.fatigue_increase, self.fatigue_decay)

--- a/tests/test_new_neuron_layers.py
+++ b/tests/test_new_neuron_layers.py
@@ -1,0 +1,43 @@
+import random
+import numpy as np
+
+from marble_core import Neuron, NEURON_TYPES
+
+
+def test_neuron_types_list_contains_new_types():
+    assert "linear" in NEURON_TYPES
+    assert "conv1d" in NEURON_TYPES
+    assert "batchnorm" in NEURON_TYPES
+    assert "dropout" in NEURON_TYPES
+
+
+def test_linear_neuron_operation():
+    n = Neuron(0, neuron_type="linear")
+    n.params["weight"] = 2.0
+    n.params["bias"] = 1.0
+    out = n.process(3.0)
+    assert out == 7.0
+
+
+def test_conv1d_neuron_operation():
+    n = Neuron(0, neuron_type="conv1d")
+    n.params["kernel"] = np.array([1.0, 1.0, 1.0])
+    for val in [1.0, 2.0, 3.0]:
+        res = n.process(val)
+    assert res == 6.0
+
+
+def test_batchnorm_neuron_operation():
+    n = Neuron(0, neuron_type="batchnorm")
+    n.params["momentum"] = 1.0
+    out1 = n.process(1.0)
+    out2 = n.process(2.0)
+    assert np.isfinite(out1)
+    assert np.isfinite(out2)
+
+
+def test_dropout_neuron_operation():
+    random.seed(0)
+    n = Neuron(0, neuron_type="dropout")
+    n.params["p"] = 1.0
+    assert n.process(5.0) == 0.0


### PR DESCRIPTION
## Summary
- expand `NEURON_TYPES` with new layer-mimicking types
- give `Neuron` initialization of layer parameters and processing logic
- apply neuron processing during wandering steps
- copy layer parameters when extracting subcores
- add tests validating linear, conv1d, batchnorm and dropout neuron behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bcb43f7b48327aaa9d3e2b85ae2ca