### PR TITLE
Implement curriculum learning paradigm

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -309,4 +309,12 @@ Each entry is listed under its section heading.
 - epochs
 - batch_size
 - unlabeled_weight
-\n## federated_learning\n- enabled\n- rounds\n- local_epochs\n
+## federated_learning
+- enabled
+- rounds
+- local_epochs
+
+## curriculum_learning
+- enabled
+- epochs
+- schedule

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -184,3 +184,13 @@ Experiment by modifying these options and combining features from multiple proje
 3. Provide a dataset list matching the clients to `train_round()` for each communication round.
 4. After training, examine synapse weights to confirm they were synchronised across clients.
 
+
+## Project 13 – Curriculum Learning (Frontier)
+
+**Goal:** Gradually introduce harder examples to improve stability.**
+
+1. Enable `curriculum_learning.enabled` in `config.yaml` and set `epochs` and `schedule`.
+2. Instantiate a `Neuronenblitz` network and a `CurriculumLearner`.
+3. Provide your dataset of `(input, target)` pairs ordered by a difficulty function.
+4. Call `CurriculumLearner.train()` to run through the curriculum.
+5. Monitor `learner.history` for loss values as harder samples are introduced.

--- a/config.yaml
+++ b/config.yaml
@@ -292,3 +292,7 @@ federated_learning:
   rounds: 1
   local_epochs: 1
 
+curriculum_learning:
+  enabled: false
+  epochs: 1
+  schedule: "linear"

--- a/curriculum_learning.py
+++ b/curriculum_learning.py
@@ -1,0 +1,41 @@
+from marble_imports import *
+from marble_core import perform_message_passing, Core
+from marble_neuronenblitz import Neuronenblitz
+
+class CurriculumLearner:
+    """Progressively trains on examples ordered by difficulty."""
+
+    def __init__(self, core: Core, nb: Neuronenblitz, difficulty_fn=None, schedule: str = "linear") -> None:
+        self.core = core
+        self.nb = nb
+        self.difficulty_fn = difficulty_fn if difficulty_fn is not None else (lambda pair: 0.0)
+        self.schedule = schedule
+        self.history: list[dict] = []
+
+    def _curriculum_threshold(self, epoch: int, total_epochs: int, n_samples: int) -> int:
+        if self.schedule == "exponential":
+            ratio = 1.0 - math.exp(-epoch)
+            max_ratio = 1.0 - math.exp(-total_epochs)
+            ratio /= max_ratio if max_ratio > 0 else 1.0
+        else:
+            ratio = epoch / total_epochs
+        return max(1, int(n_samples * ratio))
+
+    def train(self, dataset: list[tuple[float, float]], epochs: int = 1) -> list[float]:
+        data = list(dataset)
+        diffs = [self.difficulty_fn(p) for p in data]
+        ordered = [x for _, x in sorted(zip(diffs, data), key=lambda t: t[0])]
+        losses = []
+        n = len(ordered)
+        for ep in range(1, int(epochs) + 1):
+            upto = self._curriculum_threshold(ep, int(epochs), n)
+            subset = ordered[:upto]
+            for inp, target in subset:
+                out, path = self.nb.dynamic_wander(inp)
+                error = target - out
+                self.nb.apply_weight_updates_and_attention(path, error)
+                perform_message_passing(self.core)
+                loss = float(error * error)
+                losses.append(loss)
+                self.history.append({"input": float(inp), "target": float(target), "loss": loss})
+        return losses

--- a/tests/test_curriculum_learning.py
+++ b/tests/test_curriculum_learning.py
@@ -1,0 +1,15 @@
+from tests.test_core_functions import minimal_params
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from curriculum_learning import CurriculumLearner
+
+
+def test_curriculum_learning_runs():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    dataset = [(0.1, 0.1), (0.5, 0.5), (1.0, 1.0)]
+    learner = CurriculumLearner(core, nb, difficulty_fn=lambda p: abs(p[0]))
+    losses = learner.train(dataset, epochs=2)
+    assert len(losses) > 0
+    assert len(learner.history) == len(losses)

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -654,3 +654,12 @@ federated_learning:
   rounds: Number of communication rounds performed.
   local_epochs: Epochs of local training executed on each client per round.
 
+curriculum_learning:
+  # Progressive training strategy that orders examples by difficulty.
+  # The learner introduces harder examples as training progresses to
+  # stabilise optimisation and accelerate convergence.
+  enabled: Enable curriculum learning when ``true``.
+  epochs: Number of passes over the dataset with increasing difficulty.
+  schedule: Determines how quickly more difficult samples are added. Use
+    ``linear`` for a steady increase or ``exponential`` to focus on easy
+    examples longer.


### PR DESCRIPTION
## Summary
- add CurriculumLearner module for progressive training
- include configuration block and documentation
- extend YAML manual and parameter listings
- add tutorial project for curriculum learning
- test curriculum learning functionality

## Testing
- `PYTHONPATH=. pytest tests/test_curriculum_learning.py -q`
- `PYTHONPATH=. pytest tests/test_autoencoder_learning.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d58013d648327bb029dd1fff63672