### PR TITLE
Enable custom PyTorch loss modules

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -71,6 +71,7 @@ Each entry is listed under its section heading.
 - structural_plasticity_enabled
 - backtrack_enabled
 - loss_scale
+- loss_module
 - exploration_bonus
 - synapse_potential_cap
 - attention_update_scale

--- a/config.yaml
+++ b/config.yaml
@@ -65,6 +65,7 @@ neuronenblitz:
   structural_plasticity_enabled: true
   backtrack_enabled: true
   loss_scale: 1.0
+  loss_module: null
   exploration_bonus: 0.0
   synapse_potential_cap: 100.0
   attention_update_scale: 1.0

--- a/marble_main.py
+++ b/marble_main.py
@@ -84,6 +84,7 @@ class MARBLE:
             "merge_tolerance": 0.01,
             "combine_fn": None,
             "loss_fn": None,
+            "loss_module": None,
             "weight_update_fn": None,
             "plasticity_threshold": 10.0,
             "max_wander_depth": 100,

--- a/tests/test_loss_module.py
+++ b/tests/test_loss_module.py
@@ -1,0 +1,19 @@
+import random
+import torch
+import torch.nn as nn
+
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from tests.test_core_functions import minimal_params
+
+
+def test_neuronenblitz_accepts_loss_module():
+    random.seed(0)
+    params = minimal_params()
+    core = Core(params)
+    loss_mod = nn.MSELoss()
+    nb = Neuronenblitz(core, loss_module=loss_mod)
+    out, err, _ = nb.train_example(0.5, 0.2)
+    expected = loss_mod(torch.tensor([out], dtype=torch.float32),
+                        torch.tensor([0.2], dtype=torch.float32)).item()
+    assert abs(err - expected) < 1e-6

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -148,6 +148,9 @@ neuronenblitz:
   backtrack_enabled: If false, wandering never returns to previously visited
     neurons regardless of ``backtrack_probability``.
   loss_scale: Multiplier for training errors before they are applied to weights.
+  loss_module: PyTorch loss module object to compute training errors. If set to
+    an instance such as ``torch.nn.MSELoss()``, all weight updates use this
+    module's output as the error value.
   exploration_bonus: Additional reward added to rarely used synapses when they
     are traversed, encouraging exploration.
   synapse_potential_cap: Upper bound for ``synapse.potential`` to prevent


### PR DESCRIPTION
## Summary
- allow Neuronenblitz to use a PyTorch loss module
- expose `loss_module` through MARBLE and defaults
- document `loss_module` in YAML config and manuals
- test that a PyTorch loss module can drive training

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c049410488327a36cbb34619129f3