### PR TITLE
Add federated learning paradigm

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -309,3 +309,4 @@ Each entry is listed under its section heading.
 - epochs
 - batch_size
 - unlabeled_weight
+\n## federated_learning\n- enabled\n- rounds\n- local_epochs\n

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -174,3 +174,13 @@ alter its behaviour.
 ```
 
 Experiment by modifying these options and combining features from multiple projects. The test suite (`pytest`) exercises every component and can be run to verify your setup.
+
+## Project 12 – Federated Learning (Frontier)
+
+**Goal:** Train multiple Neuronenblitz networks on separate datasets and combine them using federated averaging.**
+
+1. Enable `federated_learning.enabled` in `config.yaml` and set `rounds` and `local_epochs`.
+2. Create one `Core`/`Neuronenblitz` pair for each client and instantiate `FederatedAveragingTrainer` with them.
+3. Provide a dataset list matching the clients to `train_round()` for each communication round.
+4. After training, examine synapse weights to confirm they were synchronised across clients.
+

--- a/config.yaml
+++ b/config.yaml
@@ -286,3 +286,9 @@ semi_supervised_learning:
   epochs: 1
   batch_size: 4
   unlabeled_weight: 0.5
+
+federated_learning:
+  enabled: false
+  rounds: 1
+  local_epochs: 1
+

--- a/federated_learning.py
+++ b/federated_learning.py
@@ -1,0 +1,38 @@
+from marble_imports import *
+from marble_core import perform_message_passing, Core
+from marble_neuronenblitz import Neuronenblitz
+
+
+class FederatedAveragingTrainer:
+    """Federated averaging across multiple Neuronenblitz clients."""
+
+    def __init__(self, clients: list[tuple[Core, Neuronenblitz]]) -> None:
+        if not clients:
+            raise ValueError("at least one client required")
+        self.clients = clients
+
+    def _get_weights(self, core: Core) -> list[float]:
+        return [syn.weight for syn in core.synapses]
+
+    def _set_weights(self, core: Core, weights: list[float]) -> None:
+        for syn, w in zip(core.synapses, weights):
+            syn.weight = float(w)
+
+    def _average_weights(self) -> list[float]:
+        weight_lists = [self._get_weights(c) for c, _ in self.clients]
+        return list(np.mean(weight_lists, axis=0))
+
+    def aggregate(self) -> None:
+        """Average synapse weights across clients."""
+        avg = self._average_weights()
+        for c, _ in self.clients:
+            self._set_weights(c, avg)
+
+    def train_round(self, datasets: list[list[tuple[float, float]]], epochs: int = 1) -> None:
+        """Train each client locally then aggregate weights."""
+        if len(datasets) != len(self.clients):
+            raise ValueError("datasets length must match clients")
+        for (core, nb), data in zip(self.clients, datasets):
+            nb.train(data, epochs=epochs)
+            perform_message_passing(core)
+        self.aggregate()

--- a/tests/test_federated_learning.py
+++ b/tests/test_federated_learning.py
@@ -1,0 +1,36 @@
+import random
+import numpy as np
+from tests.test_core_functions import minimal_params
+from marble_core import Core, Neuron
+from marble_neuronenblitz import Neuronenblitz
+from federated_learning import FederatedAveragingTrainer
+
+
+def create_client(seed: int = 0):
+    random.seed(seed)
+    np.random.seed(seed)
+    params = minimal_params()
+    core = Core(params)
+    core.neurons = [Neuron(0, value=0.0), Neuron(1, value=0.0)]
+    core.synapses = []
+    core.add_synapse(0, 1, weight=0.5)
+    nb = Neuronenblitz(
+        core,
+        split_probability=0.0,
+        alternative_connection_prob=0.0,
+        backtrack_probability=0.0,
+        backtrack_enabled=False,
+    )
+    return core, nb
+
+
+def test_federated_round_updates_all_clients():
+    c1 = create_client(0)
+    c2 = create_client(1)
+    trainer = FederatedAveragingTrainer([c1, c2])
+    datasets = [[(1.0, 2.0)], [(0.5, 1.0)]]
+    trainer.train_round(datasets, epochs=1)
+    w1 = c1[0].synapses[0].weight
+    w2 = c2[0].synapses[0].weight
+    assert abs(w1 - w2) < 1e-6
+    assert w1 != 0.5

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -645,3 +645,12 @@ semi_supervised_learning:
   unlabeled_weight: Scaling factor applied to the consistency loss derived from
     the two unlabeled outputs. Values between ``0.1`` and ``1.0`` control how
     strongly the unlabeled data influences learning.
+
+federated_learning:
+  # Federated averaging trainer that coordinates multiple clients.
+  # Each round trains all local Neuronenblitz networks on their
+  # respective datasets before averaging synapse weights.
+  enabled: Enable federated training when set to ``true``.
+  rounds: Number of communication rounds performed.
+  local_epochs: Epochs of local training executed on each client per round.
+


### PR DESCRIPTION
## Summary
- implement `FederatedAveragingTrainer` for federated learning across Neuronenblitz clients
- document new YAML options
- expose new configurable parameters
- extend tutorial with federated learning project
- add basic federated learning test
- include defaults in `config.yaml`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d5659b5488327bcff1f570c7fc0cf