### PR TITLE
Enhance playground with RL sandbox

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1284,6 +1284,11 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
     background training threads or enable auto-firing so MARBLE keeps learning
     while you explore other tabs. Use **Wait For Training** to block until the
     current session finishes or stop auto-firing at any time.
+23. **Explore reinforcement learning** on the *RL Sandbox* tab. Set the grid
+    size, number of episodes, step limit and optionally enable double
+    Q-learning, then click **Run GridWorld** to train a
+    `MarbleQLearningAgent`. The reward curve for each episode is displayed so
+    you can observe learning progress.
 
 Uploaded datasets are previewed directly in the sidebar so you can verify their
 contents before training. The currently active YAML configuration is also shown

--- a/tests/test_streamlit_playground.py
+++ b/tests/test_streamlit_playground.py
@@ -62,6 +62,8 @@ from streamlit_playground import (
     training_in_progress,
     start_auto_firing,
     stop_auto_firing,
+    create_gridworld_env,
+    run_gridworld_episode,
     metrics_dataframe,
     metrics_figure,
     load_readme,
@@ -528,3 +530,15 @@ def test_documentation_helpers():
 def test_source_browser():
     code = load_module_source("reinforcement_learning")
     assert "def" in code
+
+
+def test_gridworld_helpers(tmp_path):
+    cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.dump(cfg, f)
+    marble = initialize_marble(str(cfg_path))
+    env = create_gridworld_env(size=3)
+    assert env.size == 3
+    rewards = run_gridworld_episode(marble, episodes=1, max_steps=2, size=3)
+    assert isinstance(rewards, list) and len(rewards) == 1


### PR DESCRIPTION
## Summary
- extend the Streamlit playground with GridWorld reinforcement learning controls
- expose helper functions `create_gridworld_env` and `run_gridworld_episode`
- add new RL tab in the UI and mention in tutorial
- test new helper functions

## Testing
- `pytest -k streamlit_playground`

------
https://chatgpt.com/codex/tasks/task_e_687e978957308327aed6b5e9c3dc3a47