### PR TITLE
Support PyTorch-style datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 The MARBLE system is a modular neural architecture that begins with a Mandelbrot-inspired seed and adapts through neuromodulatory feedback and structural plasticity. This repository contains the source code for the system along with utilities and configuration files.
 
+MARBLE can train on datasets provided as lists of ``(input, target)`` pairs or using PyTorch-style ``Dataset``/``DataLoader`` objects. Each sample must expose an ``input`` and ``target`` field. After training and saving a model, ``Brain.infer`` generates outputs when given only an input value.
+
 ## Possible MARBLE Backcronyms
 
 Below is a list of ideas explored when naming the project:


### PR DESCRIPTION
## Summary
- add helper functions `_parse_example` and `_normalize_examples`
- allow `Brain.train` and `Brain.validate` to accept PyTorch `Dataset`/`DataLoader`
- provide simple `Brain.infer` method
- document dataset usage in README
- test training with `DataLoader` and inference on saved model

## Testing
- `pytest tests/test_brain_io.py::test_train_with_pytorch_dataloader_and_infer -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c01fbf1ac8327a9e9d29c35fb50a9