### PR TITLE
Add high-level convenience functions

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1173,4 +1173,43 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
    ```
 3. **Run the script** with `python project27_hybrid_memory.py`. The retrieved list should contain the key `'a'` showing the memory system found the correct entry.
 
+## Project 28 – Convenience Interface Functions (Easy)
+
+**Goal:** Utilise the high-level helper functions in `marble_interface` for rapid experiments.
+
+1. **Load a small dataset** directly from Hugging Face:
+   ```python
+   from marble_interface import load_hf_dataset
+
+   train_pairs = load_hf_dataset(
+       "mnist", "train[:100]", input_key="image", target_key="label"
+   )
+   ```
+2. **Create and train a MARBLE system** using a pandas dataframe:
+   ```python
+   import pandas as pd
+   from marble_interface import new_marble_system, train_from_dataframe
+
+   df = pd.DataFrame({"input": [0.1, 0.2], "target": [0.2, 0.4]})
+   marble = new_marble_system()
+   train_from_dataframe(marble, df, epochs=1)
+   ```
+3. **Evaluate and serialise the core** for later use:
+   ```python
+   from marble_interface import evaluate_marble_system, export_core_to_json
+
+   mse = evaluate_marble_system(marble, train_pairs[:10])
+   json_core = export_core_to_json(marble)
+   with open("core.json", "w", encoding="utf-8") as f:
+       f.write(json_core)
+   ```
+4. **Restore the core** to a fresh system when needed:
+   ```python
+   from marble_interface import import_core_from_json
+
+   with open("core.json", "r", encoding="utf-8") as f:
+       loaded_json = f.read()
+   restored = import_core_from_json(loaded_json)
+   ```
+
 

--- a/marble_utils.py
+++ b/marble_utils.py
@@ -1,4 +1,5 @@
 import json
+import numpy as np
 from marble_core import Core, Neuron, Synapse
 
 
@@ -8,7 +9,7 @@ def core_to_json(core: Core) -> str:
         "neurons": [
             {
                 "id": n.id,
-                "value": n.value,
+                "value": n.value.tolist() if hasattr(n.value, "tolist") else n.value,
                 "tier": n.tier,
                 "formula": str(n.formula) if n.formula is not None else None,
             }
@@ -47,7 +48,10 @@ def core_from_json(json_str: str) -> Core:
     core.neurons = []
     core.synapses = []
     for n in payload.get("neurons", []):
-        neuron = Neuron(n["id"], value=n["value"], tier=n.get("tier", "vram"))
+        val = n["value"]
+        if isinstance(val, list):
+            val = np.array(val)
+        neuron = Neuron(n["id"], value=val, tier=n.get("tier", "vram"))
         if n.get("formula"):
             neuron.formula = n["formula"]
         core.neurons.append(neuron)

--- a/tests/test_marble_interface.py
+++ b/tests/test_marble_interface.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import yaml
+from unittest.mock import patch
+import pandas as pd
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -20,6 +22,11 @@ from marble_interface import (
     train_marble_system,
     set_dreaming,
     set_autograd,
+    load_hf_dataset,
+    train_from_dataframe,
+    evaluate_marble_system,
+    export_core_to_json,
+    import_core_from_json,
 )
 
 
@@ -65,3 +72,42 @@ def test_toggle_features(tmp_path):
     assert m.get_autograd_layer() is not None
     set_autograd(m, False)
     assert m.get_autograd_layer() is None
+
+
+def test_load_dataset_and_dataframe_training(tmp_path):
+    marble_imports.tqdm = std_tqdm
+    marble_brain.tqdm = std_tqdm
+    marble_main.MetricsVisualizer = MetricsVisualizer
+
+    dummy = [{"input": 0.1, "target": 0.2}, {"input": 0.2, "target": 0.4}]
+    with patch("marble_interface.load_dataset", return_value=dummy):
+        pairs = load_hf_dataset("dummy", "train")
+    assert pairs == [(0.1, 0.2), (0.2, 0.4)]
+
+    cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.dump(cfg, f)
+
+    m = new_marble_system(str(cfg_path))
+    df = pd.DataFrame(dummy)
+    train_from_dataframe(m, df, epochs=1)
+    mse = evaluate_marble_system(m, pairs)
+    assert isinstance(mse, float)
+
+
+def test_export_and_import_core(tmp_path):
+    marble_imports.tqdm = std_tqdm
+    marble_brain.tqdm = std_tqdm
+    marble_main.MetricsVisualizer = MetricsVisualizer
+
+    cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.dump(cfg, f)
+
+    m = new_marble_system(str(cfg_path))
+    train_marble_system(m, [(0.1, 0.2)], epochs=1)
+    js = export_core_to_json(m)
+    m2 = import_core_from_json(js)
+    assert len(m2.get_core().neurons) == len(m.get_core().neurons)


### PR DESCRIPTION
## Summary
- implement dataset loading, dataframe training, evaluation and serialization helpers in `marble_interface`
- support JSON roundtrip with numpy arrays in `marble_utils`
- extend tutorial with new project using convenience functions
- add corresponding unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e2a9cb84483278c33975622c23037