### PR TITLE
Enhance Neuronenblitz path exploration

### DIFF
--- a/remote_offload.py
+++ b/remote_offload.py
@@ -132,14 +132,15 @@ class RemoteBrainClient:
             payload = {'core': json.loads(core_to_json(core))}
         requests.post(self.url + '/offload', json=payload, timeout=self.timeout)
 
-    def process(self, value: float) -> float:
+    def process(self, value: float, timeout: float | None = None) -> float:
         if self.use_compression:
             val_bytes = json.dumps(value).encode()
             comp = self.compressor.compress(val_bytes)
             payload = {'value': base64.b64encode(comp).decode()}
         else:
             payload = {'value': value}
-        resp = requests.post(self.url + '/process', json=payload, timeout=self.timeout)
+        req_timeout = timeout if timeout is not None else self.timeout
+        resp = requests.post(self.url + '/process', json=payload, timeout=req_timeout)
         data = resp.json()
         if self.use_compression:
             comp_out = base64.b64decode(data['output'].encode())


### PR DESCRIPTION
## Summary
- implement synapse dropout in `_wander`
- propagate remote timeout to `RemoteBrainClient`
- skip fallback path when dropout is full
- expose optional timeout parameter in remote client
- add tests for dropout and remote timeout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d22df70f083278fa98ae4f77c29f3