### PR TITLE
Enhance playground pipeline editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ pretrained model from the Hugging Face Hub and converting it into a MARBLE
 system with one click.
 Pipelines can be imported or exported as JSON and a **Custom Code** tab lets you
 run arbitrary Python snippets with the active MARBLE instance.
+Pipeline steps may also be reordered or removed directly from the UI so complex
+workflows can be iterated on quickly.
 The advanced interface now features a **Config Editor** tab where any
 parameter from the YAML configuration can be modified on the fly.  Changes are
 applied immediately and you can re-initialise the system with the updated

--- a/tests/test_streamlit_playground.py
+++ b/tests/test_streamlit_playground.py
@@ -32,6 +32,8 @@ from streamlit_playground import (
     preview_hf_dataset,
     save_pipeline_to_json,
     load_pipeline_from_json,
+    move_pipeline_step,
+    remove_pipeline_step,
     run_custom_code,
     core_to_networkx,
     core_figure,
@@ -210,6 +212,18 @@ def test_pipeline_save_load(tmp_path):
     with open(path, "r", encoding="utf-8") as f:
         loaded = load_pipeline_from_json(f)
     assert loaded == pipeline
+
+
+def test_pipeline_move_and_remove():
+    pipe = [
+        {"func": "a"},
+        {"func": "b"},
+        {"func": "c"},
+    ]
+    move_pipeline_step(pipe, 2, 0)
+    assert [s["func"] for s in pipe] == ["c", "a", "b"]
+    remove_pipeline_step(pipe, 1)
+    assert [s["func"] for s in pipe] == ["c", "b"]
 
 
 def test_run_custom_code(tmp_path):


### PR DESCRIPTION
## Summary
- allow editing pipeline steps in `streamlit_playground`
- mention new editing features in README
- test pipeline step movement and removal

## Testing
- `pip install -r requirements.txt` *(fails: ResolutionImpossible)*
- `pytest tests/test_streamlit_playground.py -k move_and_remove -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_687e60d591708327bc5cc1d7c1644e2c