### PR TITLE
Enhance playground with config editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ calls that execute sequentially. This makes it possible to combine training,
 evaluation and utility operations into a single workflow directly from the UI.
 Pipelines can be imported or exported as JSON and a **Custom Code** tab lets you
 run arbitrary Python snippets with the active MARBLE instance.
+The advanced interface now features a **Config Editor** tab where any
+parameter from the YAML configuration can be modified on the fly.  Changes are
+applied immediately and you can re-initialise the system with the updated
+configuration without leaving the browser.
 The sidebar now previews uploaded datasets and shows the active configuration
 YAML so you can verify exactly what will be used for training and inference.
 An additional **Visualization** tab renders an interactive graph of the core so

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1247,7 +1247,10 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
    analysis commands without leaving the UI.
 9. **View the core graph** on the *Visualization* tab. Press **Generate Graph**
    to see an interactive display of neurons and synapses.
-10. **Consult the YAML manual** from the sidebar while adjusting parameters.
+10. **Edit configuration** from the *Config Editor* tab. Specify any dot-
+    separated parameter path and new value to update the YAML in place. Press
+    **Reinitialize** to rebuild the system with the modified settings.
+11. **Consult the YAML manual** from the sidebar while adjusting parameters.
 
 Uploaded datasets are previewed directly in the sidebar so you can verify their
 contents before training. The currently active YAML configuration is also shown

--- a/tests/test_streamlit_playground.py
+++ b/tests/test_streamlit_playground.py
@@ -36,6 +36,7 @@ from streamlit_playground import (
     core_to_networkx,
     core_figure,
     load_yaml_manual,
+    set_yaml_value,
 )
 
 
@@ -234,3 +235,17 @@ def test_core_network_visualization(tmp_path):
 def test_load_yaml_manual_text():
     text = load_yaml_manual()
     assert "core:" in text
+
+
+def test_set_yaml_value_simple():
+    yaml_text = "a:\n  b: 1\n"
+    new = set_yaml_value(yaml_text, "a.b", 2)
+    cfg = yaml.safe_load(new)
+    assert cfg["a"]["b"] == 2
+
+
+def test_set_yaml_value_nested_creation():
+    yaml_text = "a: {}\n"
+    new = set_yaml_value(yaml_text, "a.c.d", 5)
+    cfg = yaml.safe_load(new)
+    assert cfg["a"]["c"]["d"] == 5


### PR DESCRIPTION
## Summary
- extend `streamlit_playground` with a YAML config editor
- add helper `set_yaml_value` and integrate into Streamlit UI
- test new helper
- document new features in README and TUTORIAL

## Testing
- `pip install --use-deprecated=legacy-resolver -r requirements.txt`
- `pytest -k streamlit_playground`

------
https://chatgpt.com/codex/tasks/task_e_687e5d0b40e88327bd4601928fa0cd23