### PR TITLE
Improve playground with test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ button press.
 A dedicated **Metrics** tab graphs loss, memory usage and other statistics in
 real time inside the browser. A **System Stats** tab displays current CPU and
 GPU memory usage. Another **Documentation** tab provides quick access to the
-README, YAML manual and full tutorial without leaving the playground.
+README, YAML manual and full tutorial without leaving the playground. A **Tests**
+tab lets you run the repository's pytest suite directly from the UI so you can
+validate changes after each experiment.
 
 ## Possible MARBLE Backcronyms
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1269,6 +1269,8 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
 17. **Read the documentation** on the *Documentation* tab. The README, YAML
     manual and tutorial are available directly in the browser for quick
     reference.
+18. **Run unit tests** on the *Tests* tab. Select one or more test files and
+    click **Run Tests** to verify everything works as expected.
 
 Uploaded datasets are previewed directly in the sidebar so you can verify their
 contents before training. The currently active YAML configuration is also shown

--- a/tests/test_streamlit_playground.py
+++ b/tests/test_streamlit_playground.py
@@ -60,6 +60,8 @@ from streamlit_playground import (
     load_tutorial,
     search_hf_models,
     system_stats,
+    list_test_files,
+    run_tests,
 )
 
 
@@ -429,3 +431,12 @@ def test_system_stats():
     ):
         stats = system_stats()
     assert stats == {"ram_mb": 123.0, "gpu_mb": 45.0}
+
+
+def test_list_tests_and_run(tmp_path):
+    files = list_test_files()
+    assert "test_streamlit_playground.py" in files
+    with mock.patch("streamlit_playground.pytest.main", return_value=0) as pm:
+        out = run_tests("dummy")
+    pm.assert_called_once_with(["-k", "dummy"])
+    assert "Exit code" in out


### PR DESCRIPTION
## Summary
- add helper functions to list and run pytest
- expose "Tests" tab in Streamlit playground
- document the new capability in README and TUTORIAL
- test list_test_files and run_tests

## Testing
- `ruff check streamlit_playground.py tests/test_streamlit_playground.py`
- `pytest tests/test_streamlit_playground.py::test_list_tests_and_run -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8213874c8327b9429e5206ab41ed