### PR TITLE
Fix requirements.txt conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,13 +49,13 @@ narwhals==1.47.1
 nest-asyncio==1.6.0
 networkx==3.3
 nodeenv==1.9.1
-numpy==2.1.2
-packaging==25.0
+numpy==1.26.4
+packaging==24.0
 pandas==2.3.1
 parso==0.8.4
 pathspec==0.12.1
 pexpect==4.9.0
-pillow==11.0.0
+pillow==10.3.0
 platformdirs==4.3.8
 plotly==6.2.0
 pluggy==1.6.0


### PR DESCRIPTION
## Summary
- pin numpy to 1.26.4 to satisfy packages that require `<2`
- pin packaging to 24.0 to meet streamlit's `<25` constraint
- pin pillow to 10.3.0 for compatibility with streamlit

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e637221a0832786beedb397b0ccff