### PR TITLE
Improve message passing in MARBLE core

### DIFF
--- a/tests/test_message_passing.py
+++ b/tests/test_message_passing.py
@@ -112,3 +112,29 @@ def test_message_passing_beta_effect():
     perform_message_passing(core)
     after = [n.representation.copy() for n in core.neurons]
     assert all(np.allclose(b, a) for b, a in zip(before, after))
+
+
+def test_run_message_passing_iterations():
+    np.random.seed(0)
+    params = minimal_params()
+    params["message_passing_iterations"] = 2
+    core_single = Core(params)
+    core_multi = Core(params)
+    for n1, n2 in zip(core_single.neurons, core_multi.neurons):
+        rep = np.random.rand(4)
+        n1.representation = rep.copy()
+        n2.representation = rep.copy()
+
+    base = [n.representation.copy() for n in core_single.neurons]
+    single_change = perform_message_passing(core_single)
+    multi_change = core_multi.run_message_passing()
+    single_diff = sum(
+        float(np.linalg.norm(n.representation - base[i]))
+        for i, n in enumerate(core_single.neurons)
+    )
+    multi_diff = sum(
+        float(np.linalg.norm(n.representation - base[i]))
+        for i, n in enumerate(core_multi.neurons)
+    )
+    assert multi_diff > single_diff
+    assert not np.isclose(multi_change, single_change)

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -44,7 +44,9 @@ core:
   gradient_clip_value: Absolute value used to clip weight updates during
     training. ``0`` disables clipping.
   message_passing_iterations: Number of times the message passing routine runs
-    per training step. Increasing this deepens information flow but costs time.
+    per training step. ``Core.run_message_passing`` automatically performs this
+    many iterations when called without an explicit count. Increasing the value
+    deepens information flow but costs time.
   cluster_algorithm: Name of the clustering method used by ``cluster_neurons``;
     ``"kmeans"`` is the current default.
   vram_limit_mb: Maximum megabytes of GPU memory dedicated to VRAM tiers. If


### PR DESCRIPTION
## Summary
- add `Core.run_message_passing` for iterative execution
- document the new behaviour in `yaml-manual.txt`
- test the iteration feature in `test_message_passing`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bee041d9083278c928594a1a23416