### PR TITLE
Improve Marble core autotuning

### DIFF
--- a/tests/test_memory_management.py
+++ b/tests/test_memory_management.py
@@ -16,5 +16,19 @@ def test_choose_new_tier_uses_disk_when_ram_full():
     params = minimal_params()
     params['vram_limit_mb'] = 0
     params['ram_limit_mb'] = 0.0001
+    params['tier_autotune_enabled'] = False
     core = Core(params)
     assert core.choose_new_tier() == 'disk'
+
+
+def test_autotune_tiers_migrates_neurons():
+    params = minimal_params()
+    params['vram_limit_mb'] = 0.0001
+    params['ram_limit_mb'] = 0.0002
+    params['tier_autotune_enabled'] = True
+    core = Core(params)
+    vram_neurons = sum(n.tier == 'vram' for n in core.neurons)
+    has_ram = any(n.tier == 'ram' for n in core.neurons)
+    has_disk = any(n.tier == 'disk' for n in core.neurons)
+    assert vram_neurons == 0
+    assert has_ram or has_disk

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -32,8 +32,11 @@ core:
     seed. Increasing this explores a wider region of the complex plane.
   mandelbrot_power: Power applied during Mandelbrot iterations. ``2`` produces
     the classic set while higher integers create different fractal patterns.
-  tier_autotune_enabled: When true the core monitors tier usage and adjusts
-    limits based on ``vram_limit_mb`` and ``ram_limit_mb``.
+  tier_autotune_enabled: When enabled the core automatically migrates neurons
+    between VRAM, RAM and disk to keep usage below the configured
+    ``*_limit_mb`` values. Neurons are moved in order of age with the oldest
+    leaving the faster tiers first. This prevents out-of-memory errors while
+    keeping recently created neurons in the quickest storage available.
   memory_cleanup_interval: Seconds between automated clean-up passes that remove
     expired objects from lower tiers.
   representation_noise_std: Standard deviation of Gaussian noise added to


### PR DESCRIPTION
## Summary
- add `autotune_tiers` in `marble_core` to automatically migrate neurons when tier limits are exceeded
- call `autotune_tiers` after initialization and expansion
- expand YAML manual description of `tier_autotune_enabled`
- test memory autotuning logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bec2c4b7083278050f97bf983f5a0