### PR TITLE
Introduce novel learning paradigms

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -352,3 +352,19 @@ Each entry is listed under its section heading.
 - enabled
 - epochs
 - echo_influence
+
+## fractal_dimension_learning
+- enabled
+- epochs
+- target_dimension
+
+## quantum_flux_learning
+- enabled
+- epochs
+- phase_rate
+
+## dream_reinforcement_learning
+- enabled
+- episodes
+- dream_cycles
+- dream_strength

--- a/ML_PARADIGMS_HANDBOOK.md
+++ b/ML_PARADIGMS_HANDBOOK.md
@@ -62,8 +62,16 @@ MARBLE watches demonstrations and tries to mimic them. It stores pairs of inputs
 An experimental method where inputs are encoded as sine waves. The frequency gradually changes, guiding MARBLE to capture periodic relationships.
 
 ### Synaptic Echo Learning
-Another experimental approach that reuses recent neuron activity stored in "echo" buffers. Past activations influence how weights update.
+Each synapse maintains an echo buffer of recent activations. Weight updates scale the normal error term by the mean echo value: (Delta w = ta,	ext{echo}	imes	ext{error}). This links short-term memory with learning dynamics.
 
+### Fractal Dimension Learning
+MARBLE monitors the fractal dimension of activations and increases representation size when it grows too high.
+
+### Quantum Flux Learning
+Weights are updated with a sinusoidal phase factor that evolves over time, creating oscillatory plasticity.
+
+### Dream Reinforcement Learning
+After each real update the network performs short dream rollouts and learns from their errors.
 ---
 
 ## Version for ML Scientists
@@ -140,6 +148,14 @@ Demonstration pairs \((s,a)\) are recorded. Loss is \(\|a - f(s)\|^2\). Training
 Inputs are represented as sinusoidal embeddings: \(r=[\sin(\omega x), \cos(\omega x)]\). After each step, frequency \(\omega\) decays by `decay`, allowing exploration of resonant structures in the data.
 
 ### Synaptic Echo Learning
+### Fractal Dimension Learning
+MARBLE monitors the fractal dimension of activations and increases representation size when it grows too high.
+
+### Quantum Flux Learning
+Weights are updated with a sinusoidal phase factor that evolves over time, creating oscillatory plasticity.
+
+### Dream Reinforcement Learning
+After each real update the network performs short dream rollouts and learns from their errors.
 Each synapse maintains an echo buffer of recent activations. Weight updates scale the normal error term by the mean echo value: \(\Delta w = \eta\,\text{echo}\times\text{error}\). This links short-term memory with learning dynamics.
 
 ---
@@ -204,5 +220,13 @@ By watching an expert perform actions, MARBLE records those moves and practices 
 This experimental idea turns numbers into sine waves before feeding them into MARBLE. The frequency slowly changes, helping the system notice repeating patterns.
 
 ### Synaptic Echo Learning
+### Fractal Dimension Learning
+MARBLE monitors the fractal dimension of activations and increases representation size when it grows too high.
+
+### Quantum Flux Learning
+Weights are updated with a sinusoidal phase factor that evolves over time, creating oscillatory plasticity.
+
+### Dream Reinforcement Learning
+After each real update the network performs short dream rollouts and learns from their errors.
 MARBLE keeps short memories of recent neuron activity. These echoes influence how the connections change, giving the network a sense of its immediate past.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -266,3 +266,30 @@ a subset of synapses.**
    mechanism.
 4. Examine `learner.history` and synapse echo buffers to understand how
    past activations influence learning.
+
+## Project 20 – Fractal Dimension Learning (Novel)
+
+**Goal:** Let MARBLE expand its representations when activity becomes complex.**
+
+1. Enable `fractal_dimension_learning.enabled` in `config.yaml` and set `epochs` and `target_dimension`.
+2. Create a `FractalDimensionLearner` with your `Core` and `Neuronenblitz` objects.
+3. Provide `(input, target)` pairs to `FractalDimensionLearner.train()`.
+4. Observe `core.rep_size` in `learner.history` to see when dimensions grow.
+
+## Project 21 – Quantum Flux Learning (Novel)
+
+**Goal:** Explore phase-modulated weight updates.**
+
+1. Enable `quantum_flux_learning.enabled` in `config.yaml` and set `epochs` and `phase_rate`.
+2. Instantiate `QuantumFluxLearner` using existing `Core` and `Neuronenblitz` instances.
+3. Call `train_step(input, target)` repeatedly to apply flux-based updates.
+4. Inspect `learner.phases` to understand how synapse phases evolve.
+
+## Project 22 – Dream Reinforcement Synergy (Novel)
+
+**Goal:** Combine dreaming with reinforcement-like updates.**
+
+1. Enable `dream_reinforcement_learning.enabled` in `config.yaml` and set `episodes`, `dream_cycles` and `dream_strength`.
+2. Instantiate `DreamReinforcementLearner` with your `Core` and `Neuronenblitz` objects.
+3. Use `train_episode(input, target)` for each interaction step.
+4. The `dream_cycles` parameter controls how many imaginary updates occur after each real one.

