### PR TITLE
Enhance Streamlit playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,13 @@ streamlit run streamlit_playground.py
 ```
 
 Upload CSV, JSON or ZIP datasets containing any mix of numbers, text, images or
-audio. The inference panel accepts the same modalities so you can explore how
-different data types influence the system in real time. Models may be saved and
-loaded from the sidebar, and you can export or import the core JSON for
-experimentation. Advanced mode now displays function docstrings and generates
-widgets for each parameter so every capability of the ``marble_interface`` can
-be invoked without writing code.
+audio. Provide a YAML configuration by path, file upload or inline text before
+initializing the system. The inference panel accepts the same modalities so you
+can explore how different data types influence the system in real time. Models
+may be saved and loaded from the sidebar, and you can export or import the core
+JSON for experimentation. Advanced mode displays function docstrings and
+generates widgets for each parameter so every capability of the
+``marble_interface`` can be invoked without writing code.
 
 ## Possible MARBLE Backcronyms
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1226,16 +1226,19 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
    ```bash
    streamlit run streamlit_playground.py
    ```
-3. **Upload a dataset** in CSV, JSON or ZIP format. ZIP archives may contain
+3. **Provide a configuration.** Enter a YAML path, upload a YAML file or paste
+   YAML directly in the sidebar. Press **Initialize MARBLE** to create the
+   system.
+4. **Upload a dataset** in CSV, JSON or ZIP format. ZIP archives may contain
    `dataset.csv`/`dataset.json` or paired `inputs/` and `targets/` folders with
    images or audio files. Any mixture of numbers, text, images and audio is
    supported. Select the desired number of epochs and click **Train**.
-4. **Perform inference** by providing a numeric value, text, image or audio
+5. **Perform inference** by providing a numeric value, text, image or audio
    sample under the *Inference* section and pressing **Infer**. Training metrics
    appear automatically after each run.
-5. **Save and load models** using the sidebar controls. You can also export or
+6. **Save and load models** using the sidebar controls. You can also export or
    import the core JSON to share systems between sessions.
-6. **Switch to Advanced mode** to access every function in
+7. **Switch to Advanced mode** to access every function in
    ``marble_interface``. The playground displays each function's docstring and
    generates widgets for all parameters so you can call any operation directly.
 

--- a/tests/test_streamlit_playground.py
+++ b/tests/test_streamlit_playground.py
@@ -64,6 +64,13 @@ def test_initialize_marble(tmp_path):
     assert len(m.get_core().neurons) > 0
 
 
+def test_initialize_marble_with_yaml_text(tmp_path):
+    cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}
+    yaml_str = yaml.dump(cfg)
+    m = initialize_marble(None, yaml_text=yaml_str)
+    assert len(m.get_core().neurons) > 0
+
+
 def test_execute_marble_function(tmp_path):
     cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}
     cfg_path = tmp_path / "cfg.yaml"


### PR DESCRIPTION
## Summary
- enable initializing MARBLE via uploaded/pasted YAML
- update docs with new playground instructions
- add unit test for YAML text initialization

## Testing
- `pytest tests/test_streamlit_playground.py::test_initialize_marble_with_yaml_text -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_687e3dd581c4832787bf62f78447f022