### PR TITLE
Enhance neuronenblitz synapse update handling

### DIFF
--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -5,6 +5,7 @@ import threading
 import multiprocessing as mp
 import pickle
 from collections import deque
+import math
 
 
 def _wander_worker(state_bytes, input_value, seed):
@@ -532,7 +533,10 @@ class Neuronenblitz:
             mom = self._momentum.get(syn, 0.0)
             mom = self.momentum_coefficient * mom + delta
             self._momentum[syn] = mom
-            syn.weight += self.learning_rate * mom
+            update = self.learning_rate * mom
+            if abs(update) > self.synapse_update_cap:
+                update = math.copysign(self.synapse_update_cap, update)
+            syn.weight += update
             if random.random() < self.consolidation_probability:
                 syn.weight *= self.consolidation_strength
             if syn.weight > self._weight_limit:

--- a/tests/test_neuronenblitz_enhancements.py
+++ b/tests/test_neuronenblitz_enhancements.py
@@ -103,6 +103,7 @@ def test_weight_update_with_noise():
         consolidation_probability=0.0,
         weight_decay=0.0,
         gradient_noise_std=0.5,
+        synapse_update_cap=2.0,
     )
     nb.learning_rate = 1.0
     core.neurons[0].value = 1.0
@@ -231,4 +232,24 @@ def test_dropout_probability_decays():
     nb.train([(1.0, 0.0)], epochs=2)
     expected = 0.5 * 0.8 * 0.8
     assert np.isclose(nb.dropout_probability, expected)
+
+
+def test_synapse_update_cap_limits_change():
+    random.seed(0)
+    core, syn = create_simple_core()
+
+    def fixed_update(source, error, path_len):
+        return 10.0
+
+    nb = Neuronenblitz(
+        core,
+        consolidation_probability=0.0,
+        weight_decay=0.0,
+        synapse_update_cap=0.05,
+        weight_update_fn=fixed_update,
+    )
+    nb.learning_rate = 1.0
+    core.neurons[0].value = 1.0
+    nb.apply_weight_updates_and_attention([syn], error=1.0)
+    assert np.isclose(syn.weight, 1.05)
 


### PR DESCRIPTION
## Summary
- enforce `synapse_update_cap` in `apply_weight_updates_and_attention`
- add test covering update cap limits
- adjust noise test to set high cap

## Testing
- `pytest tests/test_neuronenblitz_enhancements.py::test_weight_update_with_noise -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3a819b3c8327865d149c2ef9cb46