### PR TITLE
Enhance dataloader configurability

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -188,6 +188,9 @@ Each entry is listed under its section heading.
 - compression_level
 - compression_enabled
 
+## dataloader
+- tensor_dtype
+
 ## formula
 - formula
 - formula_num_neurons

--- a/config.yaml
+++ b/config.yaml
@@ -185,6 +185,8 @@ torrent_client:
 data_compressor:
   compression_level: 6
   compression_enabled: true
+dataloader:
+  tensor_dtype: "uint8"
 remote_server:
   enabled: false
   host: "localhost"

--- a/config_loader.py
+++ b/config_loader.py
@@ -64,9 +64,12 @@ def create_marble_from_config(path: str | None = None) -> MARBLE:
     compressor_cfg = cfg.get("data_compressor", {})
     compression_level = compressor_cfg.get("compression_level", 6)
     compression_enabled = compressor_cfg.get("compression_enabled", True)
+    dataloader_cfg = cfg.get("dataloader", {})
+    tensor_dtype = dataloader_cfg.get("tensor_dtype", "uint8")
     dataloader_params = {
         "compression_level": compression_level,
         "compression_enabled": compression_enabled,
+        "tensor_dtype": tensor_dtype,
     }
 
     autograd_params = cfg.get("autograd", {})

--- a/marble_core.py
+++ b/marble_core.py
@@ -935,6 +935,7 @@ class DataLoader:
         compression_level: int = 6,
         compression_enabled: bool = True,
         metrics_visualizer: "MetricsVisualizer | None" = None,
+        tensor_dtype: str = "uint8",
     ) -> None:
         self.compressor = (
             compressor
@@ -944,6 +945,7 @@ class DataLoader:
             )
         )
         self.metrics_visualizer = metrics_visualizer
+        self.tensor_dtype = cp.dtype(tensor_dtype)
 
     def encode(self, data):
         serialized = pickle.dumps(data)
@@ -951,8 +953,14 @@ class DataLoader:
         if self.metrics_visualizer is not None:
             ratio = len(compressed) / max(len(serialized), 1)
             self.metrics_visualizer.update({"compression_ratio": ratio})
-        tensor = np.frombuffer(compressed, dtype=np.uint8)
-        return tensor
+        array_module = cp if CUDA_AVAILABLE else np
+        base = array_module.frombuffer(compressed, dtype=array_module.uint8)
+        if (
+            self.tensor_dtype != array_module.uint8
+            and len(base) % self.tensor_dtype.itemsize == 0
+        ):
+            base = base.view(self.tensor_dtype)
+        return base
 
     def decode(self, tensor):
         compressed = tensor.tobytes()
@@ -971,12 +979,23 @@ class DataLoader:
         if self.metrics_visualizer is not None:
             ratio = len(compressed) / max(array.nbytes, 1)
             self.metrics_visualizer.update({"compression_ratio": ratio})
-        return np.frombuffer(compressed, dtype=np.uint8)
+        array_module = cp if CUDA_AVAILABLE else np
+        base = array_module.frombuffer(compressed, dtype=array_module.uint8)
+        if (
+            self.tensor_dtype != array_module.uint8
+            and len(base) % self.tensor_dtype.itemsize == 0
+        ):
+            base = base.view(self.tensor_dtype)
+        return base
 
     def decode_array(self, tensor: np.ndarray) -> np.ndarray:
         """Decode a tensor created by ``encode_array`` back to a NumPy array."""
         if isinstance(tensor, torch.Tensor):
             tensor = tensor.detach().cpu().numpy()
+        elif isinstance(tensor, cp.ndarray):
+            tensor = cp.asnumpy(tensor)
+        if tensor.dtype != np.uint8:
+            tensor = tensor.view(np.uint8)
         compressed = tensor.tobytes()
         array = self.compressor.decompress_array(compressed)
         if self.metrics_visualizer is not None:
