### PR TITLE
Expose synapse_update_cap via config

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -162,3 +162,13 @@ def test_remote_server_start(tmp_path):
     marble = create_marble_from_config(str(cfg_path))
     assert hasattr(marble, "remote_server")
     marble.remote_server.stop()
+
+
+def test_synapse_update_cap_configurable(tmp_path):
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg = load_config()
+    cfg["neuronenblitz"]["synapse_update_cap"] = 0.5
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(cfg, f)
+    marble = create_marble_from_config(str(cfg_path))
+    assert marble.neuronenblitz.synapse_update_cap == 0.5

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -145,8 +145,10 @@ neuronenblitz:
     ``update_attention``. Disabling keeps attention static.
   backtrack_depth_limit: Maximum distance for which backtracking may revisit
     previous neurons when ``backtrack_enabled`` is true.
-  synapse_update_cap: Absolute limit applied to single weight updates to avoid
-    extreme jumps.
+  synapse_update_cap: Maximum absolute magnitude allowed for each individual
+    weight update. Prevents large sudden jumps that may destabilize learning.
+    The default is 1.0 and values typically range from 0.01 to 5.0 depending on
+    how aggressively weights should adapt.
   structural_plasticity_enabled: When false, ``apply_structural_plasticity`` is
     skipped entirely.
   backtrack_enabled: If false, wandering never returns to previously visited


### PR DESCRIPTION
## Summary
- add test ensuring `synapse_update_cap` can be overridden via YAML
- document configuration range for `synapse_update_cap` in `yaml-manual.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3e03f2188327b9c71b0d69f2c6f2