### PR TITLE
Add dropout decay rate feature

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -60,6 +60,7 @@ Each entry is listed under its section heading.
 - learning_rate
 - weight_decay
 - dropout_probability
+- dropout_decay_rate
 - exploration_decay
 - reward_scale
 - stress_scale

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -30,6 +30,7 @@ This tutorial demonstrates every major component of MARBLE through a series of p
    marble.brain.train(train_examples, epochs=10, validation_examples=val_examples)
    ```
 6. Inspect live metrics with the `MetricsVisualizer` which plots loss and memory usage. Options such as `fig_width` and `color_scheme` are configurable in `config.yaml` under `metrics_visualizer`.
+7. To slowly reduce regularization as training progresses, set `dropout_probability` and `dropout_decay_rate` under `neuronenblitz` in `config.yaml`. A decay rate below `1.0` multiplies the current dropout after each epoch.
 
 This project introduces the **Core**, **Neuronenblitz** and **Brain** objects along with the data compression pipeline.
 

--- a/config.yaml
+++ b/config.yaml
@@ -54,6 +54,7 @@ neuronenblitz:
   learning_rate: 0.01
   weight_decay: 0.0
   dropout_probability: 0.0
+  dropout_decay_rate: 1.0
   exploration_decay: 0.99
   reward_scale: 1.0
   stress_scale: 1.0

--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -53,6 +53,7 @@ class Neuronenblitz:
         learning_rate=0.01,
         weight_decay=0.0,
         dropout_probability=0.0,
+        dropout_decay_rate=1.0,
         exploration_decay=0.99,
         reward_scale=1.0,
         stress_scale=1.0,
@@ -107,6 +108,7 @@ class Neuronenblitz:
         self.learning_rate = learning_rate
         self.weight_decay = weight_decay
         self.dropout_probability = dropout_probability
+        self.dropout_decay_rate = dropout_decay_rate
         self.exploration_decay = exploration_decay
         self.reward_scale = reward_scale
         self.stress_scale = stress_scale
@@ -631,6 +633,11 @@ class Neuronenblitz:
             self.last_message_passing_change = change
             self.decide_synapse_action()
             self.adjust_learning_rate()
+            if self.dropout_decay_rate != 1.0:
+                self.dropout_probability *= self.dropout_decay_rate
+                self.dropout_probability = float(
+                    max(0.0, min(1.0, self.dropout_probability))
+                )
 
     def get_training_history(self):
         return self.training_history

--- a/tests/test_neuronenblitz_enhancements.py
+++ b/tests/test_neuronenblitz_enhancements.py
@@ -214,3 +214,21 @@ def test_remote_timeout_passed():
     nb.dynamic_wander(1.0)
     assert client.last_timeout == 2.5
 
+
+def test_dropout_probability_decays():
+    random.seed(0)
+    np.random.seed(0)
+    core, _ = create_simple_core()
+    nb = Neuronenblitz(
+        core,
+        dropout_probability=0.5,
+        dropout_decay_rate=0.8,
+        split_probability=0.0,
+        alternative_connection_prob=0.0,
+        backtrack_probability=0.0,
+        backtrack_enabled=False,
+    )
+    nb.train([(1.0, 0.0)], epochs=2)
+    expected = 0.5 * 0.8 * 0.8
+    assert np.isclose(nb.dropout_probability, expected)
+

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -127,6 +127,10 @@ neuronenblitz:
     to prevent uncontrolled growth. ``0.0`` disables this effect.
   dropout_probability: Fraction of synapses temporarily ignored during training
     to improve robustness.
+  dropout_decay_rate: Multiplicative factor applied to ``dropout_probability``
+    after each training epoch. Values below ``1.0`` gradually reduce the
+    effective dropout as learning progresses while higher values keep it
+    constant. The rate must be between ``0.0`` and ``1.0``.
   exploration_decay: Rate at which the exploration bonus diminishes over time.
     Values slightly below ``1.0`` gradually reduce random behaviour.
   reward_scale: Multiplier applied to reward signals before they adjust


### PR DESCRIPTION
## Summary
- add `dropout_decay_rate` parameter to `Neuronenblitz`
- decay dropout probability each training epoch
- document new parameter in `CONFIGURABLE_PARAMETERS.md`, `yaml-manual.txt`, and `TUTORIAL.md`
- add default value to `config.yaml`
- test dropout decay behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3871e8188327888a86ab79d7ebd7