### PR TITLE
Improve MARBLE playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ streamlit run streamlit_playground.py
 
 Upload CSV, JSON or ZIP datasets containing any mix of numbers, text, images or
 audio. The inference panel accepts the same modalities so you can explore how
-different data types influence the system in real time.
+different data types influence the system in real time. Models may be saved and
+loaded from the sidebar, and you can export or import the core JSON for
+experimentation. Advanced mode now displays function docstrings and generates
+widgets for each parameter so every capability of the ``marble_interface`` can
+be invoked without writing code.
 
 ## Possible MARBLE Backcronyms
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1233,5 +1233,11 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
 4. **Perform inference** by providing a numeric value, text, image or audio
    sample under the *Inference* section and pressing **Infer**. Training metrics
    appear automatically after each run.
+5. **Save and load models** using the sidebar controls. You can also export or
+   import the core JSON to share systems between sessions.
+6. **Switch to Advanced mode** to access every function in
+   ``marble_interface``. The playground displays each function's docstring and
+   generates widgets for all parameters so you can call any operation directly.
 
-The playground provides toggles for dreaming and autograd features so you can experiment with MARBLE's advanced capabilities without writing code.
+The playground provides toggles for dreaming and autograd features so you can
+experiment with MARBLE's advanced capabilities without writing code.

--- a/tests/test_streamlit_playground.py
+++ b/tests/test_streamlit_playground.py
@@ -1,4 +1,5 @@
 import os, sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import yaml
 from unittest import mock
@@ -16,6 +17,10 @@ from streamlit_playground import (
     initialize_marble,
     list_marble_functions,
     execute_marble_function,
+    save_marble_system,
+    load_marble_system,
+    export_core_to_json,
+    import_core_from_json,
 )
 
 
@@ -69,3 +74,22 @@ def test_execute_marble_function(tmp_path):
     assert "count_marble_synapses" in funcs
     out = execute_marble_function("count_marble_synapses", m)
     assert isinstance(out, int)
+
+
+def test_save_load_and_core_roundtrip(tmp_path):
+    cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.dump(cfg, f)
+    m = initialize_marble(str(cfg_path))
+
+    save_path = tmp_path / "model.pkl"
+    save_marble_system(m, str(save_path))
+    assert save_path.exists()
+
+    m2 = load_marble_system(str(save_path))
+    assert len(m2.get_core().neurons) == len(m.get_core().neurons)
+
+    js = export_core_to_json(m)
+    m3 = import_core_from_json(js)
+    assert len(m3.get_core().neurons) == len(m.get_core().neurons)


### PR DESCRIPTION
## Summary
- expose model save/load and core import/export in playground
- auto-generate widgets for advanced function parameters with docs
- add tests for new save/load utilities
- document playground improvements in README and tutorial

## Testing
- `pytest tests/test_streamlit_playground.py::test_save_load_and_core_roundtrip -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e3b3c617c832793363cacfd7439e5