### PR TITLE
Use max_wander_depth in Neuronenblitz

### DIFF
--- a/tests/test_neuronenblitz_enhancements.py
+++ b/tests/test_neuronenblitz_enhancements.py
@@ -57,3 +57,23 @@ def test_learning_rate_adjustment_bounds():
     assert nb.learning_rate < prev
     assert nb.min_learning_rate <= nb.learning_rate <= nb.max_learning_rate
 
+
+def test_max_wander_depth_limit():
+    random.seed(0)
+    np.random.seed(0)
+    core, _ = create_simple_core()
+    # Add a self-loop to allow indefinite wandering without the depth limit
+    core.add_synapse(1, 1, weight=1.0)
+    nb = Neuronenblitz(
+        core,
+        max_wander_depth=3,
+        wander_depth_noise=0.0,
+        continue_decay_rate=1.0,
+        split_probability=0.0,
+        alternative_connection_prob=0.0,
+        backtrack_probability=0.0,
+        backtrack_enabled=False,
+    )
+    _, path = nb.dynamic_wander(1.0)
+    assert len(path) <= 3
+

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -120,7 +120,8 @@ neuronenblitz:
     reduced after each query. Values under ``1.0`` gradually forget old
     preferences.
   max_wander_depth: Maximum recursion depth allowed in ``dynamic_wander``.
-    Limits exploration of extremely long paths.
+    Limits exploration of extremely long paths. The actual limit for each
+    call is drawn from this value plus ``wander_depth_noise``.
   learning_rate: Scalar applied to weight updates produced by ``weight_update_fn``.
   weight_decay: Proportional decrease applied to all synapse weights each epoch
     to prevent uncontrolled growth. ``0.0`` disables this effect.
@@ -155,8 +156,9 @@ neuronenblitz:
     attention statistics.
   plasticity_modulation: Global multiplier applied to weight updates after
     neuromodulation. Values above ``1.0`` accelerate structural changes.
-  wander_depth_noise: Standard deviation of random noise added to wander depth
-    calculations, introducing variability into exploration.
+  wander_depth_noise: Standard deviation of Gaussian noise used when
+    computing the per-call depth limit. Positive values occasionally
+    permit longer explorations while negative samples shorten them.
   reward_decay: Factor by which accumulated reward signals diminish each epoch.
   synapse_prune_interval: Number of epochs between automatic pruning passes
     removing low-potential synapses.


### PR DESCRIPTION
## Summary
- stop wandering when depth exceeds a noisy limit
- describe how depth noise interacts with the limit
- test depth limiting behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf02cade083279e683d7c365abf5d