### PR TITLE
Fix validation metrics for marble challenge

### DIFF
--- a/marble_brain.py
+++ b/marble_brain.py
@@ -471,8 +471,10 @@ class Brain:
         errors = []
         for input_val, target_val in validation_examples:
             output, _ = self.neuronenblitz.dynamic_wander(input_val)
-            errors.append(abs(target_val - output))
-        mean_val_loss = sum(errors) / len(errors) if errors else 0
+            pred = int(round(float(output)))
+            pred = max(0, min(9, pred))
+            errors.append((target_val - pred) ** 2)
+        mean_val_loss = sum(errors) / len(errors) if errors else 0.0
         print(f"Mean Validation Loss: {mean_val_loss:.4f}")
         return mean_val_loss
 


### PR DESCRIPTION
## Summary
- clamp challenge predictions to 0-9
- compute squared error to report validation loss

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0fd45b808327a2d36486700f192a