### PR TITLE
Add multimodal pair tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ The MARBLE system is a modular neural architecture that begins with a Mandelbrot
 
 MARBLE can train on datasets provided as lists of ``(input, target)`` pairs or using PyTorch-style ``Dataset``/``DataLoader`` objects. Each sample must expose an ``input`` and ``target`` field. After training and saving a model, ``Brain.infer`` generates outputs when given only an input value.
 
+Any Python object can serve as an ``input`` or ``target`` because the built-in
+``DataLoader`` serializes data through ``DataCompressor``. This makes it
+possible to train on multimodal pairs such as text-to-image, image-to-text or
+even audio and arbitrary byte blobs without additional conversion steps.
+
 ## Possible MARBLE Backcronyms
 
 Below is a list of ideas explored when naming the project:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
+Flask==3.1.1
+Jinja2==3.1.4
+MarkupSafe==2.1.5
+PyYAML==6.0.2
+Pygments==2.19.2
+Werkzeug==3.1.3
 aiohappyeyeballs==2.6.1
 aiohttp==3.12.14
 aiosignal==1.4.0
@@ -18,7 +24,6 @@ diffusers==0.34.0
 dill==0.3.8
 executing==2.2.0
 filelock==3.13.1
-Flask==3.1.1
 fonttools==4.59.0
 frozenlist==1.7.0
 fsspec==2024.6.1
@@ -33,13 +38,11 @@ ipywidgets==8.1.7
 isort==6.0.1
 itsdangerous==2.2.0
 jedi==0.19.2
-Jinja2==3.1.4
 joblib==1.5.1
 jupyterlab_widgets==3.0.15
 kiwisolver==1.4.8
-MarkupSafe==2.1.5
-matplotlib==3.10.3
 matplotlib-inline==0.1.7
+matplotlib==3.10.3
 mpmath==1.3.0
 multidict==6.6.3
 multiprocess==0.70.16
@@ -64,13 +67,11 @@ propcache==0.3.2
 ptyprocess==0.7.0
 pure_eval==0.2.3
 pyarrow==21.0.0
-Pygments==2.19.2
 pyparsing==3.2.3
 pyright==1.1.403
 pytest==8.4.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
-PyYAML==6.0.2
 regex==2024.11.6
 requests==2.32.4
 retrying==1.4.0
@@ -92,7 +93,6 @@ typing_extensions==4.14.1
 tzdata==2025.2
 urllib3==2.5.0
 wcwidth==0.2.13
-Werkzeug==3.1.3
 widgetsnbextension==4.0.14
 xxhash==3.5.0
 yarl==1.20.1

--- a/tests/test_multimodal_pairs.py
+++ b/tests/test_multimodal_pairs.py
@@ -1,0 +1,56 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import numpy as np
+from marble_core import DataLoader
+from PIL import Image
+import pytest
+
+
+def make_data(typ):
+    if typ == "text":
+        return "hello"
+    if typ == "image":
+        return Image.new("RGB", (2, 2), color=(123, 222, 111))
+    if typ == "audio":
+        return np.arange(8, dtype=np.float32) / 8.0
+    if typ == "blob":
+        return b"\x00\x01\x02\x03"
+    raise ValueError(f"unknown type: {typ}")
+
+
+@pytest.mark.parametrize(
+    "input_type,target_type",
+    [
+        ("text", "image"),
+        ("image", "text"),
+        ("text", "audio"),
+        ("audio", "text"),
+        ("image", "audio"),
+        ("audio", "image"),
+        ("blob", "text"),
+        ("text", "blob"),
+        ("image", "blob"),
+        ("blob", "image"),
+        ("blob", "audio"),
+        ("audio", "blob"),
+    ],
+)
+def test_dataloader_multimodal_pairs_roundtrip(input_type, target_type):
+    dl = DataLoader()
+    sample = {"input": make_data(input_type), "target": make_data(target_type)}
+    encoded = dl.encode(sample)
+    decoded = dl.decode(encoded)
+    assert type(decoded["input"]) == type(sample["input"])
+    assert type(decoded["target"]) == type(sample["target"])
+    if isinstance(sample["input"], np.ndarray):
+        assert np.array_equal(decoded["input"], sample["input"])
+    elif isinstance(sample["input"], Image.Image):
+        assert decoded["input"].size == sample["input"].size
+    else:
+        assert decoded["input"] == sample["input"]
+    if isinstance(sample["target"], np.ndarray):
+        assert np.array_equal(decoded["target"], sample["target"])
+    elif isinstance(sample["target"], Image.Image):
+        assert decoded["target"].size == sample["target"].size
+    else:
+        assert decoded["target"] == sample["target"]


### PR DESCRIPTION
## Summary
- document ability to train with multimodal pairs in README
- ensure requirements are up to date
- add tests for all supported multimodal input/target combinations

## Testing
- `pytest tests/test_multimodal_pairs.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687c0fe8a41c8327b50ff166bba5c9bd