### PR TITLE
Add async training controls to Streamlit playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ validate changes after each experiment.
 The new **Neuromodulation** tab exposes sliders for arousal, stress and reward
 signals along with an emotion field so you can tweak the brain's internal state
 interactively.
+A new **Async Training** tab lets you launch background training threads and
+enable MARBLE's auto-firing mechanism so learning continues while you explore
+other features.
 
 ## Possible MARBLE Backcronyms
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1278,6 +1278,10 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
     playground.
 20. **Run unit tests** on the *Tests* tab. Select one or more test files and
     click **Run Tests** to verify everything works as expected.
+21. **Control asynchronous behaviour** on the *Async Training* tab. Start
+    background training threads or enable auto-firing so MARBLE keeps learning
+    while you explore other tabs. Use **Wait For Training** to block until the
+    current session finishes or stop auto-firing at any time.
 
 Uploaded datasets are previewed directly in the sidebar so you can verify their
 contents before training. The currently active YAML configuration is also shown


### PR DESCRIPTION
## Summary
- extend playground with background training and auto-firing helpers
- expose new "Async Training" tab with controls
- document async features in README and tutorial
- test new async helper functions

## Testing
- `ruff check --fix streamlit_playground.py tests/test_streamlit_playground.py README.md TUTORIAL.md`
- `black -q streamlit_playground.py tests/test_streamlit_playground.py`
- `pytest tests/test_streamlit_playground.py::test_async_helpers -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8bf378fc8327a3bce55f3fea8754