### PR TITLE
Add Synaptic Echo Learning paradigm

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -46,6 +46,8 @@ Each entry is listed under its section heading.
 - pretraining_epochs
 - min_cluster_k
 - cross_tier_migration
+- synapse_echo_length
+- synapse_echo_decay
 
 ## neuronenblitz
 - backtrack_probability
@@ -98,6 +100,7 @@ Each entry is listed under its section heading.
 - fatigue_decay
 - lr_adjustment_factor
 - momentum_coefficient
+- use_echo_modulation
 - reinforcement_learning_enabled
 - rl_discount
 - rl_epsilon
@@ -344,3 +347,8 @@ Each entry is listed under its section heading.
 - epochs
 - base_frequency
 - decay
+
+## synaptic_echo_learning
+- enabled
+- epochs
+- echo_influence

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -252,3 +252,17 @@ a subset of synapses.**
    objects.
 3. Call `train_step(value, target)` in a loop for the specified number of epochs.
 4. Inspect `learner.history` to monitor the frequency error over time.
+
+## Project 19 – Synaptic Echo Learning (Novel)
+
+**Goal:** Experiment with echo-modulated weight updates.**
+
+1. Enable `synaptic_echo_learning.enabled` in `config.yaml` and set
+   `epochs` and `echo_influence` as desired.
+2. Instantiate `SynapticEchoLearner` with your `Core` and `Neuronenblitz`
+   objects. The Neuronenblitz instance must have `use_echo_modulation`
+   enabled.
+3. Call `train_step(value, target)` repeatedly to train using the echo
+   mechanism.
+4. Examine `learner.history` and synapse echo buffers to understand how
+   past activations influence learning.

--- a/config.yaml
+++ b/config.yaml
@@ -41,6 +41,8 @@ core:
   pretraining_epochs: 0
   min_cluster_k: 2
   cross_tier_migration: true
+  synapse_echo_length: 5
+  synapse_echo_decay: 0.9
 neuronenblitz:
   backtrack_probability: 0.3
   consolidation_probability: 0.2
@@ -92,6 +94,7 @@ neuronenblitz:
   fatigue_decay: 0.95
   lr_adjustment_factor: 0.1
   momentum_coefficient: 0.0
+  use_echo_modulation: false
   reinforcement_learning_enabled: false
   rl_discount: 0.9
   rl_epsilon: 1.0
@@ -320,3 +323,7 @@ harmonic_resonance_learning:
   epochs: 1
   base_frequency: 1.0
   decay: 0.99
+synaptic_echo_learning:
+  enabled: false
+  epochs: 1
+  echo_influence: 1.0

--- a/synaptic_echo_learning.py
+++ b/synaptic_echo_learning.py
@@ -1,0 +1,26 @@
+from marble_imports import *
+from marble_core import perform_message_passing, Core
+from marble_neuronenblitz import Neuronenblitz
+
+class SynapticEchoLearner:
+    """Experimental learning paradigm using synaptic echo buffers."""
+
+    def __init__(self, core: Core, nb: Neuronenblitz, echo_influence: float = 1.0) -> None:
+        self.core = core
+        self.nb = nb
+        self.echo_influence = float(echo_influence)
+        self.nb.use_echo_modulation = True
+        self.history: list[dict] = []
+
+    def train_step(self, value: float, target: float) -> float:
+        out, path = self.nb.dynamic_wander(value)
+        error = target - out
+        self.nb.apply_weight_updates_and_attention(path, error * self.echo_influence)
+        perform_message_passing(self.core)
+        self.history.append({"input": value, "target": target, "error": float(error)})
+        return float(error)
+
+    def train(self, pairs: list[tuple[float, float]], epochs: int = 1) -> None:
+        for _ in range(int(epochs)):
+            for inp, tgt in pairs:
+                self.train_step(float(inp), float(tgt))

--- a/tests/test_synaptic_echo_learning.py
+++ b/tests/test_synaptic_echo_learning.py
@@ -1,0 +1,17 @@
+from tests.test_core_functions import minimal_params
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from synaptic_echo_learning import SynapticEchoLearner
+
+
+def test_synaptic_echo_learning_runs():
+    params = minimal_params()
+    params['synapse_echo_length'] = 3
+    params['synapse_echo_decay'] = 0.8
+    core = Core(params)
+    nb = Neuronenblitz(core, use_echo_modulation=True)
+    learner = SynapticEchoLearner(core, nb)
+    err = learner.train_step(0.5, 1.0)
+    assert isinstance(err, float)
+    assert any(s.echo_buffer for s in core.synapses)
+    assert learner.history

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -95,6 +95,11 @@ core:
     is invoked automatically.
   cross_tier_migration: When ``true`` neurons may move between tiers even if
     their age thresholds have not been reached.
+  synapse_echo_length: Number of past activations each synapse stores in its
+    echo buffer. Larger values retain longer history but increase memory usage.
+  synapse_echo_decay: Multiplicative factor applied to incoming activations
+    before they are appended to the echo buffer. Values in ``0.0``–``1.0``
+    gradually forget older activity.
 
 neuronenblitz:
   backtrack_probability: Probability between 0 and 1 that the wandering
@@ -216,6 +221,9 @@ neuronenblitz:
     ``0.0`` and ``1.0`` accelerate training by smoothing updates. Momentum is
     applied in ``apply_weight_updates_and_attention`` and is stored per-synapse
     so that frequently updated connections gain additional inertia.
+  use_echo_modulation: When ``true`` weight updates are multiplied by each
+    synapse's echo buffer average, enabling the synaptic echo learning
+    mechanism. Disable to revert to standard updates.
   reinforcement_learning_enabled: Turn on Q-learning inside Neuronenblitz. When
     enabled the ``rl_`` methods may be used to select actions and update
     values directly through the network.
@@ -724,3 +732,12 @@ harmonic_resonance_learning:
     larger numbers increase oscillation speed.
   decay: Multiplicative factor applied to ``base_frequency`` after each
     training step. ``0.99`` slowly lowers the frequency over time.
+
+synaptic_echo_learning:
+  # Uses the echo buffers stored on each synapse to modulate updates.
+  # Weight changes are scaled by the average echoed activity.
+  enabled: Activate the synaptic echo learner when ``true``.
+  epochs: Number of training epochs to run. Usually ``1`` or ``2`` is
+    sufficient for simple experiments.
+  echo_influence: Multiplier applied to the error signal before updating
+    weights. Larger values amplify the effect of echoed activations.


### PR DESCRIPTION
## Summary
- extend `Core`/`Synapse` with echo buffers
- add echo modulation support in `Neuronenblitz`
- implement new `SynapticEchoLearner`
- document new config options and tutorial section
- provide tests for synaptic echo learning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d65fdfa68832780067687125a1288