### PR TITLE
Add reinforcement learning support

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -261,3 +261,12 @@ Each entry is listed under its section heading.
 - enabled
 - alpha
 - teacher_model
+
+## reinforcement_learning
+- enabled
+- episodes
+- max_steps
+- discount_factor
+- epsilon_start
+- epsilon_decay
+- epsilon_min

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -97,6 +97,14 @@ This project covers **autograd integration** and the **PyTorch challenge** mecha
 5. Optionally apply **knowledge distillation** by training a student brain with `DistillationTrainer`, using a previously saved MARBLE model as the teacher.
 
 This final project introduces the **GPT components**, **distillation**, and the **dimensional search** capability if `dimensional_search.enabled` is set in the configuration.
+## Project 6 – Reinforcement Learning (Master)
+
+**Goal:** Solve a simple GridWorld using Q-learning built on top of MARBLE.
+
+1. Set `reinforcement_learning.enabled` in `config.yaml` to `true`.
+2. Use `reinforcement_learning.train_gridworld()` with a `MarbleQLearningAgent` created from your core and neuronenblitz instances.
+3. Observe the total rewards returned after each episode to verify learning progress.
+
 
 ## Where to Go Next
 

--- a/config.yaml
+++ b/config.yaml
@@ -240,3 +240,11 @@ distillation:
   enabled: false
   alpha: 0.5
   teacher_model: null
+reinforcement_learning:
+  enabled: false
+  episodes: 10
+  max_steps: 50
+  discount_factor: 0.9
+  epsilon_start: 1.0
+  epsilon_decay: 0.95
+  epsilon_min: 0.1

--- a/reinforcement_learning.py
+++ b/reinforcement_learning.py
@@ -1,0 +1,104 @@
+import random
+import numpy as np
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+
+
+class GridWorld:
+    """Simple grid environment with deterministic transitions."""
+
+    def __init__(self, size: int = 4) -> None:
+        self.size = size
+        self.start = (0, 0)
+        self.goal = (size - 1, size - 1)
+        self.reset()
+
+    @property
+    def n_actions(self) -> int:
+        return 4  # up, down, left, right
+
+    def reset(self) -> tuple[int, int]:
+        self.pos = self.start
+        return self.pos
+
+    def step(self, action: int) -> tuple[tuple[int, int], float, bool]:
+        x, y = self.pos
+        if action == 0 and x > 0:
+            x -= 1
+        elif action == 1 and x < self.size - 1:
+            x += 1
+        elif action == 2 and y > 0:
+            y -= 1
+        elif action == 3 and y < self.size - 1:
+            y += 1
+        self.pos = (x, y)
+        done = self.pos == self.goal
+        reward = 10.0 if done else -1.0
+        return self.pos, reward, done
+
+
+class MarbleQLearningAgent:
+    """Q-learning agent powered by the MARBLE system."""
+
+    def __init__(
+        self,
+        core: Core,
+        nb: Neuronenblitz,
+        discount: float = 0.9,
+        epsilon: float = 1.0,
+        epsilon_decay: float = 0.95,
+        min_epsilon: float = 0.1,
+    ) -> None:
+        self.core = core
+        self.nb = nb
+        self.discount = discount
+        self.epsilon = epsilon
+        self.epsilon_decay = epsilon_decay
+        self.min_epsilon = min_epsilon
+
+    def _encode(self, state: tuple[int, int], action: int) -> float:
+        """Encode state-action pair into a numeric input."""
+        return float(state[0] * 10 + state[1] + action / 10)
+
+    def select_action(self, state: tuple[int, int], n_actions: int) -> int:
+        if random.random() < self.epsilon:
+            return random.randrange(n_actions)
+        q_values = [
+            self.nb.dynamic_wander(self._encode(state, a))[0] for a in range(n_actions)
+        ]
+        return int(np.argmax(q_values))
+
+    def update(
+        self,
+        state: tuple[int, int],
+        action: int,
+        reward: float,
+        next_state: tuple[int, int],
+        done: bool,
+    ) -> None:
+        next_q = 0.0
+        if not done:
+            next_q = max(
+                self.nb.dynamic_wander(self._encode(next_state, a))[0]
+                for a in range(4)
+            )
+        target = reward + self.discount * next_q
+        self.nb.train([(self._encode(state, action), target)], epochs=1)
+        self.epsilon = max(self.min_epsilon, self.epsilon * self.epsilon_decay)
+
+
+def train_gridworld(agent: MarbleQLearningAgent, env: GridWorld, episodes: int, max_steps: int = 50) -> list[float]:
+    rewards = []
+    for _ in range(episodes):
+        state = env.reset()
+        total = 0.0
+        for _ in range(max_steps):
+            action = agent.select_action(state, env.n_actions)
+            next_state, reward, done = env.step(action)
+            agent.update(state, action, reward, next_state, done)
+            total += reward
+            state = next_state
+            if done:
+                break
+        rewards.append(total)
+    return rewards

--- a/tests/test_reinforcement_learning.py
+++ b/tests/test_reinforcement_learning.py
@@ -1,0 +1,17 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from reinforcement_learning import GridWorld, MarbleQLearningAgent, train_gridworld
+from tests.test_core_functions import minimal_params
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+
+
+def test_qlearning_improves_reward():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    agent = MarbleQLearningAgent(core, nb, discount=0.9, epsilon=1.0, epsilon_decay=0.8)
+    env = GridWorld(size=3)
+    rewards = train_gridworld(agent, env, episodes=5, max_steps=20)
+    assert rewards[-1] >= rewards[0] - 1e-9

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -542,3 +542,15 @@ distillation:
   teacher_model: Path to a pickled MARBLE system used as the teacher. If ``null``
     the caller must provide the teacher programmatically when invoking the
     distillation trainer.
+
+reinforcement_learning:
+  enabled: Activate training in a reinforcement learning loop using the MARBLE
+    core and Neuronenblitz. Set to ``true`` to begin episodic interaction with
+    the environment defined in ``reinforcement_learning.py``.
+  episodes: Number of training episodes to run. More episodes generally yield
+    better policies but increase computation time.
+  max_steps: Maximum steps per episode before resetting the environment.
+  discount_factor: Discount applied to future rewards when computing Q-values.
+  epsilon_start: Initial exploration rate for the epsilon-greedy policy.
+  epsilon_decay: Multiplicative decay applied to ``epsilon`` after each update.
+  epsilon_min: Lowest exploration rate allowed once ``epsilon`` has decayed.


### PR DESCRIPTION
## Summary
- implement GridWorld and Q-learning agent using MARBLE Core and Neuronenblitz
- expose reinforcement learning parameters in configuration
- document parameters and new tutorial project
- list new config options
- test Q-learning training loop

## Testing
- `pytest tests/test_reinforcement_learning.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4033d93c8327be0b08878b3d6cf9