### PR TITLE
Add Streamlit playground

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1213,3 +1213,20 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
    ```
 
 
+
+## Project 29 – Streamlit Playground (Easy)
+
+**Goal:** Interactively explore MARBLE through a web-based GUI.
+
+1. **Install Streamlit** (already in `requirements.txt`).
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. **Launch the playground** from the repository root:
+   ```bash
+   streamlit run streamlit_playground.py
+   ```
+3. **Upload a CSV dataset** with `input` and `target` columns in the sidebar, set the desired number of epochs and click **Train**.
+4. **Perform inference** by entering a numeric value under the *Inference* section and pressing **Infer**. Training metrics appear automatically after each run.
+
+The playground provides toggles for dreaming and autograd features so you can experiment with MARBLE's advanced capabilities without writing code.

--- a/requirements.txt
+++ b/requirements.txt
@@ -100,3 +100,4 @@ widgetsnbextension==4.0.14
 xxhash==3.5.0
 yarl==1.20.1
 zipp==3.23.0
+streamlit==1.35.0

--- a/streamlit_playground.py
+++ b/streamlit_playground.py
@@ -1,0 +1,65 @@
+import streamlit as st
+import pandas as pd
+
+from marble_interface import (
+    new_marble_system,
+    train_marble_system,
+    infer_marble_system,
+    set_dreaming,
+    set_autograd,
+)
+
+
+def load_examples(file) -> list[tuple[float, float]]:
+    """Load training examples from a CSV file object."""
+    df = pd.read_csv(file)
+    return list(zip(df["input"].astype(float), df["target"].astype(float)))
+
+
+def initialize_marble(cfg_path: str):
+    """Create a MARBLE system using a YAML configuration path."""
+    return new_marble_system(cfg_path)
+
+
+def run_playground() -> None:
+    """Launch the Streamlit MARBLE playground."""
+    st.set_page_config(page_title="MARBLE Playground")
+    st.title("MARBLE Playground")
+
+    if "marble" not in st.session_state:
+        st.session_state["marble"] = None
+
+    cfg_path = st.sidebar.text_input("Config YAML", "config.yaml")
+    if st.sidebar.button("Initialize MARBLE"):
+        st.session_state["marble"] = initialize_marble(cfg_path)
+        st.sidebar.success("System initialized")
+
+    marble = st.session_state.get("marble")
+    if marble is None:
+        st.info("Initialize MARBLE to begin.")
+        return
+
+    dreaming = st.sidebar.checkbox("Dreaming", value=marble.get_brain().dreaming_active)
+    set_dreaming(marble, dreaming)
+
+    autograd = st.sidebar.checkbox("Autograd", value=marble.get_autograd_layer() is not None)
+    set_autograd(marble, autograd)
+
+    train_file = st.sidebar.file_uploader("Training CSV", type="csv")
+    epochs = st.sidebar.number_input("Epochs", min_value=1, value=1, step=1)
+    if st.sidebar.button("Train") and train_file is not None:
+        examples = load_examples(train_file)
+        train_marble_system(marble, examples, epochs=epochs)
+        st.sidebar.success("Training complete")
+        if marble.get_metrics_visualizer().fig:
+            st.pyplot(marble.get_metrics_visualizer().fig)
+
+    st.header("Inference")
+    val = st.number_input("Input Value", value=0.0, format="%f")
+    if st.button("Infer"):
+        out = infer_marble_system(marble, float(val))
+        st.write(f"Output: {out}")
+
+
+if __name__ == "__main__":
+    run_playground()

--- a/tests/test_streamlit_playground.py
+++ b/tests/test_streamlit_playground.py
@@ -1,0 +1,27 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import yaml
+from unittest import mock
+
+import pandas as pd
+
+from tests.test_core_functions import minimal_params
+
+from streamlit_playground import load_examples, initialize_marble
+
+
+def test_load_examples(tmp_path):
+    path = tmp_path / "data.csv"
+    path.write_text("input,target\n0.1,0.2\n0.2,0.4\n")
+    with open(path, "r", encoding="utf-8") as f:
+        ex = load_examples(f)
+    assert ex == [(0.1, 0.2), (0.2, 0.4)]
+
+
+def test_initialize_marble(tmp_path):
+    cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.dump(cfg, f)
+    m = initialize_marble(str(cfg_path))
+    assert len(m.get_core().neurons) > 0


### PR DESCRIPTION
## Summary
- add new Streamlit playground for MARBLE experimentation
- document the playground in the tutorial
- add simple tests for loading examples and creating a MARBLE instance
- include Streamlit in requirements

## Testing
- `pytest tests/test_streamlit_playground.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687e32c15aa8832799bd796932fedd20