### PR TITLE
Improve MARBLE playground

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1266,10 +1266,14 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
     statistics are plotted live so you can observe training behaviour.
 16. **Check system resources** on the *System Stats* tab. RAM and GPU usage are
     displayed so you can monitor consumption while experimenting.
-17. **Read the documentation** on the *Documentation* tab. The README, YAML
-    manual and tutorial are available directly in the browser for quick
+17. **Read the documentation** on the *Documentation* tab. Every markdown file
+    in the repository, including the architecture overview, configurable
+    parameters list and machine learning handbook, can be opened here for quick
     reference.
-18. **Run unit tests** on the *Tests* tab. Select one or more test files and
+18. **Browse source code** on the *Source Browser* tab. Select any module and
+    click **Show Source** to view its implementation without leaving the
+    playground.
+19. **Run unit tests** on the *Tests* tab. Select one or more test files and
     click **Run Tests** to verify everything works as expected.
 
 Uploaded datasets are previewed directly in the sidebar so you can verify their

--- a/streamlit_playground.py
+++ b/streamlit_playground.py
@@ -531,6 +531,26 @@ def load_tutorial() -> str:
         return f.read()
 
 
+def list_documentation_files() -> list[str]:
+    """Return available markdown documentation files."""
+    root = os.path.dirname(__file__)
+    files = [f for f in os.listdir(root) if f.endswith(".md")]
+    return sorted(files)
+
+
+def load_documentation(doc_name: str) -> str:
+    """Return the contents of ``doc_name`` located in the repository root."""
+    path = os.path.join(os.path.dirname(__file__), doc_name)
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def load_module_source(module_name: str) -> str:
+    """Return source code for ``module_name``."""
+    module = importlib.import_module(module_name)
+    return inspect.getsource(module)
+
+
 def load_pipeline_from_json(file) -> list[dict]:
     """Load a function pipeline from a JSON file or file-like object."""
     if hasattr(file, "read"):
@@ -942,6 +962,7 @@ def run_playground() -> None:
             tab_proj,
             tab_tests,
             tab_docs,
+            tab_src,
         ) = st.tabs(
             [
                 "marble_interface",
@@ -959,6 +980,7 @@ def run_playground() -> None:
                 "Projects",
                 "Tests",
                 "Documentation",
+                "Source Browser",
             ]
         )
 
@@ -1494,15 +1516,19 @@ def run_playground() -> None:
 
         with tab_docs:
             st.write("View repository documentation.")
-            doc_choice = st.selectbox(
-                "Document", ["README", "TUTORIAL", "YAML Manual"], key="doc_select"
-            )
-            if doc_choice == "README":
-                st.code(load_readme(), language="markdown")
-            elif doc_choice == "TUTORIAL":
-                st.code(load_tutorial(), language="markdown")
-            else:
-                st.code(load_yaml_manual(), language="yaml")
+            docs = list_documentation_files()
+            doc_choice = st.selectbox("Document", docs, key="doc_select")
+            text = load_documentation(doc_choice)
+            lang = "markdown" if doc_choice.endswith(".md") else "yaml"
+            st.code(text, language=lang)
+
+        with tab_src:
+            st.write("Browse repository source code.")
+            modules = list_repo_modules()
+            mod_choice = st.selectbox("Module", modules, key="src_mod")
+            if st.button("Show Source", key="src_show"):
+                code = load_module_source(mod_choice)
+                st.code(code, language="python")
 
 
 if __name__ == "__main__":

--- a/tests/test_streamlit_playground.py
+++ b/tests/test_streamlit_playground.py
@@ -63,6 +63,9 @@ from streamlit_playground import (
     system_stats,
     list_test_files,
     run_tests,
+    list_documentation_files,
+    load_documentation,
+    load_module_source,
 )
 
 
@@ -454,3 +457,15 @@ def test_list_tests_and_run(tmp_path):
         out = run_tests("dummy")
     pm.assert_called_once_with(["-k", "dummy"])
     assert "Exit code" in out
+
+
+def test_documentation_helpers():
+    docs = list_documentation_files()
+    assert "README.md" in docs
+    text = load_documentation("README.md")
+    assert "MARBLE" in text
+
+
+def test_source_browser():
+    code = load_module_source("reinforcement_learning")
+    assert "def" in code


### PR DESCRIPTION
## Summary
- extend documentation helpers
- allow selecting any doc or module source from new "Source Browser" tab
- expose docs via new helper functions
- include tests for new helpers
- update tutorial instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e86c4bcac8327947364be0ef885aa