@@ -987,14 +1006,18 @@ class DataLoader:
     def encode_tensor(self, tensor: "torch.Tensor") -> "torch.Tensor":
         """Encode a PyTorch tensor using compression."""
         np_array = tensor.detach().cpu().numpy()
-        encoded_np = self.encode_array(np_array)
-        return torch.from_numpy(encoded_np.copy())
+        encoded = self.encode_array(np_array)
+        if isinstance(encoded, cp.ndarray):
+            encoded = cp.asnumpy(encoded)
+        return torch.from_numpy(encoded.copy())
 
     def decode_tensor(self, tensor: "torch.Tensor") -> "torch.Tensor":
         """Decode a tensor created by ``encode_tensor`` back to a PyTorch tensor."""
         np_tensor = tensor.detach().cpu().numpy()
-        decoded_np = self.decode_array(np_tensor)
-        return torch.from_numpy(decoded_np.copy())
+        decoded = self.decode_array(np_tensor)
+        if isinstance(decoded, cp.ndarray):
+            decoded = cp.asnumpy(decoded)
+        return torch.from_numpy(decoded.copy())
 
 
 class Core:

--- a/marble_main.py
+++ b/marble_main.py
@@ -63,13 +63,16 @@ class MARBLE:
 
         dl_level = 6
         dl_enabled = True
+        dl_dtype = "uint8"
         if dataloader_params is not None:
             dl_level = dataloader_params.get("compression_level", dl_level)
             dl_enabled = dataloader_params.get("compression_enabled", True)
+            dl_dtype = dataloader_params.get("tensor_dtype", dl_dtype)
         self.dataloader = DataLoader(
             compression_level=dl_level,
             compression_enabled=dl_enabled,
             metrics_visualizer=self.metrics_visualizer,
+            tensor_dtype=dl_dtype,
         )
 
         nb_defaults = {

--- a/tests/test_marble_dataloader.py
+++ b/tests/test_marble_dataloader.py
@@ -43,3 +43,21 @@ def test_encode_array_accepts_tensor():
     encoded = dl.encode_array(t)
     decoded = dl.decode_array(encoded)
     assert np.allclose(decoded, t.numpy())
+
+
+def test_marble_dataloader_custom_dtype():
+    dl = DataLoader(tensor_dtype="int16")
+    data = {"x": 123}
+    tensor = dl.encode(data)
+    assert str(tensor.dtype) == "int16"
+    restored = dl.decode(tensor)
+    assert restored == data
+
+
+def test_marble_dataloader_array_custom_dtype():
+    dl = DataLoader(tensor_dtype="int16")
+    arr = np.arange(4, dtype=np.float32)
+    tensor = dl.encode_array(arr)
+    assert str(tensor.dtype) == "int16"
+    decoded = dl.decode_array(tensor)
+    assert np.allclose(decoded, arr)

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -410,6 +410,14 @@ data_compressor:
   compression_enabled: Set to ``false`` to bypass compression entirely. Useful
     during debugging or when working with already compressed data.
 
+dataloader:
+  # Settings for the ``DataLoader`` which serializes and compresses data.
+  # ``tensor_dtype`` defines the NumPy dtype used when encoding objects and
+  # arrays. This affects the precision of the returned tensors and must be a
+  # valid dtype name like ``"uint8"`` or ``"int16"``. Wider dtypes can prevent
+  # overflow with exceptionally large payloads but increase memory usage.
+  tensor_dtype: String specifying the dtype of encoded tensors.
+
 remote_server:
   # Launches an optional local ``RemoteBrainServer`` so this MARBLE instance can
   # forward computation to another machine. When ``enabled`` is ``true`` the


### PR DESCRIPTION
## Summary
- allow choosing tensor dtype for `DataLoader` outputs
- plumb new `tensor_dtype` setting through config loader and `MARBLE`
- document new setting in config docs and yaml manual
- test custom dtype behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c0b1c43148327ad3ce7c072154320