### PR TITLE
Upgrade Streamlit playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ can explore how different data types influence the system in real time. Models
 may be saved and loaded from the sidebar, and you can export or import the core
 JSON for experimentation. Advanced mode displays function docstrings and
 generates widgets for each parameter so every capability of the
-``marble_interface`` can be invoked without writing code.
+``marble_interface`` can be invoked without writing code. The sidebar now
+previews uploaded datasets and shows the active configuration YAML so you can
+verify exactly what will be used for training and inference.
 
 ## Possible MARBLE Backcronyms
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1242,5 +1242,10 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
    ``marble_interface``. The playground displays each function's docstring and
    generates widgets for all parameters so you can call any operation directly.
 
+Uploaded datasets are previewed directly in the sidebar so you can verify their
+contents before training. The currently active YAML configuration is also shown
+in an expandable panel for quick reference. Use these previews to ensure your
+data and settings are correct before experimenting.
+
 The playground provides toggles for dreaming and autograd features so you can
 experiment with MARBLE's advanced capabilities without writing code.

--- a/tests/test_streamlit_playground.py
+++ b/tests/test_streamlit_playground.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import yaml
@@ -23,6 +24,8 @@ from streamlit_playground import (
     import_core_from_json,
     load_hf_examples,
     start_metrics_dashboard,
+    preview_file_dataset,
+    preview_hf_dataset,
 )
 
 
@@ -125,3 +128,21 @@ def test_load_hf_examples_and_dashboard(tmp_path):
         dash = start_metrics_dashboard(DummyMarble(), port=8062)
         start.assert_called_once()
         assert dash.port == 8062
+
+
+def test_dataset_previews(tmp_path):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("input,target\n1,2\n3,4\n")
+    with open(csv_path, "rb") as f:
+        df = preview_file_dataset(f)
+    assert isinstance(df, pd.DataFrame)
+    assert list(df.columns) == ["input", "target"]
+    assert df.shape[0] == 2
+
+    with mock.patch(
+        "streamlit_playground.load_hf_examples",
+        return_value=[(0.1, 0.2), (0.2, 0.4)],
+    ):
+        df2 = preview_hf_dataset("dummy", "train")
+    assert isinstance(df2, pd.DataFrame)
+    assert df2.shape == (2, 2)


### PR DESCRIPTION
## Summary
- enhance the Streamlit playground with dataset previews and YAML display
- expose helper functions to preview datasets
- show preview of selected training and evaluation data
- document new features in the README and tutorial
- test dataset preview helpers

## Testing
- `pytest tests/test_streamlit_playground.py::test_dataset_previews -q`

------
https://chatgpt.com/codex/tasks/task_e_687e41ca70388327a67997c0d8f01903