### PR TITLE
Add Harmonic Resonance Learning

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -338,3 +338,9 @@ Each entry is listed under its section heading.
 - enabled
 - epochs
 - max_history
+
+## harmonic_resonance_learning
+- enabled
+- epochs
+- base_frequency
+- decay

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -241,3 +241,14 @@ a subset of synapses.**
 3. Record demonstrations using `ImitationLearner.record(input, action)` then
    call `ImitationLearner.train()` or `Neuronenblitz.imitation_train()`.
 4. Query `dynamic_wander` with new inputs to evaluate the cloned policy.
+
+## Project 18 – Harmonic Resonance Learning (Novel)
+
+**Goal:** Explore the experimental frequency-based paradigm.**
+
+1. Enable `harmonic_resonance_learning.enabled` in `config.yaml` and set
+   `epochs`, `base_frequency` and `decay` as desired.
+2. Instantiate `HarmonicResonanceLearner` with your `Core` and `Neuronenblitz`
+   objects.
+3. Call `train_step(value, target)` in a loop for the specified number of epochs.
+4. Inspect `learner.history` to monitor the frequency error over time.

--- a/config.yaml
+++ b/config.yaml
@@ -315,3 +315,8 @@ imitation_learning:
   enabled: false
   epochs: 1
   max_history: 10
+harmonic_resonance_learning:
+  enabled: false
+  epochs: 1
+  base_frequency: 1.0
+  decay: 0.99

--- a/harmonic_resonance_learning.py
+++ b/harmonic_resonance_learning.py
@@ -1,0 +1,35 @@
+from marble_imports import *
+from marble_core import perform_message_passing, Core
+from marble_neuronenblitz import Neuronenblitz
+
+class HarmonicResonanceLearner:
+    """Novel frequency-based learning paradigm."""
+
+    def __init__(self, core: Core, nb: Neuronenblitz, base_frequency: float = 1.0, decay: float = 0.99) -> None:
+        self.core = core
+        self.nb = nb
+        self.base_frequency = float(base_frequency)
+        self.decay = float(decay)
+        self.history: list[dict] = []
+
+    def _encode(self, value: float) -> cp.ndarray:
+        freq = self.base_frequency
+        rep = cp.zeros(self.core.rep_size, dtype=float)
+        rep[0] = cp.sin(freq * value)
+        if self.core.rep_size > 1:
+            rep[1] = cp.cos(freq * value)
+        return rep
+
+    def train_step(self, value: float, target: float) -> float:
+        rep = self._encode(value)
+        if CUDA_AVAILABLE:
+            self.core.neurons[0].representation = cp.asnumpy(rep)
+        else:
+            self.core.neurons[0].representation = cp.asnumpy(rep)
+        output, path = self.nb.dynamic_wander(value)
+        error = float(target - output)
+        self.nb.apply_weight_updates_and_attention(path, error)
+        perform_message_passing(self.core)
+        self.base_frequency *= self.decay
+        self.history.append({"input": value, "target": target, "error": error})
+        return error

--- a/tests/test_harmonic_resonance_learning.py
+++ b/tests/test_harmonic_resonance_learning.py
@@ -1,0 +1,15 @@
+from tests.test_core_functions import minimal_params
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from harmonic_resonance_learning import HarmonicResonanceLearner
+
+
+def test_harmonic_resonance_learning_runs():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    learner = HarmonicResonanceLearner(core, nb, base_frequency=1.0, decay=0.9)
+    err = learner.train_step(0.5, 1.0)
+    assert isinstance(err, float)
+    assert len(learner.history) == 1
+    assert learner.base_frequency < 1.0

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -711,3 +711,16 @@ imitation_learning:
   max_history: Maximum number of demonstration pairs kept in memory. Older
     entries are removed once this limit is exceeded.
 
+
+harmonic_resonance_learning:
+  # Experimental paradigm that embeds inputs as sinusoidal phases.
+  # Each step encodes the current value using ``base_frequency`` and updates
+  # ``base_frequency`` by multiplying it with ``decay`` after training.
+  enabled: Enable harmonic resonance learning when set to ``true``.
+  epochs: Number of passes over the dataset. Usually ``1`` or ``2`` is enough
+    for quick experiments.
+  base_frequency: Initial frequency used when computing sine and cosine
+    representations. Values around ``1.0`` keep phase changes gradual while
+    larger numbers increase oscillation speed.
+  decay: Multiplicative factor applied to ``base_frequency`` after each
+    training step. ``0.99`` slowly lowers the frequency over time.


### PR DESCRIPTION
## Summary
- add experimental Harmonic Resonance Learning module
- document new configuration options
- teach how to use the new paradigm in the tutorial
- add tests for the new learner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d63bacc748327b405722e609e0535