### PR TITLE
Add reinforcement learning capabilities

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -36,6 +36,12 @@ Each entry is listed under its section heading.
 - message_passing_beta
 - attention_temperature
 - energy_threshold
+- reinforcement_learning_enabled
+- rl_discount
+- rl_learning_rate
+- rl_epsilon
+- rl_epsilon_decay
+- rl_min_epsilon
 - early_cleanup_enabled
 - pretraining_epochs
 - min_cluster_k
@@ -92,6 +98,11 @@ Each entry is listed under its section heading.
 - fatigue_decay
 - lr_adjustment_factor
 - momentum_coefficient
+- reinforcement_learning_enabled
+- rl_discount
+- rl_epsilon
+- rl_epsilon_decay
+- rl_min_epsilon
 
 ## brain
 - save_threshold

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -101,8 +101,12 @@ This final project introduces the **GPT components**, **distillation**, and the 
 
 **Goal:** Solve a simple GridWorld using Q-learning built on top of MARBLE.
 
-1. Set `reinforcement_learning.enabled` in `config.yaml` to `true`.
-2. Use `reinforcement_learning.train_gridworld()` with a `MarbleQLearningAgent` created from your core and neuronenblitz instances.
+1. Enable `reinforcement_learning.enabled` in `config.yaml` and also set
+   `core.reinforcement_learning_enabled` and
+   `neuronenblitz.reinforcement_learning_enabled` to `true`.
+2. Either drive the environment manually using the new `rl_` methods on the
+   core and Neuronenblitz or call `reinforcement_learning.train_gridworld()`
+   which demonstrates these helpers in action.
 3. Observe the total rewards returned after each episode to verify learning progress.
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -31,6 +31,12 @@ core:
   message_passing_beta: 1.0
   attention_temperature: 1.0
   energy_threshold: 0.5
+  reinforcement_learning_enabled: false
+  rl_discount: 0.9
+  rl_learning_rate: 0.1
+  rl_epsilon: 1.0
+  rl_epsilon_decay: 0.95
+  rl_min_epsilon: 0.1
   early_cleanup_enabled: false
   pretraining_epochs: 0
   min_cluster_k: 2
@@ -86,6 +92,11 @@ neuronenblitz:
   fatigue_decay: 0.95
   lr_adjustment_factor: 0.1
   momentum_coefficient: 0.0
+  reinforcement_learning_enabled: false
+  rl_discount: 0.9
+  rl_epsilon: 1.0
+  rl_epsilon_decay: 0.95
+  rl_min_epsilon: 0.1
 brain:
   save_threshold: 0.05
   max_saved_models: 5

--- a/tests/test_reinforcement_learning.py
+++ b/tests/test_reinforcement_learning.py
@@ -1,4 +1,7 @@
-import os, sys
+import os
+import sys
+import pytest
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from reinforcement_learning import GridWorld, MarbleQLearningAgent, train_gridworld
@@ -15,3 +18,26 @@ def test_qlearning_improves_reward():
     env = GridWorld(size=3)
     rewards = train_gridworld(agent, env, episodes=5, max_steps=20)
     assert rewards[-1] >= rewards[0] - 1e-9
+
+
+def test_neuronenblitz_rl_toggle():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    with pytest.raises(RuntimeError):
+        nb.rl_select_action((0, 0), 2)
+    nb.enable_rl()
+    action = nb.rl_select_action((0, 0), 2)
+    prev_eps = nb.rl_epsilon
+    nb.rl_update((0, 0), action, 1.0, (0, 1), False, n_actions=2)
+    assert nb.rl_epsilon < prev_eps
+
+
+def test_core_qlearning_update():
+    params = minimal_params()
+    params["reinforcement_learning_enabled"] = True
+    core = Core(params)
+    action = core.rl_select_action("s0", 2)
+    core.rl_update("s0", action, 1.0, "s1", True, n_actions=2)
+    assert core.q_table[("s0", action)] != 0.0
+

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -77,6 +77,16 @@ core:
     distributions. Must be greater than zero.
   energy_threshold: Minimum energy level required before neurons participate in
     message passing. Helps filter out inactive units.
+  reinforcement_learning_enabled: Enable or disable the internal Q-learning
+    engine in the core. Set to ``true`` to allow calling the ``rl_`` methods.
+  rl_discount: Discount factor applied to future rewards when updating the
+    core's Q-table. Typical values range from ``0.8`` to ``0.99``.
+  rl_learning_rate: Step size used for Q-value updates. Smaller values result in
+    slower but more stable learning.
+  rl_epsilon: Initial exploration rate for epsilon-greedy action selection.
+  rl_epsilon_decay: Multiplicative decay applied to ``rl_epsilon`` after each
+    update step.
+  rl_min_epsilon: Minimum exploration rate once decay has progressed.
   early_cleanup_enabled: If ``true``, unused neurons are removed before normal
     cleanup intervals, reducing memory usage.
   pretraining_epochs: Number of unsupervised epochs to run before regular
@@ -206,6 +216,14 @@ neuronenblitz:
     ``0.0`` and ``1.0`` accelerate training by smoothing updates. Momentum is
     applied in ``apply_weight_updates_and_attention`` and is stored per-synapse
     so that frequently updated connections gain additional inertia.
+  reinforcement_learning_enabled: Turn on Q-learning inside Neuronenblitz. When
+    enabled the ``rl_`` methods may be used to select actions and update
+    values directly through the network.
+  rl_discount: Discount factor for future rewards used by ``rl_update``.
+  rl_epsilon: Initial exploration probability for ``rl_select_action``.
+  rl_epsilon_decay: Multiplicative decay applied to ``rl_epsilon`` each time an
+    update occurs.
+  rl_min_epsilon: Smallest allowed exploration rate once decay has taken place.
 
 brain:
   save_threshold: Minimum improvement in validation loss required before the


### PR DESCRIPTION
## Summary
- integrate RL toggle and Q-learning utilities in `Core` and `Neuronenblitz`
- expose new RL parameters in `config.yaml`
- document new parameters in `yaml-manual.txt` and `CONFIGURABLE_PARAMETERS.md`
- update tutorial to describe RL with internal methods
- extend reinforcement learning tests

## Testing
- `ruff check tests/test_reinforcement_learning.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d42ef42d08327b51ecff1fc8298c2