### PR TITLE
Add imitation learning support

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -333,3 +333,8 @@ Each entry is listed under its section heading.
 - enabled
 - epochs
 - memory_size
+
+## imitation_learning
+- enabled
+- epochs
+- max_history

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -229,3 +229,15 @@ a subset of synapses.**
 3. For each dataset that arrives over time, call `ReplayContinualLearner.train()`
    to update the model while old examples are replayed from memory.
 4. Examine `learner.history` to monitor reconstruction loss across tasks.
+
+## Project 17 – Imitation Learning (Exploration)
+
+**Goal:** Learn a policy directly from demonstration pairs.**
+
+1. Enable `imitation_learning.enabled` in `config.yaml` and set `epochs` and
+   `max_history`.
+2. Instantiate an `ImitationLearner` with your `Core` and `Neuronenblitz`
+   objects.
+3. Record demonstrations using `ImitationLearner.record(input, action)` then
+   call `ImitationLearner.train()` or `Neuronenblitz.imitation_train()`.
+4. Query `dynamic_wander` with new inputs to evaluate the cloned policy.

--- a/config.yaml
+++ b/config.yaml
@@ -311,3 +311,7 @@ continual_learning:
   enabled: false
   epochs: 1
   memory_size: 10
+imitation_learning:
+  enabled: false
+  epochs: 1
+  max_history: 10

--- a/imitation_learning.py
+++ b/imitation_learning.py
@@ -1,0 +1,40 @@
+from marble_imports import *
+from marble_core import perform_message_passing, Core
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from marble_neuronenblitz import Neuronenblitz
+
+class ImitationLearner:
+    """Behaviour cloning using MARBLE Core and Neuronenblitz."""
+
+    def __init__(self, core: Core, nb: 'Neuronenblitz', max_history: int = 100) -> None:
+        self.core = core
+        self.nb = nb
+        self.max_history = int(max_history)
+        self.dataset: list[tuple[float, float]] = []
+        self.history: list[dict] = []
+
+    def record(self, input_value: float, action: float) -> None:
+        """Store a demonstration pair for later training."""
+        self.dataset.append((float(input_value), float(action)))
+        if len(self.dataset) > self.max_history:
+            self.dataset.pop(0)
+
+    def train_step(self, input_value: float, action: float) -> float:
+        """Perform one behaviour cloning update for a single pair."""
+        output, path = self.nb.dynamic_wander(float(input_value))
+        error = float(action) - output
+        self.nb.apply_weight_updates_and_attention(path, error)
+        perform_message_passing(self.core)
+        loss = float(error * error)
+        self.history.append({"loss": loss})
+        return loss
+
+    def train(self, epochs: int = 1) -> None:
+        """Train over all recorded demonstrations."""
+        if not self.dataset:
+            return
+        for _ in range(int(epochs)):
+            for inp, act in list(self.dataset):
+                self.train_step(inp, act)

--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -1,6 +1,7 @@
 from marble_imports import *
 from marble_core import Neuron, SYNAPSE_TYPES, NEURON_TYPES, perform_message_passing
 from contrastive_learning import ContrastiveLearner
+from imitation_learning import ImitationLearner
 from marble_base import MetricsVisualizer
 import threading
 import multiprocessing as mp
@@ -725,6 +726,22 @@ class Neuronenblitz:
             for i in range(0, len(inputs), batch_size):
                 batch = inputs[i : i + batch_size]
                 last_loss = learner.train(batch)
+        return last_loss
+
+    def imitation_train(
+        self,
+        demonstrations: list[tuple[float, float]],
+        epochs: int = 1,
+        max_history: int = 100,
+    ) -> float:
+        """Train using behaviour cloning on demonstration pairs."""
+        learner = ImitationLearner(self.core, self, max_history=max_history)
+        for inp, act in demonstrations:
+            learner.record(float(inp), float(act))
+        last_loss = 0.0
+        for _ in range(int(epochs)):
+            for inp, act in demonstrations:
+                last_loss = learner.train_step(float(inp), float(act))
         return last_loss
 
     def update_synapse_type_attentions(self, path, loss, speed, size):

--- a/tests/test_imitation_learning.py
+++ b/tests/test_imitation_learning.py
@@ -1,0 +1,18 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from tests.test_core_functions import minimal_params
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from imitation_learning import ImitationLearner
+
+
+def test_imitation_learning_step():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    learner = ImitationLearner(core, nb, max_history=2)
+    learner.record(0.1, 0.5)
+    loss = learner.train_step(0.1, 0.5)
+    assert isinstance(loss, float)
+    assert len(learner.history) == 1

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -698,3 +698,16 @@ continual_learning:
     values offer better retention of old tasks but increase memory
     usage. Reasonable ranges are between ``10`` and ``100``.
 
+imitation_learning:
+  # Behaviour cloning of expert demonstrations using the ``ImitationLearner``.
+  # Each demonstration contains an input value and the corresponding action
+  # taken by the expert. The learner replays these demonstrations and
+  # adjusts synaptic weights so that Neuronenblitz reproduces the expert's
+  # behaviour for the same inputs.
+  enabled: Enable imitation learning updates. Set to ``true`` to process
+    recorded demonstrations after normal training.
+  epochs: Number of passes over the stored demonstrations. Values between
+    ``1`` and ``10`` work well for small datasets.
+  max_history: Maximum number of demonstration pairs kept in memory. Older
+    entries are removed once this limit is exceeded.
+


### PR DESCRIPTION
## Summary
- integrate new behaviour cloning module
- expose imitation training through `Neuronenblitz.imitation_train`
- document configuration options and tutorial project
- test imitation learning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d609f6d608327821392a778b5c4c1