### PR TITLE
Add PyTorch to MARBLE converter

### DIFF
--- a/marble.py
+++ b/marble.py
@@ -18,6 +18,7 @@ from data_compressor import DataCompressor
 import random
 import math
 import sympy as sp
+from marble_core import Neuron, Synapse, Core
 import threading
 from datetime import datetime
 from marble_imports import cp
@@ -778,13 +779,16 @@ class MarbleConverter:
                 for j, out_id in enumerate(output_ids):
                     for i, in_id in enumerate(prev_neuron_ids):
                         weight_val = float(weight_matrix[j, i])
-                        syn = Synapse(
-                            in_id,
-                            out_id,
-                            weight=weight_val,
-                            synapse_type="standard",
-                        )
+                        syn = Synapse(in_id, out_id, weight_val)
                         new_core.neurons[in_id].synapses.append(syn)
+                        new_core.synapses.append(syn)
+                if layer.bias is not None:
+                    bias_id = len(new_core.neurons)
+                    new_core.neurons.append(Neuron(bias_id, value=1.0, tier="vram"))
+                    for j, out_id in enumerate(output_ids):
+                        bias_val = float(layer.bias.detach().cpu().numpy()[j])
+                        syn = Synapse(bias_id, out_id, bias_val)
+                        new_core.neurons[bias_id].synapses.append(syn)
                         new_core.synapses.append(syn)
                 prev_neuron_ids = output_ids
         return new_core

--- a/marble_interface.py
+++ b/marble_interface.py
@@ -78,3 +78,41 @@ def set_autograd(marble: MARBLE, enabled: bool, learning_rate: float = 0.01) -> 
     elif not enabled and marble.get_autograd_layer() is not None:
         marble.get_brain().set_autograd_layer(None)
         marble.autograd_layer = None
+
+
+def convert_pytorch_model(
+    model: "torch.nn.Module",
+    core_params: dict | None = None,
+    nb_params: dict | None = None,
+    brain_params: dict | None = None,
+    dataloader_params: dict | None = None,
+) -> MARBLE:
+    """Return a :class:`MARBLE` instance converted from a PyTorch ``model``.
+
+    Parameters
+    ----------
+    model:
+        The PyTorch model to convert.
+    core_params:
+        Optional parameters passed to :class:`MARBLE` for core creation.
+    nb_params:
+        Optional :class:`Neuronenblitz` parameters.
+    brain_params:
+        Optional :class:`Brain` parameters.
+    dataloader_params:
+        Optional :class:`DataLoader` parameters.
+
+    Returns
+    -------
+    MARBLE
+        A new MARBLE system initialized from ``model`` weights.
+    """
+
+    return MARBLE(
+        core_params or {},
+        converter_model=model,
+        nb_params=nb_params,
+        brain_params=brain_params,
+        dataloader_params=dataloader_params,
+        init_from_weights=True,
+    )

--- a/marble_main.py
+++ b/marble_main.py
@@ -5,6 +5,7 @@ from marble_neuronenblitz import Neuronenblitz
 from marble_brain import Brain, BenchmarkManager
 from marble_autograd import MarbleAutogradLayer
 from marble_base import MetricsVisualizer
+from marble import MarbleConverter
 
 
 class MARBLE:

--- a/tests/test_pytorch_conversion.py
+++ b/tests/test_pytorch_conversion.py
@@ -1,0 +1,29 @@
+import torch
+from datasets import load_dataset
+from transformers import AutoModel
+from marble_interface import convert_pytorch_model
+from tests.test_core_functions import minimal_params
+
+
+def test_pytorch_conversion_predictions_match():
+    model = AutoModel.from_pretrained("dacorvo/mnist-mlp", trust_remote_code=True)
+    ds = load_dataset("mnist", split="test[:5]")
+    marble = convert_pytorch_model(model, minimal_params())
+
+    torch_preds = []
+    with torch.no_grad():
+        for record in ds:
+            img = record["image"].convert("L")
+            flat = torch.tensor(list(img.getdata()), dtype=torch.float32) / 255.0
+            out = model(flat.unsqueeze(0))
+            torch_preds.append(out.squeeze())
+
+    marble_preds = []
+    for record in ds:
+        img = record["image"].convert("L")
+        val = float(torch.tensor(list(img.getdata()), dtype=torch.float32).mean())
+        out = marble.get_brain().infer(val)
+        marble_preds.append(out)
+
+    for p1, p2 in zip(torch_preds, marble_preds):
+        assert torch.allclose(p1.float(), torch.tensor(p2).float(), atol=1e-5)


### PR DESCRIPTION
## Summary
- add `convert_pytorch_model` helper
- import `MarbleConverter` in `marble_main`
- handle linear layer biases during conversion
- initial failing test for pytorch model conversion

## Testing
- `pytest -k pytorch_conversion -q` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_687c123f397c8327b066191a086d4166