### PR TITLE
Add marble system interface utilities

### DIFF
--- a/marble_brain.py
+++ b/marble_brain.py
@@ -773,6 +773,24 @@ class Brain:
         pbar.close()
 
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["training_thread"] = None
+        state["auto_fire_thread"] = None
+        state["dream_thread"] = None
+        state["metrics_visualizer"] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.training_thread = None
+        self.auto_fire_thread = None
+        self.dream_thread = None
+        if self.metrics_visualizer is None:
+            from marble_base import MetricsVisualizer
+
+            self.metrics_visualizer = MetricsVisualizer()
+
 class BenchmarkManager:
     def __init__(self, marble_system, target_metrics=None):
         self.marble = marble_system

--- a/marble_interface.py
+++ b/marble_interface.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pickle
+from typing import Any, Iterable
+
+from config_loader import create_marble_from_config, load_config
+from marble_main import MARBLE
+from marble_autograd import MarbleAutogradLayer
+
+
+def new_marble_system(config_path: str | None = None) -> MARBLE:
+    """Instantiate a :class:`MARBLE` system from an optional YAML config."""
+    return create_marble_from_config(config_path)
+
+
+def configure_marble_system(marble: MARBLE, config: str | dict) -> None:
+    """Update an existing MARBLE system using a config path or dict."""
+    cfg = load_config(config) if isinstance(config, str) else config
+    core_params = cfg.get("core", {})
+    nb_params = cfg.get("neuronenblitz", {})
+    brain_params = cfg.get("brain", {})
+
+    marble.core.params.update(core_params)
+    for k, v in core_params.items():
+        if hasattr(marble.core, k):
+            setattr(marble.core, k, v)
+
+    for k, v in nb_params.items():
+        if hasattr(marble.neuronenblitz, k):
+            setattr(marble.neuronenblitz, k, v)
+
+    for k, v in brain_params.items():
+        if hasattr(marble.brain, k):
+            setattr(marble.brain, k, v)
+
+
+def save_marble_system(marble: MARBLE, path: str) -> None:
+    """Persist ``marble`` to ``path`` using pickle."""
+    with open(path, "wb") as f:
+        pickle.dump(marble, f)
+
+
+def load_marble_system(path: str) -> MARBLE:
+    """Load a MARBLE system previously saved with :func:`save_marble_system`."""
+    with open(path, "rb") as f:
+        return pickle.load(f)
+
+
+def infer_marble_system(marble: MARBLE, input_value: float) -> float:
+    """Return model output for ``input_value`` using ``marble``."""
+    return marble.get_brain().infer(input_value)
+
+
+def train_marble_system(
+    marble: MARBLE,
+    train_examples: Iterable[Any],
+    epochs: int = 1,
+    validation_examples: Iterable[Any] | None = None,
+) -> None:
+    """Train ``marble`` on ``train_examples`` for ``epochs``."""
+    marble.get_brain().train(train_examples, epochs=epochs, validation_examples=validation_examples)
+
+
+def set_dreaming(marble: MARBLE, enabled: bool) -> None:
+    """Enable or disable dreaming for ``marble``."""
+    if enabled:
+        marble.get_brain().start_dreaming()
+    else:
+        marble.get_brain().stop_dreaming()
+
+
+def set_autograd(marble: MARBLE, enabled: bool, learning_rate: float = 0.01) -> None:
+    """Toggle the autograd layer on ``marble``."""
+    if enabled and marble.get_autograd_layer() is None:
+        layer = MarbleAutogradLayer(marble.get_brain(), learning_rate=learning_rate)
+        marble.get_brain().set_autograd_layer(layer)
+        marble.autograd_layer = layer
+    elif not enabled and marble.get_autograd_layer() is not None:
+        marble.get_brain().set_autograd_layer(None)
+        marble.autograd_layer = None

--- a/marble_main.py
+++ b/marble_main.py
@@ -216,6 +216,21 @@ class MARBLE:
     def get_pytorch_challenge_params(self):
         return self.pytorch_challenge_params
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["metrics_dashboard"] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        if self.metrics_dashboard is not None:
+            try:
+                self.metrics_dashboard.stop()
+            except Exception:
+                pass
+        if self.metrics_visualizer is None:
+            self.metrics_visualizer = MetricsVisualizer()
+
 
 if __name__ == "__main__":
     # Core parameters

--- a/tests/test_marble_interface.py
+++ b/tests/test_marble_interface.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import yaml
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import marble_imports
+import marble_brain
+import marble_main
+from marble_base import MetricsVisualizer
+from tqdm import tqdm as std_tqdm
+from tests.test_core_functions import minimal_params
+
+from marble_interface import (
+    new_marble_system,
+    configure_marble_system,
+    save_marble_system,
+    load_marble_system,
+    infer_marble_system,
+    train_marble_system,
+    set_dreaming,
+    set_autograd,
+)
+
+
+def test_save_and_load_marble(tmp_path):
+    marble_imports.tqdm = std_tqdm
+    marble_brain.tqdm = std_tqdm
+    marble_main.MetricsVisualizer = MetricsVisualizer
+
+    cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.dump(cfg, f)
+
+    m = new_marble_system(str(cfg_path))
+    train_marble_system(m, [(0.1, 0.2), (0.2, 0.4)], epochs=1)
+    acts = m.get_neuronenblitz().global_activation_count
+    save_path = tmp_path / "marble.pkl"
+    save_marble_system(m, str(save_path))
+
+    loaded = load_marble_system(str(save_path))
+    assert len(loaded.get_core().neurons) == len(m.get_core().neurons)
+    assert loaded.get_neuronenblitz().global_activation_count == acts
+    out = infer_marble_system(loaded, 0.1)
+    assert isinstance(out, float)
+
+
+def test_toggle_features(tmp_path):
+    marble_imports.tqdm = std_tqdm
+    marble_brain.tqdm = std_tqdm
+    marble_main.MetricsVisualizer = MetricsVisualizer
+
+    cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.dump(cfg, f)
+
+    m = new_marble_system(str(cfg_path))
+    set_dreaming(m, True)
+    assert m.get_brain().dreaming_active
+    set_dreaming(m, False)
+    assert not m.get_brain().dreaming_active
+    set_autograd(m, True)
+    assert m.get_autograd_layer() is not None
+    set_autograd(m, False)
+    assert m.get_autograd_layer() is None


### PR DESCRIPTION
## Summary
- add pickling support to `Brain` and `MARBLE`
- introduce `marble_interface` with high level control functions
- test saving/loading and feature toggles in `marble_interface`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c088202188327a5be1743502b7573