### PR TITLE
Enhance Neuronenblitz context handling

### DIFF
--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -186,6 +186,14 @@ class Neuronenblitz:
         self.plasticity_threshold = max(0.5, self.plasticity_threshold - adjustment)
         self.last_context = context.copy()
 
+    def update_context(self, **kwargs):
+        """Update the stored neuromodulatory context without modifying plasticity."""
+        self.last_context.update(kwargs)
+
+    def get_context(self):
+        """Return a copy of the most recently stored neuromodulatory context."""
+        return self.last_context.copy()
+
     def reset_neuron_values(self):
         for neuron in self.core.neurons:
             neuron.value = None

--- a/tests/test_neuronenblitz_enhancements.py
+++ b/tests/test_neuronenblitz_enhancements.py
@@ -147,3 +147,12 @@ def test_prune_low_potential_synapses():
     assert weak not in core.synapses
     assert syn_main in core.synapses
 
+
+def test_update_and_get_context():
+    core, _ = create_simple_core()
+    nb = Neuronenblitz(core)
+    nb.update_context(arousal=0.2, stress=0.1)
+    ctx = nb.get_context()
+    assert ctx["arousal"] == 0.2
+    assert ctx["stress"] == 0.1
+


### PR DESCRIPTION
## Summary
- add `update_context` and `get_context` in `Neuronenblitz`
- test new context helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d1a0485d883278d9ca345cc83a25e