### PR TITLE
Add transfer learning paradigm

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -323,3 +323,8 @@ Each entry is listed under its section heading.
 - epochs
 - inner_steps
 - meta_lr
+## transfer_learning
+- enabled
+- epochs
+- batch_size
+- freeze_fraction

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A semi-supervised paradigm leverages both labeled and unlabeled data by applying
 A meta-learning module implements a Reptile-style algorithm allowing
 rapid adaptation to new tasks by blending weights from short inner
 training loops back into the main network.
+Transfer learning is supported through a new learner that freezes a
+fraction of synapses while fine-tuning on a different dataset.
 
 MARBLE can train on datasets provided as lists of ``(input, target)`` pairs or using PyTorch-style ``Dataset``/``DataLoader`` objects. Each sample must expose an ``input`` and ``target`` field. After training and saving a model, ``Brain.infer`` generates outputs when given only an input value.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -204,3 +204,16 @@ Experiment by modifying these options and combining features from multiple proje
 3. Instantiate a `MetaLearner` with your `Core` and `Neuronenblitz` objects.
 4. Call `MetaLearner.train_step(tasks)` inside a loop for the desired number of epochs.
 5. Inspect `learner.history` to track the average meta-loss across tasks.
+
+## Project 15 – Transfer Learning (Frontier)
+
+**Goal:** Fine-tune a pretrained MARBLE model on a new dataset while freezing
+a subset of synapses.**
+
+1. Enable `transfer_learning.enabled` in `config.yaml` and set `epochs`,
+   `batch_size` and `freeze_fraction`.
+2. Load an existing model or train a base model, then create a
+   `TransferLearner` with the `Core` and `Neuronenblitz` objects.
+3. Provide your new `(input, target)` pairs to `TransferLearner.train()`.
+4. Adjust `freeze_fraction` to control how many synapses stay fixed during
+   fine-tuning.

--- a/config.yaml
+++ b/config.yaml
@@ -301,3 +301,8 @@ meta_learning:
   epochs: 1
   inner_steps: 1
   meta_lr: 0.1
+transfer_learning:
+  enabled: false
+  epochs: 1
+  batch_size: 4
+  freeze_fraction: 0.5

--- a/marble_core.py
+++ b/marble_core.py
@@ -764,7 +764,13 @@ class Neuron:
 
 class Synapse:
     def __init__(
-        self, source, target, weight=1.0, synapse_type="standard", fatigue=0.0
+        self,
+        source,
+        target,
+        weight=1.0,
+        synapse_type="standard",
+        fatigue=0.0,
+        frozen: bool = False,
     ):
         self.source = source
         self.target = target
@@ -775,6 +781,7 @@ class Synapse:
         )
         self.created_at = datetime.now()
         self.fatigue = float(fatigue)
+        self.frozen = bool(frozen)
 
     def update_fatigue(self, increase: float, decay: float) -> None:
         """Update fatigue using a decay factor and additive increase."""
@@ -1177,11 +1184,33 @@ class Core:
         migrate("ram", "disk")
         self.check_memory_usage()
 
-    def add_synapse(self, source_id, target_id, weight=1.0, synapse_type="standard"):
-        syn = Synapse(source_id, target_id, weight=weight, synapse_type=synapse_type)
+    def add_synapse(
+        self,
+        source_id,
+        target_id,
+        weight=1.0,
+        synapse_type="standard",
+        frozen: bool = False,
+    ):
+        syn = Synapse(
+            source_id,
+            target_id,
+            weight=weight,
+            synapse_type=synapse_type,
+            frozen=frozen,
+        )
         self.neurons[source_id].synapses.append(syn)
         self.synapses.append(syn)
         return syn
+
+    def freeze_fraction_of_synapses(self, fraction: float) -> None:
+        """Randomly mark a fraction of synapses as frozen."""
+        if not 0.0 <= fraction <= 1.0:
+            raise ValueError("fraction must be between 0 and 1")
+        count = int(len(self.synapses) * fraction)
+        to_freeze = random.sample(self.synapses, count)
+        for syn in to_freeze:
+            syn.frozen = True
 
     def get_detailed_status(self):
         status = {}

