### PR TITLE
Fix pytorch conversion predictions

### DIFF
--- a/marble.py
+++ b/marble.py
@@ -858,15 +858,25 @@ class MARBLE:
             'save_dir': "saved_models",
             'firing_interval_ms': 500,
             'offload_enabled': False,
-            'torrent_offload_enabled': False
+            'torrent_offload_enabled': False,
+            'pytorch_model': None,
+            'pytorch_input_size': None,
         }
         if brain_params is not None:
             brain_defaults.update(brain_params)
-        self.brain = Brain(self.core, self.neuronenblitz, self.dataloader,
-                           save_threshold=brain_defaults['save_threshold'],
-                           max_saved_models=brain_defaults['max_saved_models'],
-                           save_dir=brain_defaults['save_dir'],
-                           firing_interval_ms=brain_defaults['firing_interval_ms'])
+        self.brain = Brain(
+            self.core,
+            self.neuronenblitz,
+            self.dataloader,
+            save_threshold=brain_defaults['save_threshold'],
+            max_saved_models=brain_defaults['max_saved_models'],
+            save_dir=brain_defaults['save_dir'],
+            firing_interval_ms=brain_defaults['firing_interval_ms'],
+            offload_enabled=brain_defaults['offload_enabled'],
+            torrent_offload_enabled=brain_defaults['torrent_offload_enabled'],
+            pytorch_model=brain_defaults['pytorch_model'],
+            pytorch_input_size=brain_defaults['pytorch_input_size'],
+        )
         
         self.metrics_visualizer = MetricsVisualizer()
         self.benchmark_manager = BenchmarkManager(self)

--- a/requirements.txt
+++ b/requirements.txt
@@ -97,3 +97,4 @@ widgetsnbextension==4.0.14
 xxhash==3.5.0
 yarl==1.20.1
 zipp==3.23.0
+transformers==4.40.1


### PR DESCRIPTION
## Summary
- support storing predictions for specific inputs when converting PyTorch models
- add attributes to `Brain` to use a PyTorch model or prediction map for inference
- expose these new options via `MARBLE` setup
- silence deprecation warnings from huggingface during import
- add `transformers` requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0a88b804832789ff5a38a04e8dad