### PR TITLE
Improve tutorial and RL stability

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -285,6 +285,7 @@ Each entry is listed under its section heading.
 - epsilon_start
 - epsilon_decay
 - epsilon_min
+- seed
 
 ## contrastive_learning
 - enabled

--- a/config.yaml
+++ b/config.yaml
@@ -263,6 +263,7 @@ reinforcement_learning:
   epsilon_start: 1.0
   epsilon_decay: 0.95
   epsilon_min: 0.1
+  seed: 0
 contrastive_learning:
   enabled: false
   temperature: 0.5

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -583,6 +583,8 @@ reinforcement_learning:
   epsilon_start: Initial exploration rate for the epsilon-greedy policy.
   epsilon_decay: Multiplicative decay applied to ``epsilon`` after each update.
   epsilon_min: Lowest exploration rate allowed once ``epsilon`` has decayed.
+  seed: Integer random seed for reproducible training. Set to ``null`` to allow
+    nondeterministic runs.
 
 contrastive_learning:
   # Self-supervised contrastive representation learning using the


### PR DESCRIPTION
## Summary
- extend the instructions in `TUTORIAL.md` for greater detail
- stabilize reinforcement-learning training by adding a Q-table implementation and deterministic evaluation
- expose a `seed` option for reinforcement learning and document it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ddc96974c83279f912623858ba681