### PR TITLE
Extend Streamlit playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ attach it to the running system. You can also spin up a torrent client with its
 own tracker to distribute lobes among peers. High‑attention regions of the brain
 may then be offloaded to the remote server or shared via torrent with a single
 button press.
+A dedicated **Metrics** tab graphs loss, memory usage and other statistics in
+real time inside the browser. Another **Documentation** tab provides quick
+access to the README, YAML manual and full tutorial without leaving the
+playground.
 
 ## Possible MARBLE Backcronyms
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1262,6 +1262,11 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
     interface and attach it to the active MARBLE instance. Use the provided
     buttons to offload high‑attention lobes to the remote server or share them
     with peers via torrent.
+15. **Monitor progress** on the *Metrics* tab. Loss, memory usage and other
+    statistics are plotted live so you can observe training behaviour.
+16. **Read the documentation** on the *Documentation* tab. The README, YAML
+    manual and tutorial are available directly in the browser for quick
+    reference.
 
 Uploaded datasets are previewed directly in the sidebar so you can verify their
 contents before training. The currently active YAML configuration is also shown

--- a/tests/test_streamlit_playground.py
+++ b/tests/test_streamlit_playground.py
@@ -10,6 +10,7 @@ from PIL import Image
 from zipfile import ZipFile
 from io import BytesIO
 import numpy as np
+from plotly.graph_objs import Figure
 
 from tests.test_core_functions import minimal_params
 
@@ -53,6 +54,10 @@ from streamlit_playground import (
     list_learner_classes,
     create_learner,
     train_learner,
+    metrics_dataframe,
+    metrics_figure,
+    load_readme,
+    load_tutorial,
 )
 
 
@@ -375,3 +380,27 @@ def test_learner_helpers(tmp_path):
     learner = create_learner("contrastive_learning", "ContrastiveLearner", marble)
     data = [0.0, 1.0]
     train_learner(learner, data, epochs=1)
+
+
+def test_metrics_and_docs_helpers(tmp_path):
+    from marble_base import MetricsVisualizer
+
+    class DummyMarble:
+        def __init__(self):
+            self.mv = MetricsVisualizer()
+            self.mv.metrics["loss"] = [1.0, 0.5]
+
+        def get_metrics_visualizer(self):
+            return self.mv
+
+    marble = DummyMarble()
+    df = metrics_dataframe(marble)
+    fig = metrics_figure(marble)
+    assert isinstance(df, pd.DataFrame)
+    assert "loss" in df.columns
+    assert isinstance(fig, Figure)
+
+    readme = load_readme()
+    tutorial = load_tutorial()
+    assert "MARBLE" in readme
+    assert "Project" in tutorial


### PR DESCRIPTION
## Summary
- expand Streamlit playground with Metrics and Documentation tabs
- expose helper functions for building metrics plots and loading docs
- update tutorial and README for new playground features
- test metrics/document helpers

## Testing
- `ruff check streamlit_playground.py tests/test_streamlit_playground.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e790be1c88327b845a0e1fd8ab543