### PR TITLE
Add Continuous Weight Field Learning paradigm

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -379,6 +379,14 @@ Each entry is listed under its section heading.
 - dream_cycles
 - dream_strength
 
+## continuous_weight_field_learning
+- enabled
+- epochs
+- num_basis
+- bandwidth
+- reg_lambda
+- learning_rate
+
 ## n_dimensional_topology
 - enabled
 - target_dimensions

--- a/ML_PARADIGMS_HANDBOOK.md
+++ b/ML_PARADIGMS_HANDBOOK.md
@@ -72,6 +72,13 @@ Weights are updated with a sinusoidal phase factor that evolves over time, creat
 
 ### Dream Reinforcement Learning
 After each real update the network performs short dream rollouts and learns from their errors.
+
+### Continuous Weight Field Learning
+Instead of a fixed weight vector, MARBLE learns a smooth function \(W(x)\). Each
+input has its own weights, derived from radial basis functions. Neuronenblitz
+provides features \(\phi(x)\) and the prediction is \(\phi(x) \cdot W(x)\). A
+variational loss with a gradient regulariser ensures the field changes smoothly
+across \(x\).
 ---
 
 ## Version for ML Scientists
@@ -229,4 +236,9 @@ Weights are updated with a sinusoidal phase factor that evolves over time, creat
 ### Dream Reinforcement Learning
 After each real update the network performs short dream rollouts and learns from their errors.
 MARBLE keeps short memories of recent neuron activity. These echoes influence how the connections change, giving the network a sense of its immediate past.
+
+### Continuous Weight Field Learning
+Each input has its own weights generated from a smooth field. MARBLE uses the
+current neuron representations to compute a prediction and adjusts the field so
+nearby inputs share similar weights while matching their targets.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Continual learning is enabled via a replay-based learner that revisits
 previous examples to prevent catastrophic forgetting between tasks.
 An ``OmniLearner`` paradigm seamlessly unifies all available learners so
 that multiple approaches can train the same model in concert.
