### PR TITLE
Add n-dimensional topology management

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -370,3 +370,10 @@ Each entry is listed under its section heading.
 - episodes
 - dream_cycles
 - dream_strength
+
+## n_dimensional_topology
+- enabled
+- target_dimensions
+- attention_threshold
+- loss_improve_threshold
+- stagnation_epochs

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -274,7 +274,7 @@ print(advanced_gpt.generate_text(marble.brain, 'Once upon a time'))
 ```
 Run `python project5_gpt_training.py` after enabling GPT settings in `config.yaml`.
 
-This final project introduces the **GPT components**, **distillation**, and the **dimensional search** capability if `dimensional_search.enabled` is set in the configuration.
+This final project introduces the **GPT components**, **distillation**, and the **dimensional search** capability if `dimensional_search.enabled` is set in the configuration. It also demonstrates the optional **n‑dimensional topology** feature controlled by `n_dimensional_topology.enabled`, which gradually expands the representation when learning stagnates.
 
 ## Project 6 – Reinforcement Learning (Master)
 

--- a/config.yaml
+++ b/config.yaml
@@ -342,3 +342,10 @@ dream_reinforcement_learning:
   episodes: 1
   dream_cycles: 1
   dream_strength: 0.5
+
+n_dimensional_topology:
+  enabled: false
+  target_dimensions: 6
+  attention_threshold: 0.8
+  loss_improve_threshold: 0.01
+  stagnation_epochs: 5

--- a/marble_brain.py
+++ b/marble_brain.py
@@ -258,6 +258,21 @@ class Brain:
                 plateau_epochs=dimensional_search_params.get("plateau_epochs", 2),
                 metrics_visualizer=self.metrics_visualizer,
             )
+        nd_params = core.params.get("n_dimensional_topology", {})
+        self.nd_topology = None
+        if nd_params.get("enabled", False):
+            from n_dimensional_topology import NDimensionalTopologyManager
+
+            self.nd_topology = NDimensionalTopologyManager(
+                self.core,
+                self.nb,
+                enabled=True,
+                target_dimensions=nd_params.get("target_dimensions", self.core.rep_size),
+                attention_threshold=nd_params.get("attention_threshold", 0.5),
+                loss_improve_threshold=nd_params.get("loss_improve_threshold", 0.01),
+                stagnation_epochs=nd_params.get("stagnation_epochs", 5),
+                metrics_visualizer=self.metrics_visualizer,
+            )
 
     def set_autograd_layer(self, layer):
         """Attach an autograd layer for benchmarking."""
@@ -425,6 +440,8 @@ class Brain:
                 )
             if self.dim_search is not None and val_loss is not None:
                 self.dim_search.evaluate(val_loss)
+            if self.nd_topology is not None and val_loss is not None:
+                self.nd_topology.evaluate(val_loss)
 
             epoch_time = time.time() - start_time
             if self.super_evo_controller is not None:

--- a/marble_core.py
+++ b/marble_core.py
@@ -1338,6 +1338,20 @@ class Core:
             neuron.representation = np.pad(neuron.representation, (0, delta))
         self.rep_size = new_size
 
+    def decrease_representation_size(self, delta: int = 1) -> None:
+        """Decrease representation dimensionality for all neurons."""
+        if delta <= 0:
+            return
+        if self.rep_size - delta < 1:
+            delta = self.rep_size - 1
+        if delta <= 0:
+            return
+        new_size = self.rep_size - delta
+        configure_representation_size(new_size)
+        for neuron in self.neurons:
+            neuron.representation = neuron.representation[:new_size]
+        self.rep_size = new_size
+
     # Built-in reinforcement learning utilities
     def enable_rl(self) -> None:
         """Enable Q-learning inside the core."""

--- a/n_dimensional_topology.py
+++ b/n_dimensional_topology.py
@@ -1,0 +1,85 @@
+class NDimensionalTopologyManager:
+    """Dynamically grow and shrink representation dimensions based on loss trends
+    and a self-attention signal from Neuronenblitz."""
+
+    def __init__(
+        self,
+        core,
+        nb,
+        enabled: bool = False,
+        target_dimensions: int | None = None,
+        attention_threshold: float = 0.5,
+        loss_improve_threshold: float = 0.01,
+        stagnation_epochs: int = 5,
+        metrics_visualizer=None,
+    ) -> None:
+        self.core = core
+        self.nb = nb
+        self.enabled = bool(enabled)
+        self.target_dimensions = (
+            target_dimensions if target_dimensions is not None else core.rep_size
+        )
+        self.attention_threshold = float(attention_threshold)
+        self.loss_improve_threshold = float(loss_improve_threshold)
+        self.stagnation_epochs = int(stagnation_epochs)
+        self.metrics_visualizer = metrics_visualizer
+        self.loss_history: list[float] = []
+        self.adding_dimension = False
+        self.loss_at_add = None
+        self.prev_size = core.rep_size
+
+    def _self_attention_score(self) -> float:
+        if not hasattr(self.nb, "type_attention"):
+            return 0.0
+        if not self.nb.type_attention:
+            return 0.0
+        return max(float(v) for v in self.nb.type_attention.values())
+
+    def evaluate(self, loss: float) -> None:
+        if not self.enabled:
+            return
+        self.loss_history.append(float(loss))
+        if len(self.loss_history) > self.stagnation_epochs:
+            self.loss_history.pop(0)
+
+        if self.adding_dimension:
+            if self.loss_at_add is None:
+                self.loss_at_add = loss
+                return
+            rel_drop = (self.loss_at_add - loss) / max(abs(self.loss_at_add), 1e-8)
+            if rel_drop >= self.loss_improve_threshold:
+                self.adding_dimension = False
+                self.loss_at_add = None
+                self.prev_size = self.core.rep_size
+                return
+            if len(self.loss_history) >= self.stagnation_epochs and all(
+                abs(self.loss_history[i] - self.loss_history[0]) < self.loss_improve_threshold
+                for i in range(len(self.loss_history))
+            ):
+                self.core.decrease_representation_size(1)
+                self.adding_dimension = False
+                self.loss_at_add = None
+                self.loss_history.clear()
+            return
+
+        if self.core.rep_size >= self.target_dimensions:
+            return
+
+        if len(self.loss_history) < self.stagnation_epochs:
+            return
+
+        if all(
+            abs(self.loss_history[i] - self.loss_history[0]) < self.loss_improve_threshold
+            for i in range(len(self.loss_history))
+        ):
+            attn = self._self_attention_score()
+            if attn >= self.attention_threshold:
+                self.core.increase_representation_size(1)
+                self.adding_dimension = True
+                self.loss_at_add = loss
+                self.loss_history.clear()
+                if self.metrics_visualizer is not None:
+                    self.metrics_visualizer.update({"ndim": self.core.rep_size})
+                return
+
+

--- a/tests/test_n_dimensional_topology.py
+++ b/tests/test_n_dimensional_topology.py
@@ -1,0 +1,38 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from tests.test_core_functions import minimal_params
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from n_dimensional_topology import NDimensionalTopologyManager
+
+
+def test_decrease_representation_size():
+    params = minimal_params()
+    core = Core(params)
+    initial = core.rep_size
+    core.increase_representation_size(2)
+    core.decrease_representation_size(1)
+    assert core.rep_size == initial + 1
+    for n in core.neurons:
+        assert len(n.representation) == core.rep_size
+
+
+def test_nd_topology_add_remove():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    manager = NDimensionalTopologyManager(
+        core,
+        nb,
+        enabled=True,
+        target_dimensions=core.rep_size + 1,
+        attention_threshold=0.0,
+        loss_improve_threshold=0.1,
+        stagnation_epochs=1,
+    )
+    manager.evaluate(1.0)  # stagnation triggers add
+    assert core.rep_size == params["representation_size"] + 1
+    manager.evaluate(1.0)  # no improvement -> remove
+    assert core.rep_size == params["representation_size"]

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -771,3 +771,15 @@ dream_reinforcement_learning:
   episodes: Number of training episodes consisting of input-target pairs.
   dream_cycles: How many dream updates follow each real step.
   dream_strength: Multiplier applied to dream errors before weight updates.
+
+n_dimensional_topology:
+  # Dynamically expands the representation size when learning stalls.
+  # A self-attention score compared with ``attention_threshold`` decides whether
+  # to add a new dimension. If the validation loss fails to improve by
+  # ``loss_improve_threshold`` within ``stagnation_epochs`` epochs, the extra
+  # dimension is removed and all neuron representations are truncated.
+  enabled: Turn on n-dimensional growth when ``true``.
+  target_dimensions: Upper bound on representation size.
+  attention_threshold: Minimum self-attention required before trying to grow.
+  loss_improve_threshold: Relative loss decrease needed to keep the new dimension.
+  stagnation_epochs: Number of stagnant epochs before another dimension may be added.


### PR DESCRIPTION
## Summary
- allow `Core` to decrease representation size
- introduce `NDimensionalTopologyManager` for dynamic dimensional growth
- wire the new manager into `marble_brain`
- document YAML parameters and tutorial updates
- add tests for the new functionality

## Testing
- `pytest -k n_dimensional_topology -q`

------
https://chatgpt.com/codex/tasks/task_e_687dfe279b088327a5cf0a55e878d2f2