--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -583,6 +583,8 @@ class Neuronenblitz:
     def apply_weight_updates_and_attention(self, path, error):
         path_length = len(path)
         for syn in path:
+            if getattr(syn, "frozen", False):
+                continue
             source_value = self.core.neurons[syn.source].value
             delta = self.weight_update_fn(source_value, error, path_length)
             if self.gradient_noise_std > 0:
@@ -617,6 +619,8 @@ class Neuronenblitz:
             )
         if self.weight_decay:
             for syn in self.core.synapses:
+                if getattr(syn, "frozen", False):
+                    continue
                 syn.weight *= 1.0 - self.weight_decay
         return path_length
 

--- a/tests/test_transfer_learning.py
+++ b/tests/test_transfer_learning.py
@@ -1,0 +1,24 @@
+from tests.test_core_functions import minimal_params
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from transfer_learning import TransferLearner
+
+
+def test_freeze_fraction_of_synapses():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    core.expand(num_new_neurons=2, num_new_synapses=2)
+    core.freeze_fraction_of_synapses(0.5)
+    frozen = [s for s in core.synapses if getattr(s, "frozen", False)]
+    assert 0 < len(frozen) <= len(core.synapses)
+
+
+def test_transfer_learning_runs():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    learner = TransferLearner(core, nb, freeze_fraction=0.5)
+    loss = learner.train_step(0.5, 1.0)
+    assert isinstance(loss, float)
+    assert learner.history

--- a/transfer_learning.py
+++ b/transfer_learning.py
@@ -1,0 +1,28 @@
+from marble_core import Core, perform_message_passing
+from marble_neuronenblitz import Neuronenblitz
+
+class TransferLearner:
+    """Fine-tune a pretrained network while freezing a subset of synapses."""
+
+    def __init__(self, core: Core, nb: Neuronenblitz, freeze_fraction: float = 0.5) -> None:
+        if not 0.0 <= freeze_fraction <= 1.0:
+            raise ValueError("freeze_fraction must be between 0 and 1")
+        self.core = core
+        self.nb = nb
+        self.freeze_fraction = float(freeze_fraction)
+        self.core.freeze_fraction_of_synapses(self.freeze_fraction)
+        self.history: list[dict] = []
+
+    def train_step(self, input_value: float, target_value: float) -> float:
+        output, path = self.nb.dynamic_wander(input_value)
+        error = target_value - output
+        self.nb.apply_weight_updates_and_attention(path, error)
+        perform_message_passing(self.core)
+        loss = float(error * error)
+        self.history.append({"loss": loss})
+        return loss
+
+    def train(self, examples: list[tuple[float, float]], epochs: int = 1) -> None:
+        for _ in range(int(epochs)):
+            for inp, tgt in examples:
+                self.train_step(float(inp), float(tgt))

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -675,4 +675,14 @@ meta_learning:
     before the meta update is applied. Typically between 1 and 5.
   meta_lr: Step size used when blending task weights back into the
     primary network. Values around ``0.1`` work well for most setups.
+transfer_learning:
+  # Fine-tune a pretrained model while keeping a portion of synapses fixed.
+  # ``freeze_fraction`` controls what percentage of synapses are marked as
+  # frozen before training begins. Frozen synapses do not receive weight
+  # updates in ``apply_weight_updates_and_attention``.
+  enabled: Set to ``true`` to run transfer learning updates.
+  epochs: Number of fine-tuning passes over the new dataset.
+  batch_size: Mini-batch size used during fine-tuning steps.
+  freeze_fraction: Fraction between ``0.0`` and ``1.0`` specifying the portion
+    of synapses that remain unchanged.
 


### PR DESCRIPTION
## Summary
- add transfer learning module
- allow freezing synapses in the core and skip updates in Neuronenblitz
- document new config options
- update README, tutorial and config lists
- test transfer learning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d5c0b6cf08327b2b32d67606dbe01