### PR TITLE
Add distillation trainer

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -250,3 +250,8 @@ Each entry is listed under its section heading.
 - num_train_steps
 - dataset_path
 - batch_size
+
+## distillation
+- enabled
+- alpha
+- teacher_model

--- a/config.yaml
+++ b/config.yaml
@@ -229,3 +229,7 @@ gpt:
   num_train_steps: 50
   dataset_path: "data/sample_text.txt"
   batch_size: 4
+distillation:
+  enabled: false
+  alpha: 0.5
+  teacher_model: null

--- a/distillation_trainer.py
+++ b/distillation_trainer.py
@@ -1,0 +1,38 @@
+import math
+from typing import Iterable, Tuple, Any
+from marble_brain import Brain, _normalize_examples
+from tqdm import tqdm
+
+
+class DistillationTrainer:
+    """Train a student brain using a teacher brain for guidance."""
+
+    def __init__(self, student: Brain, teacher: Brain, alpha: float = 0.5) -> None:
+        if not 0.0 <= alpha <= 1.0:
+            raise ValueError("alpha must be between 0 and 1")
+        self.student = student
+        self.teacher = teacher
+        self.alpha = alpha
+
+    def _blend_targets(
+        self, examples: Iterable[Tuple[float, float]]
+    ) -> list[Tuple[float, float]]:
+        blended = []
+        for inp, tgt in _normalize_examples(examples):
+            teacher_out = self.teacher.infer(inp)
+            mixed = (1.0 - self.alpha) * tgt + self.alpha * teacher_out
+            blended.append((inp, mixed))
+        return blended
+
+    def train(
+        self,
+        train_examples: Iterable[Any],
+        epochs: int = 1,
+        validation_examples: Iterable[Any] | None = None,
+    ) -> None:
+        """Train ``self.student`` using teacher-guided targets."""
+        blended = self._blend_targets(train_examples)
+        pbar = tqdm(range(epochs), desc="DistillationEpochs", ncols=100)
+        for _ in pbar:
+            self.student.train(blended, epochs=1, validation_examples=validation_examples)
+        pbar.close()

--- a/marble_interface.py
+++ b/marble_interface.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pickle
 from typing import Any, Iterable
 
+from distillation_trainer import DistillationTrainer
 from config_loader import create_marble_from_config, load_config
 from marble_main import MARBLE
 from marble_autograd import MarbleAutogradLayer
@@ -59,6 +60,19 @@ def train_marble_system(
 ) -> None:
     """Train ``marble`` on ``train_examples`` for ``epochs``."""
     marble.get_brain().train(train_examples, epochs=epochs, validation_examples=validation_examples)
+
+
+def distillation_train_marble_system(
+    student: MARBLE,
+    teacher: MARBLE,
+    train_examples: Iterable[Any],
+    epochs: int = 1,
+    alpha: float = 0.5,
+    validation_examples: Iterable[Any] | None = None,
+) -> None:
+    """Train ``student`` using ``teacher`` outputs for knowledge distillation."""
+    trainer = DistillationTrainer(student.get_brain(), teacher.get_brain(), alpha=alpha)
+    trainer.train(train_examples, epochs=epochs, validation_examples=validation_examples)
 
 
 def set_dreaming(marble: MARBLE, enabled: bool) -> None:

--- a/tests/test_distillation.py
+++ b/tests/test_distillation.py
@@ -1,0 +1,39 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from tests.test_core_functions import minimal_params
+from marble_core import Core, DataLoader
+from marble_neuronenblitz import Neuronenblitz
+from marble_brain import Brain
+from distillation_trainer import DistillationTrainer
+
+
+def build_brain():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    dl = DataLoader()
+    return Brain(core, nb, dl)
+
+
+def simple_dataset():
+    return [(0.1, 0.2), (0.2, 0.4), (0.3, 0.6)]
+
+
+def test_distillation_reduces_student_error():
+    teacher = build_brain()
+    teacher.train(simple_dataset(), epochs=3)
+
+    student = build_brain()
+    trainer = DistillationTrainer(student, teacher, alpha=0.5)
+
+    inp = 0.25
+    teacher_pred = teacher.infer(inp)
+    student_before = student.infer(inp)
+
+    trainer.train(simple_dataset(), epochs=2)
+
+    student_after = student.infer(inp)
+    err_before = abs(student_before - teacher_pred)
+    err_after = abs(student_after - teacher_pred)
+    assert err_after <= err_before

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -505,3 +505,19 @@ gpt:
     coverage and allows more diverse sequences.
   batch_size: Number of sequences processed before each optimisation step. Batches between 1 and 64 are typical. Larger
     values yield smoother gradient estimates but require more memory, especially when running on GPU with CuPy.
+
+distillation:
+  # Knowledge distillation allows training a "student" brain using guidance from
+  # a pre-trained "teacher" brain. When enabled the student blends the teacher's
+  # predictions with the ground truth targets before performing regular training
+  # updates. This is useful for compressing a large model into a smaller one or
+  # for transferring knowledge between different MARBLE instances.
+  enabled: Set to ``true`` to activate distillation during training.
+  alpha: Weighting factor between the true target and the teacher's output when
+    computing the blended target value. ``0.0`` relies solely on the ground
+    truth while ``1.0`` exactly matches the teacher. Typical values range from
+    ``0.3`` to ``0.7`` depending on how strongly the teacher should influence
+    learning.
+  teacher_model: Path to a pickled MARBLE system used as the teacher. If ``null``
+    the caller must provide the teacher programmatically when invoking the
+    distillation trainer.


### PR DESCRIPTION
## Summary
- add `DistillationTrainer` class
- enable distillation training through `distillation_train_marble_system`
- document new YAML `distillation` section
- list distillation parameters in config docs and defaults
- test distillation trainer

## Testing
- `pytest tests/test_distillation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687c155b36188327b583f81982578316