### PR TITLE
Add Reptile meta learning paradigm

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -318,3 +318,8 @@ Each entry is listed under its section heading.
 - enabled
 - epochs
 - schedule
+## meta_learning
+- enabled
+- epochs
+- inner_steps
+- meta_lr

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ The MARBLE system is a modular neural architecture that begins with a Mandelbrot
 It also includes a new unsupervised Hebbian learning module that ties together message passing in the Core with Neuronenblitz path exploration.
 An autoencoder learning paradigm further reconstructs noisy inputs through Neuronenblitz wander paths integrated with the Core.
 A semi-supervised paradigm leverages both labeled and unlabeled data by applying consistency regularization directly through Neuronenblitz.
+A meta-learning module implements a Reptile-style algorithm allowing
+rapid adaptation to new tasks by blending weights from short inner
+training loops back into the main network.
 
 MARBLE can train on datasets provided as lists of ``(input, target)`` pairs or using PyTorch-style ``Dataset``/``DataLoader`` objects. Each sample must expose an ``input`` and ``target`` field. After training and saving a model, ``Brain.infer`` generates outputs when given only an input value.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -194,3 +194,13 @@ Experiment by modifying these options and combining features from multiple proje
 3. Provide your dataset of `(input, target)` pairs ordered by a difficulty function.
 4. Call `CurriculumLearner.train()` to run through the curriculum.
 5. Monitor `learner.history` for loss values as harder samples are introduced.
+
+## Project 14 – Meta Learning (Frontier)
+
+**Goal:** Adapt quickly to new tasks using the Reptile algorithm.**
+
+1. Enable `meta_learning.enabled` in `config.yaml` and configure `epochs`, `inner_steps` and `meta_lr`.
+2. Create a list of tasks, where each task is a list of `(input, target)` pairs.
+3. Instantiate a `MetaLearner` with your `Core` and `Neuronenblitz` objects.
+4. Call `MetaLearner.train_step(tasks)` inside a loop for the desired number of epochs.
+5. Inspect `learner.history` to track the average meta-loss across tasks.

--- a/config.yaml
+++ b/config.yaml
@@ -296,3 +296,8 @@ curriculum_learning:
   enabled: false
   epochs: 1
   schedule: "linear"
+meta_learning:
+  enabled: false
+  epochs: 1
+  inner_steps: 1
+  meta_lr: 0.1

--- a/meta_learning.py
+++ b/meta_learning.py
@@ -1,0 +1,52 @@
+from marble_imports import *
+from marble_core import perform_message_passing, Core
+from marble_neuronenblitz import Neuronenblitz
+import copy
+
+
+class MetaLearner:
+    """Reptile-style meta learning across multiple tasks."""
+
+    def __init__(self, core: Core, nb: Neuronenblitz, inner_steps: int = 1, meta_lr: float = 0.1) -> None:
+        self.core = core
+        self.nb = nb
+        self.inner_steps = int(inner_steps)
+        self.meta_lr = float(meta_lr)
+        self.history: list[dict] = []
+
+    def _get_weights(self, core: Core) -> list[float]:
+        return [syn.weight for syn in core.synapses]
+
+    def _set_weights(self, core: Core, weights: list[float]) -> None:
+        for syn, w in zip(core.synapses, weights):
+            syn.weight = float(w)
+
+    def train_step(self, tasks: list[list[tuple[float, float]]]) -> float:
+        if not tasks:
+            raise ValueError("at least one task required")
+        orig = self._get_weights(self.core)
+        task_weights = []
+        losses = []
+        for t in tasks:
+            c = copy.deepcopy(self.core)
+            nb = copy.deepcopy(self.nb)
+            nb.core = c
+            for _ in range(self.inner_steps):
+                for inp, tgt in t:
+                    out, path = nb.dynamic_wander(inp)
+                    err = tgt - out
+                    nb.apply_weight_updates_and_attention(path, err)
+                    perform_message_passing(c)
+            task_weights.append(self._get_weights(c))
+            val = 0.0
+            for inp, tgt in t:
+                pred, _ = nb.dynamic_wander(inp)
+                val += float((tgt - pred) ** 2)
+            losses.append(val / len(t))
+        avg = np.mean(task_weights, axis=0)
+        for syn, w_old, w_new in zip(self.core.synapses, orig, avg):
+            syn.weight = float(w_old + self.meta_lr * (w_new - w_old))
+        perform_message_passing(self.core)
+        loss = float(np.mean(losses))
+        self.history.append({"loss": loss})
+        return loss

--- a/tests/test_meta_learning.py
+++ b/tests/test_meta_learning.py
@@ -1,0 +1,35 @@
+import random
+import numpy as np
+from tests.test_core_functions import minimal_params
+from marble_core import Core, Neuron
+from marble_neuronenblitz import Neuronenblitz
+from meta_learning import MetaLearner
+
+
+def create_meta():
+    random.seed(0)
+    np.random.seed(0)
+    params = minimal_params()
+    core = Core(params)
+    core.neurons = [Neuron(0, value=0.0), Neuron(1, value=0.0)]
+    core.synapses = []
+    core.add_synapse(0, 1, weight=0.1)
+    nb = Neuronenblitz(
+        core,
+        split_probability=0.0,
+        alternative_connection_prob=0.0,
+        backtrack_probability=0.0,
+        backtrack_enabled=False,
+    )
+    return core, nb
+
+
+def test_meta_learning_updates_weights():
+    core, nb = create_meta()
+    learner = MetaLearner(core, nb, inner_steps=1, meta_lr=0.5)
+    tasks = [[(1.0, 2.0)], [(1.0, 3.0)]]
+    old_w = core.synapses[0].weight
+    loss = learner.train_step(tasks)
+    assert isinstance(loss, float)
+    assert core.synapses[0].weight != old_w
+    assert len(learner.history) == 1

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -663,3 +663,16 @@ curriculum_learning:
   schedule: Determines how quickly more difficult samples are added. Use
     ``linear`` for a steady increase or ``exponential`` to focus on easy
     examples longer.
+meta_learning:
+  # Reptile-style meta learning for rapid adaptation across tasks.
+  # Each task contains input-target pairs. The learner clones the
+  # current Core and Neuronenblitz, performs ``inner_steps`` of
+  # training on each task and then moves the main network weights
+  # toward the average of the task-specific weights using ``meta_lr``.
+  enabled: Set to ``true`` to activate meta learning during training.
+  epochs: Number of meta-training iterations over the provided tasks.
+  inner_steps: Training steps executed inside each temporary clone
+    before the meta update is applied. Typically between 1 and 5.
+  meta_lr: Step size used when blending task weights back into the
+    primary network. Values around ``0.1`` work well for most setups.
+


### PR DESCRIPTION
## Summary
- implement `MetaLearner` for Reptile-style meta learning
- support the new meta learning section in the default configuration
- document parameters in `CONFIGURABLE_PARAMETERS.md` and `yaml-manual.txt`
- mention meta learning in the README and tutorial
- test meta learning workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d59df00c08327a474375f6725d976