### PR TITLE
Add Neural Schema Induction learning paradigm

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -387,6 +387,12 @@ Each entry is listed under its section heading.
 - reg_lambda
 - learning_rate
 
+## neural_schema_induction
+- enabled
+- epochs
+- support_threshold
+- max_schema_size
+
 ## n_dimensional_topology
 - enabled
 - target_dimensions

--- a/ML_PARADIGMS_HANDBOOK.md
+++ b/ML_PARADIGMS_HANDBOOK.md
@@ -73,6 +73,11 @@ Weights are updated with a sinusoidal phase factor that evolves over time, creat
 ### Dream Reinforcement Learning
 After each real update the network performs short dream rollouts and learns from their errors.
 
+### Neural Schema Induction
+Neuronenblitz traces are mined for frequent activation patterns. When a sequence
+appears in many examples the Core adds a new schema neuron connected to every
+step, allowing the full pattern to trigger as one concept in future reasoning.
+
 ### Continuous Weight Field Learning
 Instead of a fixed weight vector, MARBLE learns a smooth function \(W(x)\). Each
 input has its own weights, derived from radial basis functions. Neuronenblitz
@@ -165,6 +170,12 @@ Weights are updated with a sinusoidal phase factor that evolves over time, creat
 After each real update the network performs short dream rollouts and learns from their errors.
 Each synapse maintains an echo buffer of recent activations. Weight updates scale the normal error term by the mean echo value: \(\Delta w = \eta\,\text{echo}\times\text{error}\). This links short-term memory with learning dynamics.
 
+### Neural Schema Induction
+Let \(G_t\) be the set of observed activation graphs. Any subgraph \(P\) with
+\(\text{count}(P)\geq\tau\) triggers creation of an abstract node \(N_P\). This
+node connects to each vertex in \(P\), enabling higher-level reasoning chunks
+without gradient updates.
+
 ---
 
 ## Version for High School Students
@@ -236,6 +247,11 @@ Weights are updated with a sinusoidal phase factor that evolves over time, creat
 ### Dream Reinforcement Learning
 After each real update the network performs short dream rollouts and learns from their errors.
 MARBLE keeps short memories of recent neuron activity. These echoes influence how the connections change, giving the network a sense of its immediate past.
+
+### Neural Schema Induction
+The system spots repeating chains of reasoning steps. When a pattern shows up
+often enough it becomes its own neuron, so future tasks can recall the whole
+idea at once without relearning it.
 
 ### Continuous Weight Field Learning
 Each input has its own weights generated from a smooth field. MARBLE uses the

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ An ``OmniLearner`` paradigm seamlessly unifies all available learners so
 that multiple approaches can train the same model in concert.
 Continuous Weight Field Learning introduces a variational method where each
 input has its own smoothly varying weight vector generated on the fly.