--- a/config.yaml
+++ b/config.yaml
@@ -327,3 +327,16 @@ synaptic_echo_learning:
   enabled: false
   epochs: 1
   echo_influence: 1.0
+fractal_dimension_learning:
+  enabled: false
+  epochs: 1
+  target_dimension: 4.0
+quantum_flux_learning:
+  enabled: false
+  epochs: 1
+  phase_rate: 0.1
+dream_reinforcement_learning:
+  enabled: false
+  episodes: 1
+  dream_cycles: 1
+  dream_strength: 0.5

--- a/dream_reinforcement_learning.py
+++ b/dream_reinforcement_learning.py
@@ -1,0 +1,34 @@
+from marble_imports import *
+from marble_core import perform_message_passing, Core
+from marble_neuronenblitz import Neuronenblitz
+
+class DreamReinforcementLearner:
+    """Hybrid reinforcement paradigm mixing real and dreamed experiences."""
+
+    def __init__(self, core: Core, nb: Neuronenblitz, dream_cycles: int = 1, dream_strength: float = 0.5) -> None:
+        self.core = core
+        self.nb = nb
+        self.dream_cycles = int(dream_cycles)
+        self.dream_strength = float(dream_strength)
+        self.history: list[dict] = []
+
+    def _dream_step(self, value: float) -> None:
+        dream_output, path = self.nb.dynamic_wander(value)
+        error = value - dream_output
+        self.nb.apply_weight_updates_and_attention(path, error * self.dream_strength)
+        perform_message_passing(self.core)
+
+    def train_episode(self, input_value: float, target_value: float) -> float:
+        output, path = self.nb.dynamic_wander(input_value)
+        error = target_value - output
+        self.nb.apply_weight_updates_and_attention(path, error)
+        perform_message_passing(self.core)
+        for _ in range(self.dream_cycles):
+            self._dream_step(output)
+        self.history.append({"error": float(error)})
+        return float(error)
+
+    def train(self, episodes: list[tuple[float, float]], repeat: int = 1) -> None:
+        for _ in range(int(repeat)):
+            for inp, tgt in episodes:
+                self.train_episode(float(inp), float(tgt))

--- a/fractal_dimension_learning.py
+++ b/fractal_dimension_learning.py
@@ -1,0 +1,44 @@
+from marble_imports import *
+from marble_core import perform_message_passing, Core
+from marble_neuronenblitz import Neuronenblitz
+from scipy.spatial.distance import pdist
+import numpy as np
+
+class FractalDimensionLearner:
+    """Adaptive paradigm adjusting representation size via fractal dimension."""
+
+    def __init__(self, core: Core, nb: Neuronenblitz, target_dimension: float = 4.0) -> None:
+        self.core = core
+        self.nb = nb
+        self.target_dimension = float(target_dimension)
+        self.history: list[dict] = []
+
+    def _estimate_dimension(self) -> float:
+        reps = np.stack([n.representation for n in self.core.neurons])
+        if reps.size == 0:
+            return 0.0
+        dists = pdist(reps)
+        if len(dists) == 0:
+            return 0.0
+        eps = float(np.median(dists))
+        counts = float(np.sum(dists < eps))
+        if eps <= 0 or counts <= 1:
+            return 0.0
+        return float(np.log(counts) / np.log(eps))
+
+    def train_step(self, input_value: float, target_value: float) -> float:
+        output, path = self.nb.dynamic_wander(input_value)
+        error = target_value - output
+        self.nb.apply_weight_updates_and_attention(path, error)
+        perform_message_passing(self.core)
+        dim = self._estimate_dimension()
+        if dim > self.target_dimension:
+            self.core.increase_representation_size(1)
+            self.target_dimension = self.core.rep_size * 0.8
+        self.history.append({"error": float(error), "dimension": dim})
+        return float(error)
+
+    def train(self, examples: list[tuple[float, float]], epochs: int = 1) -> None:
+        for _ in range(int(epochs)):
+            for inp, tgt in examples:
+                self.train_step(float(inp), float(tgt))

--- a/marble_core.py
+++ b/marble_core.py
@@ -3,6 +3,11 @@ from marble_base import MetricsVisualizer
 from typing import Hashable
 import copy
 from collections import deque
+import numpy as np
+import os
+import pickle
+import random
+from datetime import datetime
 
 # Representation size for GNN-style message passing
 _REP_SIZE = 4

--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -6,6 +6,9 @@ from marble_base import MetricsVisualizer
 import threading
 import multiprocessing as mp
 import pickle
+import random
+import numpy as np
+from datetime import datetime
 from collections import deque
 import math
 

