### PR TITLE
Enhance playground with neuromodulation controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ GPU memory usage. Another **Documentation** tab provides quick access to the
 README, YAML manual and full tutorial without leaving the playground. A **Tests**
 tab lets you run the repository's pytest suite directly from the UI so you can
 validate changes after each experiment.
+The new **Neuromodulation** tab exposes sliders for arousal, stress and reward
+signals along with an emotion field so you can tweak the brain's internal state
+interactively.
 
 ## Possible MARBLE Backcronyms
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1266,14 +1266,17 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
     statistics are plotted live so you can observe training behaviour.
 16. **Check system resources** on the *System Stats* tab. RAM and GPU usage are
     displayed so you can monitor consumption while experimenting.
-17. **Read the documentation** on the *Documentation* tab. Every markdown file
+17. **Tune neuromodulatory signals** on the *Neuromodulation* tab. Adjust the
+    sliders for arousal, stress and reward or set an emotion string, then press
+    **Update Signals** to modify MARBLE's internal context on the fly.
+18. **Read the documentation** on the *Documentation* tab. Every markdown file
     in the repository, including the architecture overview, configurable
     parameters list and machine learning handbook, can be opened here for quick
     reference.
-18. **Browse source code** on the *Source Browser* tab. Select any module and
+19. **Browse source code** on the *Source Browser* tab. Select any module and
     click **Show Source** to view its implementation without leaving the
     playground.
-19. **Run unit tests** on the *Tests* tab. Select one or more test files and
+20. **Run unit tests** on the *Tests* tab. Select one or more test files and
     click **Run Tests** to verify everything works as expected.
 
 Uploaded datasets are previewed directly in the sidebar so you can verify their

--- a/streamlit_playground.py
+++ b/streamlit_playground.py
@@ -517,6 +517,33 @@ def core_statistics(marble) -> dict:
     }
 
 
+def get_neuromod_state(marble) -> dict:
+    """Return the current neuromodulatory signal levels."""
+    return marble.brain.neuromodulatory_system.get_context()
+
+
+def set_neuromod_state(
+    marble,
+    arousal: float | None = None,
+    stress: float | None = None,
+    reward: float | None = None,
+    emotion: str | None = None,
+) -> dict:
+    """Update neuromodulatory signals and return the new state."""
+    updates: dict[str, object] = {}
+    if arousal is not None:
+        updates["arousal"] = float(arousal)
+    if stress is not None:
+        updates["stress"] = float(stress)
+    if reward is not None:
+        updates["reward"] = float(reward)
+    if emotion is not None:
+        updates["emotion"] = str(emotion)
+    if updates:
+        marble.brain.neuromodulatory_system.update_signals(**updates)
+    return marble.brain.neuromodulatory_system.get_context()
+
+
 def load_readme() -> str:
     """Return the repository ``README.md`` contents."""
     path = os.path.join(os.path.dirname(__file__), "README.md")
@@ -955,6 +982,7 @@ def run_playground() -> None:
             tab_vis,
             tab_metrics,
             tab_stats,
+            tab_neuro,
             tab_core,
             tab_cfg,
             tab_model,
@@ -973,6 +1001,7 @@ def run_playground() -> None:
                 "Visualization",
                 "Metrics",
                 "System Stats",
+                "Neuromodulation",
                 "Core Tools",
                 "Config Editor",
                 "Model Conversion",
@@ -1258,6 +1287,45 @@ def run_playground() -> None:
             st.metric("GPU", f"{stats['gpu_mb']:.1f} MB")
             if st.button("Refresh Stats", key="stats_refresh"):
                 st.experimental_rerun()
+
+        with tab_neuro:
+            st.write("Adjust neuromodulatory signals.")
+            state = get_neuromod_state(marble)
+            arousal = st.slider(
+                "Arousal",
+                min_value=0.0,
+                max_value=1.0,
+                value=float(state.get("arousal", 0.0)),
+                step=0.01,
+            )
+            stress = st.slider(
+                "Stress",
+                min_value=0.0,
+                max_value=1.0,
+                value=float(state.get("stress", 0.0)),
+                step=0.01,
+            )
+            reward = st.slider(
+                "Reward",
+                min_value=0.0,
+                max_value=1.0,
+                value=float(state.get("reward", 0.0)),
+                step=0.01,
+            )
+            emotion = st.text_input(
+                "Emotion", value=str(state.get("emotion", "neutral"))
+            )
+            if st.button("Update Signals", key="neuro_update"):
+                new_state = set_neuromod_state(
+                    marble,
+                    arousal=arousal,
+                    stress=stress,
+                    reward=reward,
+                    emotion=emotion,
+                )
+                st.success(
+                    f"Signals updated: arousal={new_state['arousal']}, stress={new_state['stress']}, reward={new_state['reward']}, emotion={new_state['emotion']}"
+                )
 
         with tab_core:
             st.write("Manipulate and inspect the MARBLE core.")

--- a/tests/test_streamlit_playground.py
+++ b/tests/test_streamlit_playground.py
@@ -61,6 +61,8 @@ from streamlit_playground import (
     search_hf_models,
     core_statistics,
     system_stats,
+    get_neuromod_state,
+    set_neuromod_state,
     list_test_files,
     run_tests,
     list_documentation_files,
@@ -448,6 +450,20 @@ def test_core_statistics(tmp_path):
     assert stats["synapses"] == len(marble.get_core().synapses)
     tiers = {n.tier for n in marble.get_core().neurons}
     assert stats["tiers"] == len(tiers)
+
+
+def test_neuromod_state_helpers(tmp_path):
+    cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.dump(cfg, f)
+    marble = initialize_marble(str(cfg_path))
+
+    state = get_neuromod_state(marble)
+    assert state["arousal"] == 0.0
+    updated = set_neuromod_state(marble, arousal=0.5, emotion="happy")
+    assert updated["arousal"] == 0.5
+    assert updated["emotion"] == "happy"
 
 
 def test_list_tests_and_run(tmp_path):


### PR DESCRIPTION
## Summary
- extend `streamlit_playground` with neuromodulation state helpers
- expose new **Neuromodulation** tab in the Streamlit UI
- document the new tab in `README.md` and `TUTORIAL.md`
- add tests for neuromodulation helper functions

## Testing
- `ruff check streamlit_playground.py tests/test_streamlit_playground.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e895a0c68832797c2f53fabd0f9ae