### PR TITLE
Add memory tracking metrics

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -235,6 +235,7 @@ Each entry is listed under its section heading.
 - color_scheme
 - show_neuron_ids
 - dpi
+- track_memory_usage
 ## metrics_dashboard
 - enabled
 - host

--- a/config.yaml
+++ b/config.yaml
@@ -227,6 +227,7 @@ metrics_visualizer:
   color_scheme: "default"
   show_neuron_ids: false
   dpi: 100
+  track_memory_usage: false
 metrics_dashboard:
   enabled: false
   host: "localhost"

--- a/marble_base.py
+++ b/marble_base.py
@@ -1,4 +1,5 @@
 from marble_imports import *
+from system_metrics import get_system_memory_usage, get_gpu_memory_usage
 
 
 def clear_output(wait: bool = True) -> None:
@@ -101,6 +102,7 @@ class MetricsVisualizer:
         color_scheme="default",
         show_neuron_ids=False,
         dpi=100,
+        track_memory_usage=False,
     ):
         self.metrics = {
             "loss": [],
@@ -116,6 +118,8 @@ class MetricsVisualizer:
             "compression_ratio": [],
             "meta_loss_avg": [],
             "representation_variance": [],
+            "ram_usage": [],
+            "gpu_usage": [],
         }
         self.fig_width = fig_width
         self.fig_height = fig_height
@@ -123,6 +127,7 @@ class MetricsVisualizer:
         self.color_scheme = color_scheme
         self.show_neuron_ids = show_neuron_ids
         self.dpi = dpi
+        self.track_memory_usage = track_memory_usage
         self.setup_plot()
 
     def setup_plot(self):
@@ -137,6 +142,9 @@ class MetricsVisualizer:
             if key not in self.metrics:
                 self.metrics[key] = []
             self.metrics[key].append(value)
+        if self.track_memory_usage:
+            self.metrics["ram_usage"].append(get_system_memory_usage())
+            self.metrics["gpu_usage"].append(get_gpu_memory_usage())
         clear_output(wait=True)
         self.plot_metrics()
 
@@ -145,6 +153,14 @@ class MetricsVisualizer:
         self.ax.plot(self.metrics["loss"], "b-", label="Loss")
         self.ax_twin = self.ax.twinx()
         self.ax_twin.plot(self.metrics["vram_usage"], "r-", label="VRAM (MB)")
+        if self.track_memory_usage and self.metrics["ram_usage"]:
+            self.ax_twin.plot(
+                self.metrics["ram_usage"], "g-", label="RAM (MB)"
+            )
+        if self.track_memory_usage and self.metrics["gpu_usage"]:
+            self.ax_twin.plot(
+                self.metrics["gpu_usage"], "c-", label="GPU (MB)"
+            )
         if self.metrics["arousal"]:
             self.ax_twin.plot(self.metrics["arousal"], "g--", label="Arousal")
         if self.metrics["stress"]:

--- a/marble_brain.py
+++ b/marble_brain.py
@@ -6,6 +6,7 @@ from neuromodulatory_system import NeuromodulatorySystem
 from meta_parameter_controller import MetaParameterController
 from marble_base import MetricsVisualizer
 from marble_lobes import LobeManager
+from system_metrics import get_system_memory_usage, get_gpu_memory_usage
 
 
 def _parse_example(sample):
@@ -425,6 +426,8 @@ class Brain:
                     {
                         "loss": val_loss if val_loss is not None else 0.0,
                         "vram_usage": self.core.get_usage_by_tier("vram"),
+                        "ram_usage": get_system_memory_usage(),
+                        "gpu_usage": get_gpu_memory_usage(),
                         "arousal": ctx.get("arousal", 0.0),
                         "stress": ctx.get("stress", 0.0),
                         "reward": ctx.get("reward", 0.0),

--- a/marble_main.py
+++ b/marble_main.py
@@ -43,12 +43,18 @@ class MARBLE:
             "color_scheme": "default",
             "show_neuron_ids": False,
             "dpi": 100,
+            "track_memory_usage": False,
         }
         if mv_params is not None:
             mv_defaults.update(mv_params)
         self.metrics_visualizer = MetricsVisualizer(
             fig_width=mv_defaults["fig_width"],
             fig_height=mv_defaults["fig_height"],
+            refresh_rate=mv_defaults["refresh_rate"],
+            color_scheme=mv_defaults["color_scheme"],
+            show_neuron_ids=mv_defaults["show_neuron_ids"],
+            dpi=mv_defaults["dpi"],
+            track_memory_usage=mv_defaults["track_memory_usage"],
         )
         self.metrics_dashboard = None
         if dashboard_params is not None and dashboard_params.get("enabled", False):

--- a/marble_utils.py
+++ b/marble_utils.py
@@ -62,3 +62,5 @@ def core_from_json(json_str: str) -> Core:
         core.synapses.append(syn)
         core.neurons[syn.source].synapses.append(syn)
     return core
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -99,3 +99,4 @@ widgetsnbextension==4.0.14
 xxhash==3.5.0
 yarl==1.20.1
 zipp==3.23.0
+psutil==5.9.8

--- a/system_metrics.py
+++ b/system_metrics.py
@@ -1,0 +1,15 @@
+import psutil
+import torch
+
+
+def get_system_memory_usage() -> float:
+    """Return current system memory usage in megabytes."""
+    mem = psutil.virtual_memory()
+    return mem.used / (1024 ** 2)
+
+
+def get_gpu_memory_usage(device: int = 0) -> float:
+    """Return GPU memory usage in megabytes for ``device`` or 0.0 if CUDA unavailable."""
+    if torch.cuda.is_available():
+        return torch.cuda.memory_allocated(device) / (1024 ** 2)
+    return 0.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import json
 from marble_core import Core
 from marble_utils import core_to_json, core_from_json
+from system_metrics import get_system_memory_usage, get_gpu_memory_usage
 from tests.test_core_functions import minimal_params
 
 
@@ -16,3 +17,10 @@ def test_core_json_roundtrip():
     assert len(new_core.synapses) == len(core.synapses)
     # Compare a few attributes
     assert new_core.neurons[0].value == core.neurons[0].value
+
+
+def test_memory_usage_functions():
+    ram = get_system_memory_usage()
+    gpu = get_gpu_memory_usage()
+    assert isinstance(ram, float) and ram > 0
+    assert isinstance(gpu, float)

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -500,6 +500,9 @@ metrics_visualizer:
   show_neuron_ids: If true the plot displays neuron identifiers next to data
     points.
   dpi: Resolution of the output figure in dots per inch.
+  track_memory_usage: When true the visualizer records both system RAM and GPU
+    memory consumption after each training epoch. This requires the ``psutil``
+    package and uses ``torch.cuda`` when a CUDA-capable device is available.
 
 metrics_dashboard:
   # Optional web dashboard built with Plotly Dash for real-time monitoring.


### PR DESCRIPTION
## Summary
- add `track_memory_usage` option for MetricsVisualizer
- implement memory utilities in new `system_metrics` module
- display RAM and GPU metrics during training when enabled
- document new YAML option and default config
- test memory utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e0197d394832786fb32fbc58d7513