### PR TITLE
Enhance Neuronenblitz with momentum

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -90,6 +90,7 @@ Each entry is listed under its section heading.
 - fatigue_increase
 - fatigue_decay
 - lr_adjustment_factor
+- momentum_coefficient
 
 ## brain
 - save_threshold

--- a/config.yaml
+++ b/config.yaml
@@ -84,6 +84,7 @@ neuronenblitz:
   fatigue_increase: 0.05
   fatigue_decay: 0.95
   lr_adjustment_factor: 0.1
+  momentum_coefficient: 0.0
 brain:
   save_threshold: 0.05
   max_saved_models: 5

--- a/tests/test_neuronenblitz_enhancements.py
+++ b/tests/test_neuronenblitz_enhancements.py
@@ -156,3 +156,20 @@ def test_update_and_get_context():
     assert ctx["arousal"] == 0.2
     assert ctx["stress"] == 0.1
 
+
+def test_weight_update_momentum():
+    random.seed(0)
+    core, syn = create_simple_core()
+    nb = Neuronenblitz(
+        core,
+        consolidation_probability=0.0,
+        weight_decay=0.0,
+        momentum_coefficient=0.5,
+    )
+    nb.learning_rate = 1.0
+    core.neurons[0].value = 1.0
+    nb.apply_weight_updates_and_attention([syn], error=1.0)
+    core.neurons[0].value = 1.0
+    nb.apply_weight_updates_and_attention([syn], error=1.0)
+    assert np.isclose(syn.weight, 2.25)
+

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -195,6 +195,11 @@ neuronenblitz:
   lr_adjustment_factor: Fractional step used by ``adjust_learning_rate`` when
     increasing or decreasing ``learning_rate`` in response to recent error
     trends.
+  momentum_coefficient: Coefficient used to blend the previous weight update
+    with the current gradient. ``0.0`` disables momentum while values between
+    ``0.0`` and ``1.0`` accelerate training by smoothing updates. Momentum is
+    applied in ``apply_weight_updates_and_attention`` and is stored per-synapse
+    so that frequently updated connections gain additional inertia.
 
 brain:
   save_threshold: Minimum improvement in validation loss required before the


### PR DESCRIPTION
## Summary
- add momentum coefficient to Neuronenblitz to smooth weight updates
- support momentum in weight update routine and clear it when pruning
- expose new parameter in `config.yaml`
- document parameter in `CONFIGURABLE_PARAMETERS.md` and `yaml-manual.txt`
- test momentum behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d1c61f7d8832790693620f558eed8