### PR TITLE
Add replay-based continual learning

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -328,3 +328,8 @@ Each entry is listed under its section heading.
 - epochs
 - batch_size
 - freeze_fraction
+
+## continual_learning
+- enabled
+- epochs
+- memory_size

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ rapid adaptation to new tasks by blending weights from short inner
 training loops back into the main network.
 Transfer learning is supported through a new learner that freezes a
 fraction of synapses while fine-tuning on a different dataset.
+Continual learning is enabled via a replay-based learner that revisits
+previous examples to prevent catastrophic forgetting between tasks.
 
 MARBLE can train on datasets provided as lists of ``(input, target)`` pairs or using PyTorch-style ``Dataset``/``DataLoader`` objects. Each sample must expose an ``input`` and ``target`` field. After training and saving a model, ``Brain.infer`` generates outputs when given only an input value.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -217,3 +217,15 @@ a subset of synapses.**
 3. Provide your new `(input, target)` pairs to `TransferLearner.train()`.
 4. Adjust `freeze_fraction` to control how many synapses stay fixed during
    fine-tuning.
+
+## Project 16 – Continual Learning (Frontier)
+
+**Goal:** Train sequential tasks while replaying previous examples.**
+
+1. Enable `continual_learning.enabled` in `config.yaml` and set `epochs` and
+   `memory_size`.
+2. Instantiate a `ReplayContinualLearner` with your `Core` and `Neuronenblitz`
+   objects.
+3. For each dataset that arrives over time, call `ReplayContinualLearner.train()`
+   to update the model while old examples are replayed from memory.
+4. Examine `learner.history` to monitor reconstruction loss across tasks.

--- a/config.yaml
+++ b/config.yaml
@@ -306,3 +306,8 @@ transfer_learning:
   epochs: 1
   batch_size: 4
   freeze_fraction: 0.5
+
+continual_learning:
+  enabled: false
+  epochs: 1
+  memory_size: 10

--- a/continual_learning.py
+++ b/continual_learning.py
@@ -1,0 +1,45 @@
+from marble_core import perform_message_passing, Core
+from marble_neuronenblitz import Neuronenblitz
+import random
+
+class ReplayContinualLearner:
+    """Experience replay based continual learning integrated with MARBLE."""
+
+    def __init__(self, core: Core, nb: Neuronenblitz, memory_size: int = 10) -> None:
+        self.core = core
+        self.nb = nb
+        self.memory_size = int(memory_size)
+        self.memory: list[tuple[float, float]] = []
+        self.history: list[dict] = []
+
+    def _store_example(self, pair: tuple[float, float]) -> None:
+        if len(self.memory) < self.memory_size:
+            self.memory.append(pair)
+        else:
+            idx = random.randrange(self.memory_size)
+            self.memory[idx] = pair
+
+    def _replay(self) -> None:
+        if not self.memory:
+            return
+        inp, target = random.choice(self.memory)
+        out, path = self.nb.dynamic_wander(inp)
+        error = target - out
+        self.nb.apply_weight_updates_and_attention(path, error)
+        perform_message_passing(self.core)
+
+    def train_step(self, input_value: float, target_value: float) -> float:
+        output, path = self.nb.dynamic_wander(input_value)
+        error = target_value - output
+        self.nb.apply_weight_updates_and_attention(path, error)
+        perform_message_passing(self.core)
+        self._store_example((input_value, target_value))
+        self._replay()
+        loss = float(error * error)
+        self.history.append({"loss": loss})
+        return loss
+
+    def train(self, examples: list[tuple[float, float]], epochs: int = 1) -> None:
+        for _ in range(int(epochs)):
+            for inp, tgt in examples:
+                self.train_step(float(inp), float(tgt))

--- a/tests/test_continual_learning.py
+++ b/tests/test_continual_learning.py
@@ -1,0 +1,27 @@
+from tests.test_core_functions import minimal_params
+from marble_core import Core, Neuron
+from marble_neuronenblitz import Neuronenblitz
+from continual_learning import ReplayContinualLearner
+
+
+def create_setup():
+    params = minimal_params()
+    core = Core(params)
+    core.neurons = [Neuron(0, value=0.0), Neuron(1, value=0.0)]
+    core.synapses = []
+    core.add_synapse(0, 1, weight=0.1)
+    nb = Neuronenblitz(
+        core,
+        split_probability=0.0,
+        alternative_connection_prob=0.0,
+        backtrack_probability=0.0,
+        backtrack_enabled=False,
+    )
+    return core, nb
+
+
+def test_continual_learning_train():
+    core, nb = create_setup()
+    learner = ReplayContinualLearner(core, nb, memory_size=2)
+    learner.train([(0.5, 1.0)], epochs=1)
+    assert len(learner.history) > 0

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -686,3 +686,15 @@ transfer_learning:
   freeze_fraction: Fraction between ``0.0`` and ``1.0`` specifying the portion
     of synapses that remain unchanged.
 
+continual_learning:
+  # Replay-based continual learning that stores a limited set of
+  # previous examples and replays them during training on new data.
+  # This mitigates catastrophic forgetting when tasks arrive
+  # sequentially without requiring complex weight consolidation.
+  enabled: Set to ``true`` to activate continual learning.
+  epochs: Number of passes over each incoming dataset. Typically
+    ``1`` or ``2`` is sufficient when replay memory is used.
+  memory_size: Maximum number of examples retained for replay. Larger
+    values offer better retention of old tasks but increase memory
+    usage. Reasonable ranges are between ``10`` and ``100``.
+


### PR DESCRIPTION
## Summary
- add `ReplayContinualLearner` for experience replay style continual learning
- document new `continual_learning` config in README, yaml-manual, and config files
- list new parameters in `CONFIGURABLE_PARAMETERS.md`
- extend tutorial with a Continual Learning project
- test the new learner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d5eacf6c883278d326977702eb01d