### PR TITLE
Add Hebbian learning paradigm

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -287,3 +287,7 @@ Each entry is listed under its section heading.
 - temperature
 - epochs
 - batch_size
+
+## hebbian_learning
+- learning_rate
+- weight_decay

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **Mandelbrot Adaptive Reasoning Brain-Like Engine**
 
 The MARBLE system is a modular neural architecture that begins with a Mandelbrot-inspired seed and adapts through neuromodulatory feedback and structural plasticity. This repository contains the source code for the system along with utilities and configuration files.
+It also includes a new unsupervised Hebbian learning module that ties together message passing in the Core with Neuronenblitz path exploration.
 
 MARBLE can train on datasets provided as lists of ``(input, target)`` pairs or using PyTorch-style ``Dataset``/``DataLoader`` objects. Each sample must expose an ``input`` and ``target`` field. After training and saving a model, ``Brain.infer`` generates outputs when given only an input value.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -125,6 +125,16 @@ This final project introduces the **GPT components**, **distillation**, and the 
 This project demonstrates the new **ContrastiveLearner** and how it integrates
 with the existing Core and Neuronenblitz components.
 
+## Project 8 – Hebbian Learning (Research)
+
+**Goal:** Explore unsupervised Hebbian updates integrated with Neuronenblitz.
+
+1. Enable `hebbian_learning` settings in `config.yaml` to configure `learning_rate` and `weight_decay`.
+2. Instantiate `HebbianLearner` with the existing Core and Neuronenblitz objects.
+3. Call `HebbianLearner.train()` on a list of inputs without targets.
+4. Inspect weight changes along visited paths to verify correlation-based updates.
+
+
 
 ## Where to Go Next
 

--- a/config.yaml
+++ b/config.yaml
@@ -264,3 +264,6 @@ contrastive_learning:
   temperature: 0.5
   epochs: 1
   batch_size: 4
+hebbian_learning:
+  learning_rate: 0.01
+  weight_decay: 0.0

--- a/hebbian_learning.py
+++ b/hebbian_learning.py
@@ -1,0 +1,41 @@
+from marble_imports import *
+from marble_core import perform_message_passing, Core
+from marble_neuronenblitz import Neuronenblitz
+
+
+class HebbianLearner:
+    """Unsupervised Hebbian learning integrated with MARBLE."""
+
+    def __init__(self, core: Core, nb: Neuronenblitz, learning_rate: float = 0.01, weight_decay: float = 0.0) -> None:
+        self.core = core
+        self.nb = nb
+        self.learning_rate = float(learning_rate)
+        self.weight_decay = float(weight_decay)
+        self.history: list[dict] = []
+        self._weight_limit = 1e6
+
+    def _update_weights(self, path: list) -> None:
+        for syn in path:
+            pre = self.core.neurons[syn.source].value
+            post = self.core.neurons[syn.target].value
+            if pre is None or post is None:
+                continue
+            delta = self.learning_rate * float(pre) * float(post)
+            delta -= self.weight_decay * syn.weight
+            syn.weight += delta * getattr(self.nb, "plasticity_modulation", 1.0)
+            if syn.weight > self._weight_limit:
+                syn.weight = self._weight_limit
+            elif syn.weight < -self._weight_limit:
+                syn.weight = -self._weight_limit
+
+    def train_step(self, input_value: float) -> float:
+        out, path = self.nb.dynamic_wander(input_value, apply_plasticity=False)
+        perform_message_passing(self.core)
+        self._update_weights(path)
+        self.history.append({"input": input_value, "output": out, "path_len": len(path)})
+        return float(out) if isinstance(out, (int, float)) else float(np.mean(out))
+
+    def train(self, inputs: list, epochs: int = 1) -> None:
+        for _ in range(int(epochs)):
+            for inp in inputs:
+                self.train_step(inp)

--- a/tests/test_hebbian_learning.py
+++ b/tests/test_hebbian_learning.py
@@ -1,0 +1,33 @@
+import random
+import numpy as np
+from tests.test_core_functions import minimal_params
+from marble_core import Core, Neuron
+from marble_neuronenblitz import Neuronenblitz
+from hebbian_learning import HebbianLearner
+
+
+def create_simple_core():
+    params = minimal_params()
+    core = Core(params)
+    core.neurons = [Neuron(0, value=0.0), Neuron(1, value=0.0)]
+    core.synapses = []
+    syn = core.add_synapse(0, 1, weight=0.5)
+    return core, syn
+
+
+def test_hebbian_learning_weight_update():
+    random.seed(0)
+    np.random.seed(0)
+    core, syn = create_simple_core()
+    nb = Neuronenblitz(
+        core,
+        split_probability=0.0,
+        alternative_connection_prob=0.0,
+        backtrack_probability=0.0,
+        backtrack_enabled=False,
+    )
+    learner = HebbianLearner(core, nb, learning_rate=0.1)
+    before = syn.weight
+    learner.train_step(1.0)
+    after = syn.weight
+    assert after != before

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -592,3 +592,16 @@ contrastive_learning:
     sample produces two augmented views, so the effective batch size for
     the loss is ``2 * batch_size``. Values between ``2`` and ``32`` work
     well depending on available memory.
+
+hebbian_learning:
+  # Unsupervised Hebbian update rule integrated with Neuronenblitz.
+  # After each wander the weights along the traversed path are
+  # adjusted based on the product of pre- and post-synaptic values.
+  # ``learning_rate`` scales the Hebbian update and ``weight_decay``
+  # applies an L2 style penalty to prevent unbounded growth.
+  learning_rate: Positive step size controlling how strongly synapse
+    weights are increased when correlated neuron activations are
+    observed. Typical values range from ``0.001`` to ``0.1``.
+  weight_decay: Fraction of the current weight subtracted during each
+    update. Helps stabilise learning when set between ``0.0`` and
+    ``0.01``.


### PR DESCRIPTION
## Summary
- implement new `HebbianLearner` that integrates Core message passing and Neuronenblitz wandering
- provide simple test covering the new learner
- expose parameters in YAML configuration, configurable parameters list and manual
- expand tutorial with a Hebbian learning project
- note the feature in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d49c82ef88327b6f622d3e10f5886