### PR TITLE
Extend MARBLE playground with offloading tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ YAML so you can verify exactly what will be used for training and inference.
 An additional **Visualization** tab renders an interactive graph of the core so
 you can inspect neuron connectivity in real time. The sidebar also contains a
 collapsible YAML manual for quick reference while experimenting.
+The playground now includes an **Offloading** tab. This lets you start a
+``RemoteBrainServer`` or create a ``RemoteBrainClient`` directly from the UI and
+attach it to the running system. You can also spin up a torrent client with its
+own tracker to distribute lobes among peers. High‑attention regions of the brain
+may then be offloaded to the remote server or shared via torrent with a single
+button press.
 
 ## Possible MARBLE Backcronyms
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1254,6 +1254,11 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
 12. **Convert Hugging Face models** on the *Model Conversion* tab. Enter a
     model name, preview its architecture and click **Convert to MARBLE** to
     initialize a system from the pretrained weights.
+13. **Experiment with offloading** using the *Offloading* tab. Start a
+    ``RemoteBrainServer`` or create a torrent client directly from the
+    interface and attach it to the active MARBLE instance. Use the provided
+    buttons to offload high‑attention lobes to the remote server or share them
+    with peers via torrent.
 
 Uploaded datasets are previewed directly in the sidebar so you can verify their
 contents before training. The currently active YAML configuration is also shown


### PR DESCRIPTION
## Summary
- add helper utilities for remote/torrent offloading in playground
- provide Offloading tab in Streamlit UI
- document Offloading tab in README and TUTORIAL
- test new helpers

## Testing
- `ruff check streamlit_playground.py tests/test_streamlit_playground.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e6fa51f708327ac6c2edd9f0d7055