+Continuous Weight Field Learning introduces a variational method where each
+input has its own smoothly varying weight vector generated on the fly.
 
 MARBLE can train on datasets provided as lists of ``(input, target)`` pairs or using PyTorch-style ``Dataset``/``DataLoader`` objects. Each sample must expose an ``input`` and ``target`` field. After training and saving a model, ``Brain.infer`` generates outputs when given only an input value.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1010,3 +1010,38 @@ learner.train(examples, epochs=5)
 ```
 Run `python project23_omni.py` to test all paradigms together.
 
+## Project 24 – Continuous Weight Field Learning (Experimental)
+
+**Goal:** Train a smooth weight field that adapts to each input.**
+
+1. **Enable the learner** by setting `continuous_weight_field_learning.enabled: true` in `config.yaml` and optionally tweak `num_basis` or `bandwidth`.
+2. **Instantiate the learner**:
+   ```python
+   from continuous_weight_field_learning import ContinuousWeightFieldLearner
+   learner = ContinuousWeightFieldLearner(core, neuronenblitz)
+   ```
+3. **Download a dataset**. The diabetes set from scikit-learn provides real regression targets:
+   ```python
+   from sklearn.datasets import load_diabetes
+   ds = load_diabetes()
+   samples = list(zip(ds.data[:, 0], ds.target))
+   ```
+4. **Train** using `learner.train(samples, epochs=2)` and monitor `learner.history` for the squared error over time.
+
+**Complete Example**
+```python
+# project24_cwfl.py
+from config_loader import load_config
+from marble_main import MARBLE
+from continuous_weight_field_learning import ContinuousWeightFieldLearner
+from sklearn.datasets import load_diabetes
+
+cfg = load_config()
+marble = MARBLE(cfg['core'])
+learner = ContinuousWeightFieldLearner(marble.core, marble.neuronenblitz)
+ds = load_diabetes()
+samples = list(zip(ds.data[:, 0], ds.target))
+learner.train(samples, epochs=2)
+```
+Run `python project24_cwfl.py` to see the field adapt across the dataset.
+

--- a/config.yaml
+++ b/config.yaml
@@ -351,6 +351,14 @@ dream_reinforcement_learning:
   dream_cycles: 1
   dream_strength: 0.5
 
+continuous_weight_field_learning:
+  enabled: false
+  epochs: 1
+  num_basis: 10
+  bandwidth: 1.0
+  reg_lambda: 0.01
+  learning_rate: 0.01
+
 n_dimensional_topology:
   enabled: false
   target_dimensions: 6

--- a/continuous_weight_field_learning.py
+++ b/continuous_weight_field_learning.py
@@ -1,0 +1,63 @@
+from marble_imports import *
+from marble_core import perform_message_passing, Core
+from marble_neuronenblitz import Neuronenblitz
+
+
+class ContinuousWeightFieldLearner:
+    """Continuous Weight Field Learning integrated with MARBLE."""
+
+    def __init__(
+        self,
+        core: Core,
+        nb: Neuronenblitz,
+        num_basis: int = 10,
+        bandwidth: float = 1.0,
+        reg_lambda: float = 0.01,
+        learning_rate: float = 0.01,
+    ) -> None:
+        self.core = core
+        self.nb = nb
+        self.num_basis = int(num_basis)
+        self.bandwidth = float(bandwidth)
+        self.reg_lambda = float(reg_lambda)
+        self.learning_rate = float(learning_rate)
+        self.dim = self.core.rep_size
+        rs = np.random.RandomState(self.core.params.get("random_seed", 0))
+        self.centers = cp.asarray(rs.uniform(-1.0, 1.0, size=(self.num_basis, 1)))
+        self.weights = cp.zeros((self.num_basis, self.dim), dtype=float)
+        self.history: list[dict] = []
+
+    def _basis(self, x: float) -> cp.ndarray:
+        diff = x - self.centers
+        return cp.exp(-(diff ** 2) / (2 * self.bandwidth ** 2)).reshape(-1)
+
+    def _weight_vector(self, x: float) -> cp.ndarray:
+        phi = self._basis(x).reshape(1, -1)
+        return cp.dot(phi, self.weights).reshape(-1)
+
+    def train_step(self, inp: float, target: float) -> float:
+        rep_output, path = self.nb.dynamic_wander(inp)
+        perform_message_passing(self.core)
+        if path:
+            phi_x = cp.asarray(
+                self.core.neurons[path[-1].target].representation, dtype=float
+            )
+        else:
+            phi_x = cp.zeros(self.dim, dtype=float)
+        w_x = self._weight_vector(inp)
+        pred = cp.dot(phi_x, w_x)
+        error = float(target) - float(pred)
+        basis_vals = self._basis(inp)
+        for j in range(self.dim):
+            grad = basis_vals * error * float(phi_x[j])
+            self.weights[:, j] += self.learning_rate * grad
+            self.weights[:, j] -= self.learning_rate * self.reg_lambda * self.weights[:, j]
+        self.nb.apply_weight_updates_and_attention(path, error)
+        loss = float(error * error)
+        self.history.append({"input": float(inp), "target": float(target), "loss": loss})
+        return loss
+
+    def train(self, examples: list[tuple[float, float]], epochs: int = 1) -> None:
+        for _ in range(int(epochs)):
+            for x, y in examples:
+                self.train_step(float(x), float(y))

--- a/omni_learning.py
+++ b/omni_learning.py
@@ -16,6 +16,7 @@ from synaptic_echo_learning import SynapticEchoLearner
 from dream_reinforcement_learning import DreamReinforcementLearner
 from quantum_flux_learning import QuantumFluxLearner
 from fractal_dimension_learning import FractalDimensionLearner
+from continuous_weight_field_learning import ContinuousWeightFieldLearner
 
 
 class OmniLearner:
@@ -40,6 +41,7 @@ class OmniLearner:
         self.dream_rl = DreamReinforcementLearner(core, nb)
         self.quantum = QuantumFluxLearner(core, nb)
         self.fractal = FractalDimensionLearner(core, nb)
+        self.weight_field = ContinuousWeightFieldLearner(core, nb)
         self.env = GridWorld()
         self.rl_agent = MarbleQLearningAgent(core, nb)
 
@@ -61,6 +63,7 @@ class OmniLearner:
         self.dream_rl.train_episode(inp, target)
         self.quantum.train_step(inp, target)
         self.fractal.train_step(inp, target)
+        self.weight_field.train_step(inp, target)
         state = self.env.reset()
         action = self.rl_agent.select_action(state, self.env.n_actions)
         next_state, reward, done = self.env.step(action)

--- a/tests/test_continuous_weight_field_learning.py
+++ b/tests/test_continuous_weight_field_learning.py
@@ -1,0 +1,17 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from tests.test_core_functions import minimal_params
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from continuous_weight_field_learning import ContinuousWeightFieldLearner
+
+
+def test_cwfl_runs():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    learner = ContinuousWeightFieldLearner(core, nb, num_basis=3)
+    loss = learner.train_step(0.1, 0.2)
+    assert isinstance(loss, float)
+    assert loss >= 0.0

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -800,6 +800,21 @@ dream_reinforcement_learning:
   dream_cycles: How many dream updates follow each real step.
   dream_strength: Multiplier applied to dream errors before weight updates.
 
+continuous_weight_field_learning:
+  # Optimises a weight vector ``W(x)`` that varies smoothly with the input ``x``.
+  # The weight field is represented with radial basis functions whose centres
+  # span the input space. For each training sample MARBLE uses Neuronenblitz to
+  # produce a feature representation ``phi(x)`` from the core, then predicts
+  # ``phi(x) \cdot W(x)``. Weight field coefficients are updated via gradient
+  # descent with optional L2 regularisation.
+  enabled: Enable continuous weight field learning when set to ``true``.
+  epochs: Number of passes over the dataset to fit the field.
+  num_basis: Number of radial basis functions forming the field.
+  bandwidth: Standard deviation controlling basis width. Larger values make
+    the field smoother across inputs.
+  reg_lambda: Strength of L2 regularisation on the basis coefficients.
+  learning_rate: Step size for gradient descent updates of the field weights.
+
 n_dimensional_topology:
   # Dynamically expands the representation size when learning stalls.
   # A self-attention score compared with ``attention_threshold`` decides whether


### PR DESCRIPTION
## Summary
- implement `ContinuousWeightFieldLearner` with radial basis weight field
- integrate new learner into `OmniLearner`
- document new YAML parameters and update configuration
- extend handbook and tutorial with the new paradigm
- add tests for CWFL

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e17e95fd8832788ba89ac2213f827