### PR TITLE
Enhance Streamlit playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ Pipelines can be imported or exported as JSON and a **Custom Code** tab lets you
 run arbitrary Python snippets with the active MARBLE instance.
 The sidebar now previews uploaded datasets and shows the active configuration
 YAML so you can verify exactly what will be used for training and inference.
+An additional **Visualization** tab renders an interactive graph of the core so
+you can inspect neuron connectivity in real time. The sidebar also contains a
+collapsible YAML manual for quick reference while experimenting.
 
 ## Possible MARBLE Backcronyms
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1245,6 +1245,9 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
    ``marble_interface`` or any repository module, then press **Run Pipeline** to
    execute them sequentially. This lets you combine training, evaluation and
    analysis commands without leaving the UI.
+9. **View the core graph** on the *Visualization* tab. Press **Generate Graph**
+   to see an interactive display of neurons and synapses.
+10. **Consult the YAML manual** from the sidebar while adjusting parameters.
 
 Uploaded datasets are previewed directly in the sidebar so you can verify their
 contents before training. The currently active YAML configuration is also shown

--- a/tests/test_streamlit_playground.py
+++ b/tests/test_streamlit_playground.py
@@ -33,6 +33,9 @@ from streamlit_playground import (
     save_pipeline_to_json,
     load_pipeline_from_json,
     run_custom_code,
+    core_to_networkx,
+    core_figure,
+    load_yaml_manual,
 )
 
 
@@ -214,3 +217,20 @@ def test_run_custom_code(tmp_path):
     code = "result = len(marble.get_core().neurons)"
     out = run_custom_code(code, m)
     assert out == len(m.get_core().neurons)
+
+
+def test_core_network_visualization(tmp_path):
+    cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.dump(cfg, f)
+    m = initialize_marble(str(cfg_path))
+    g = core_to_networkx(m.get_core())
+    assert g.number_of_nodes() == len(m.get_core().neurons)
+    fig = core_figure(m.get_core())
+    assert hasattr(fig, "to_dict")
+
+
+def test_load_yaml_manual_text():
+    text = load_yaml_manual()
+    assert "core:" in text


### PR DESCRIPTION
## Summary
- show YAML manual in the sidebar
- add networkx graph visualization for the core
- expose visualization tab in the Streamlit UI
- document new features in README and TUTORIAL
- test new helper utilities

## Testing
- `pip install -r requirements.txt` *(fails: resolution impossible)*
- `pip install --no-deps -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_687e5ae053dc8327befdaa7701d9a777