+Neural Schema Induction grows new neurons representing frequently repeated
+reasoning patterns so the network can recall entire inference chains as single
+concepts.
 
 MARBLE can train on datasets provided as lists of ``(input, target)`` pairs or using PyTorch-style ``Dataset``/``DataLoader`` objects. Each sample must expose an ``input`` and ``target`` field. After training and saving a model, ``Brain.infer`` generates outputs when given only an input value.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1045,3 +1045,41 @@ learner.train(samples, epochs=2)
 ```
 Run `python project24_cwfl.py` to see the field adapt across the dataset.
 
+## Project 25 – Neural Schema Induction (Theory)
+
+**Goal:** Demonstrate structural learning of repeated reasoning patterns.**
+
+1. **Enable schema induction** by setting `neural_schema_induction.enabled: true`
+   in `config.yaml` and adjust `support_threshold` if needed.
+2. **Instantiate the learner**:
+   ```python
+   from neural_schema_induction import NeuralSchemaInductionLearner
+   learner = NeuralSchemaInductionLearner(core, neuronenblitz)
+   ```
+3. **Download a dataset** such as the digits and create a list of inputs only:
+   ```python
+   from sklearn.datasets import load_digits
+   digits = load_digits()
+   inputs = [x.reshape(-1).astype(float) for x in digits.data]
+   ```
+4. **Train** using `learner.train(inputs, epochs=2)` and inspect
+   `learner.schemas` to see the discovered patterns.
+
+**Complete Example**
+```python
+# project25_nsi.py
+from config_loader import load_config
+from marble_main import MARBLE
+from neural_schema_induction import NeuralSchemaInductionLearner
+from sklearn.datasets import load_digits
+
+cfg = load_config()
+marble = MARBLE(cfg['core'])
+learner = NeuralSchemaInductionLearner(marble.core, marble.neuronenblitz)
+digits = load_digits()
+inputs = [x.reshape(-1).astype(float) for x in digits.data]
+learner.train(inputs, epochs=2)
+print(len(learner.schemas))
+```
+Run `python project25_nsi.py` to see schema neurons emerge.
+

--- a/config.yaml
+++ b/config.yaml
@@ -359,6 +359,12 @@ continuous_weight_field_learning:
   reg_lambda: 0.01
   learning_rate: 0.01
 
+neural_schema_induction:
+  enabled: false
+  epochs: 1
+  support_threshold: 2
+  max_schema_size: 3
+
 n_dimensional_topology:
   enabled: false
   target_dimensions: 6

--- a/neural_schema_induction.py
+++ b/neural_schema_induction.py
@@ -1,0 +1,68 @@
+from collections import Counter
+from marble_imports import *
+from marble_core import Core, Neuron
+from marble_neuronenblitz import Neuronenblitz
+
+
+class NeuralSchemaInductionLearner:
+    """Discover and create schema neurons for frequently used paths."""
+
+    def __init__(
+        self,
+        core: Core,
+        nb: Neuronenblitz,
+        support_threshold: int = 2,
+        max_schema_size: int = 3,
+    ) -> None:
+        self.core = core
+        self.nb = nb
+        self.support_threshold = int(support_threshold)
+        self.max_schema_size = int(max_schema_size)
+        self.sequences: list[list[int]] = []
+        self.schemas: dict[tuple[int, ...], int] = {}
+        # disable weight learning
+        self.nb.learning_rate = 0.0
+        self.nb.weight_decay = 0.0
+
+    def _record_sequence(self, path: list) -> None:
+        if not path:
+            return
+        seq = [path[0].source]
+        seq.extend(syn.target for syn in path)
+        self.sequences.append(seq)
+
+    def _frequent_patterns(self) -> list[tuple[int, ...]]:
+        counts: Counter[tuple[int, ...]] = Counter()
+        for seq in self.sequences:
+            for length in range(2, self.max_schema_size + 1):
+                for i in range(len(seq) - length + 1):
+                    pat = tuple(seq[i : i + length])
+                    counts[pat] += 1
+        return [p for p, c in counts.items() if c >= self.support_threshold]
+
+    def _create_schema(self, pattern: tuple[int, ...]) -> None:
+        if pattern in self.schemas:
+            return
+        new_id = len(self.core.neurons)
+        tier = self.core.choose_new_tier()
+        neuron = Neuron(new_id, value=0.0, tier=tier, rep_size=self.core.rep_size)
+        self.core.neurons.append(neuron)
+        for nid in pattern:
+            self.core.add_synapse(new_id, nid, weight=1.0)
+            self.core.add_synapse(nid, new_id, weight=1.0)
+        self.schemas[pattern] = new_id
+
+    def _induce_schemas(self) -> None:
+        for pattern in self._frequent_patterns():
+            self._create_schema(pattern)
+
+    def train_step(self, input_value: float) -> float:
+        out, path = self.nb.dynamic_wander(float(input_value), apply_plasticity=False)
+        self._record_sequence(path)
+        self._induce_schemas()
+        return float(out) if isinstance(out, (int, float)) else float(np.mean(out))
+
+    def train(self, inputs: list[float], epochs: int = 1) -> None:
+        for _ in range(int(epochs)):
+            for inp in inputs:
+                self.train_step(float(inp))

--- a/omni_learning.py
+++ b/omni_learning.py
@@ -17,6 +17,7 @@ from dream_reinforcement_learning import DreamReinforcementLearner
 from quantum_flux_learning import QuantumFluxLearner
 from fractal_dimension_learning import FractalDimensionLearner
 from continuous_weight_field_learning import ContinuousWeightFieldLearner
+from neural_schema_induction import NeuralSchemaInductionLearner
 
 
 class OmniLearner:
@@ -42,6 +43,7 @@ class OmniLearner:
         self.quantum = QuantumFluxLearner(core, nb)
         self.fractal = FractalDimensionLearner(core, nb)
         self.weight_field = ContinuousWeightFieldLearner(core, nb)
+        self.schema = NeuralSchemaInductionLearner(core, nb)
         self.env = GridWorld()
         self.rl_agent = MarbleQLearningAgent(core, nb)
 
@@ -64,6 +66,7 @@ class OmniLearner:
         self.quantum.train_step(inp, target)
         self.fractal.train_step(inp, target)
         self.weight_field.train_step(inp, target)
+        self.schema.train_step(inp)
         state = self.env.reset()
         action = self.rl_agent.select_action(state, self.env.n_actions)
         next_state, reward, done = self.env.step(action)

--- a/tests/test_neural_schema_induction.py
+++ b/tests/test_neural_schema_induction.py
@@ -1,0 +1,18 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from tests.test_core_functions import minimal_params
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from neural_schema_induction import NeuralSchemaInductionLearner
+
+
+def test_neural_schema_induction_creates_schema():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    learner = NeuralSchemaInductionLearner(core, nb, support_threshold=2, max_schema_size=2)
+    initial = len(core.neurons)
+    for _ in range(5):
+        learner.train_step(0.5)
+    assert len(core.neurons) > initial
+    assert learner.schemas

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -815,6 +815,17 @@ continuous_weight_field_learning:
   reg_lambda: Strength of L2 regularisation on the basis coefficients.
   learning_rate: Step size for gradient descent updates of the field weights.
 
+neural_schema_induction:
+  # Structural learner that grows new "schema" neurons representing frequent
+  # reasoning patterns discovered during dynamic wanders. When a subsequence
+  # of neuron activations appears in at least ``support_threshold`` examples,
+  # the learner adds a new neuron connected to all participants in that
+  # sequence.
+  enabled: Enable neural schema induction when set to ``true``.
+  epochs: Number of passes over the dataset used for pattern collection.
+  support_threshold: Minimum number of occurrences before creating a schema.
+  max_schema_size: Maximum length of activation patterns considered.
+
 n_dimensional_topology:
   # Dynamically expands the representation size when learning stalls.
   # A self-attention score compared with ``attention_threshold`` decides whether


### PR DESCRIPTION
## Summary
- implement `NeuralSchemaInductionLearner` that creates schema neurons for frequent activation patterns
- integrate learner in `OmniLearner`
- expose configuration section `neural_schema_induction`
- document configurable parameters and YAML manual
- update ML paradigms handbook, tutorial and README
- add unit test

## Testing
- `pytest tests/test_neural_schema_induction.py -q`
- `pytest tests/test_core_functions.py::test_compute_mandelbrot_shape -q`

------
https://chatgpt.com/codex/tasks/task_e_687e1c930dc48327b4ad788bf670aa02