### PR TITLE
Improve MARBLE playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ generates widgets for each parameter so every capability of the
 repository are also exposed and you can construct a **pipeline** of function
 calls that execute sequentially. This makes it possible to combine training,
 evaluation and utility operations into a single workflow directly from the UI.
+Pipelines can be imported or exported as JSON and a **Custom Code** tab lets you
+run arbitrary Python snippets with the active MARBLE instance.
 The sidebar now previews uploaded datasets and shows the active configuration
 YAML so you can verify exactly what will be used for training and inference.
 

--- a/tests/test_streamlit_playground.py
+++ b/tests/test_streamlit_playground.py
@@ -21,6 +21,7 @@ from streamlit_playground import (
     list_repo_modules,
     list_module_functions,
     execute_module_function,
+    execute_function_sequence,
     save_marble_system,
     load_marble_system,
     export_core_to_json,
@@ -29,6 +30,9 @@ from streamlit_playground import (
     start_metrics_dashboard,
     preview_file_dataset,
     preview_hf_dataset,
+    save_pipeline_to_json,
+    load_pipeline_from_json,
+    run_custom_code,
 )
 
 
@@ -189,3 +193,24 @@ def test_execute_function_sequence(tmp_path):
     assert isinstance(results, list)
     assert len(results) == 2
     mod_exec.assert_called_once()
+
+
+def test_pipeline_save_load(tmp_path):
+    pipeline = [{"func": "count_marble_synapses"}]
+    path = tmp_path / "pipe.json"
+    save_pipeline_to_json(pipeline, path)
+    assert path.exists()
+    with open(path, "r", encoding="utf-8") as f:
+        loaded = load_pipeline_from_json(f)
+    assert loaded == pipeline
+
+
+def test_run_custom_code(tmp_path):
+    cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.dump(cfg, f)
+    m = initialize_marble(str(cfg_path))
+    code = "result = len(marble.get_core().neurons)"
+    out = run_custom_code(code, m)
+    assert out == len(m.get_core().neurons)


### PR DESCRIPTION
## Summary
- extend Streamlit playground with pipeline load/save and custom code tab
- add helpers for pipeline persistence and code execution
- expand README to mention new features
- test pipeline roundtrip and custom code execution

## Testing
- `ruff check streamlit_playground.py tests/test_streamlit_playground.py --fix`
- `pytest tests/test_streamlit_playground.py::test_pipeline_save_load tests/test_streamlit_playground.py::test_run_custom_code -q`


------
https://chatgpt.com/codex/tasks/task_e_687e48e955f883278c6dfa51a7917de5