### PR TITLE
Upgrade playground with pipeline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,12 @@ can explore how different data types influence the system in real time. Models
 may be saved and loaded from the sidebar, and you can export or import the core
 JSON for experimentation. Advanced mode displays function docstrings and
 generates widgets for each parameter so every capability of the
-``marble_interface`` can be invoked without writing code. The sidebar now
-previews uploaded datasets and shows the active configuration YAML so you can
-verify exactly what will be used for training and inference.
+``marble_interface`` can be invoked without writing code. Modules from the
+repository are also exposed and you can construct a **pipeline** of function
+calls that execute sequentially. This makes it possible to combine training,
+evaluation and utility operations into a single workflow directly from the UI.
+The sidebar now previews uploaded datasets and shows the active configuration
+YAML so you can verify exactly what will be used for training and inference.
 
 ## Possible MARBLE Backcronyms
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1241,6 +1241,10 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
 7. **Switch to Advanced mode** to access every function in
    ``marble_interface``. The playground displays each function's docstring and
    generates widgets for all parameters so you can call any operation directly.
+8. **Build pipelines** on the *Pipeline* tab. Add steps from
+   ``marble_interface`` or any repository module, then press **Run Pipeline** to
+   execute them sequentially. This lets you combine training, evaluation and
+   analysis commands without leaving the UI.
 
 Uploaded datasets are previewed directly in the sidebar so you can verify their
 contents before training. The currently active YAML configuration is also shown

--- a/tests/test_streamlit_playground.py
+++ b/tests/test_streamlit_playground.py
@@ -163,3 +163,29 @@ def test_module_listing_and_execution():
     with mock.patch("importlib.import_module", return_value=dummy):
         out = execute_module_function("dummy", "test_func", x=1)
     assert out == 2
+
+
+def test_execute_function_sequence(tmp_path):
+    cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.dump(cfg, f)
+    m = initialize_marble(str(cfg_path))
+
+    steps = [
+        {"func": "count_marble_synapses"},
+        {
+            "module": "reinforcement_learning",
+            "func": "train_gridworld",
+            "params": {"episodes": 1},
+        },
+    ]
+
+    with mock.patch(
+        "streamlit_playground.execute_module_function",
+        return_value="ok",
+    ) as mod_exec:
+        results = execute_function_sequence(steps, m)
+    assert isinstance(results, list)
+    assert len(results) == 2
+    mod_exec.assert_called_once()


### PR DESCRIPTION
## Summary
- enhance `streamlit_playground` with a pipeline builder for running sequences of functions
- document pipeline usage in README and TUTORIAL
- test new `execute_function_sequence` helper

## Testing
- `pytest -k streamlit_playground -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687e46bbbcf48327a72ac66dafbac249