--- a/quantum_flux_learning.py
+++ b/quantum_flux_learning.py
@@ -1,0 +1,41 @@
+from marble_imports import *
+from marble_core import perform_message_passing, Core
+from marble_neuronenblitz import Neuronenblitz
+import math
+
+class QuantumFluxLearner:
+    """Imaginary phase-based learning rule using per-synapse flux."""
+
+    def __init__(self, core: Core, nb: Neuronenblitz, phase_rate: float = 0.1) -> None:
+        self.core = core
+        self.nb = nb
+        self.phase_rate = float(phase_rate)
+        self.phases: dict = {}
+        self.history: list[dict] = []
+
+    def _get_phase(self, syn) -> float:
+        return self.phases.setdefault(syn, 0.0)
+
+    def train_step(self, input_value: float, target_value: float) -> float:
+        output, path = self.nb.dynamic_wander(input_value)
+        error = target_value - output
+        for syn in path:
+            phase = self._get_phase(syn)
+            amplitude = math.sin(phase)
+            delta = self.nb.weight_update_fn(
+                self.core.neurons[syn.source].value,
+                error * amplitude,
+                len(path),
+            )
+            if abs(delta) > self.nb.synapse_update_cap:
+                delta = math.copysign(self.nb.synapse_update_cap, delta)
+            syn.weight += self.nb.learning_rate * delta
+            self.phases[syn] = phase + self.phase_rate * float(error)
+        perform_message_passing(self.core)
+        self.history.append({"error": float(error)})
+        return float(error)
+
+    def train(self, examples: list[tuple[float, float]], epochs: int = 1) -> None:
+        for _ in range(int(epochs)):
+            for inp, tgt in examples:
+                self.train_step(float(inp), float(tgt))

--- a/tests/test_dream_reinforcement_learning.py
+++ b/tests/test_dream_reinforcement_learning.py
@@ -1,0 +1,18 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from tests.test_core_functions import minimal_params
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from dream_reinforcement_learning import DreamReinforcementLearner
+
+
+def test_dream_reinforcement_learning_runs():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    learner = DreamReinforcementLearner(core, nb, dream_cycles=1)
+    err = learner.train_episode(0.5, 1.0)
+    assert isinstance(err, float)
+    assert learner.history

--- a/tests/test_fractal_dimension_learning.py
+++ b/tests/test_fractal_dimension_learning.py
@@ -1,0 +1,18 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from tests.test_core_functions import minimal_params
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from fractal_dimension_learning import FractalDimensionLearner
+
+
+def test_fractal_dimension_learning_runs():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    learner = FractalDimensionLearner(core, nb, target_dimension=1.0)
+    err = learner.train_step(0.5, 1.0)
+    assert isinstance(err, float)
+    assert learner.history

--- a/tests/test_quantum_flux_learning.py
+++ b/tests/test_quantum_flux_learning.py
@@ -1,0 +1,18 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from tests.test_core_functions import minimal_params
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from quantum_flux_learning import QuantumFluxLearner
+
+
+def test_quantum_flux_learning_runs():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    learner = QuantumFluxLearner(core, nb, phase_rate=0.1)
+    err = learner.train_step(0.5, 1.0)
+    assert isinstance(err, float)
+    assert learner.history

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -741,3 +741,28 @@ synaptic_echo_learning:
     sufficient for simple experiments.
   echo_influence: Multiplier applied to the error signal before updating
     weights. Larger values amplify the effect of echoed activations.
+
+fractal_dimension_learning:
+  # Adjusts the representation size by estimating the fractal dimension of
+  # neuron embeddings. When the dimension exceeds ``target_dimension`` a new
+  # element is appended to each representation via ``Core.increase_representation_size``.
+  enabled: Enable fractal dimension learning when ``true``.
+  epochs: Number of passes over the dataset used to refine the estimate.
+  target_dimension: Threshold for the estimated dimension. Values between
+    2.0 and 6.0 work well for small graphs.
+
+quantum_flux_learning:
+  # Experimental rule associating a phase with every synapse. Weight updates
+  # are scaled by ``sin(phase)`` and the phase drifts by ``phase_rate``.
+  enabled: Activate quantum flux learning when set to ``true``.
+  epochs: Number of epochs using phase-modulated updates.
+  phase_rate: Amount added to each synapse's phase after each update.
+
+dream_reinforcement_learning:
+  # Combines regular reinforcement updates with short dream rollouts. After
+  # each real step ``dream_cycles`` additional wanders run using the last
+  # output as input and apply errors scaled by ``dream_strength``.
+  enabled: Enable dream reinforcement learning when ``true``.
+  episodes: Number of training episodes consisting of input-target pairs.
+  dream_cycles: How many dream updates follow each real step.
+  dream_strength: Multiplier applied to dream errors before weight updates.


### PR DESCRIPTION
## Summary
- add `FractalDimensionLearner` for adaptive representation growth
- add `QuantumFluxLearner` using oscillatory phase-modulated updates
- add `DreamReinforcementLearner` to combine real and dream rollouts
- document parameters and usage
- include tests for the new paradigms

## Testing
- `pytest tests/test_fractal_dimension_learning.py tests/test_quantum_flux_learning.py tests/test_dream_reinforcement_learning.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d6c60b3c4832792a739d3c7bfa37e