### PR TITLE
Improve playground with lobe manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ validate changes after each experiment.
 The new **Neuromodulation** tab exposes sliders for arousal, stress and reward
 signals along with an emotion field so you can tweak the brain's internal state
 interactively.
+A **Lobe Manager** tab displays all lobes with their current attention scores and
+lets you create, organize or run self‑attention directly from the interface.
 A new **Async Training** tab lets you launch background training threads and
 enable MARBLE's auto-firing mechanism so learning continues while you explore
 other features.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1271,20 +1271,23 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
 18. **Tune neuromodulatory signals** on the *Neuromodulation* tab. Adjust the
     sliders for arousal, stress and reward or set an emotion string, then press
     **Update Signals** to modify MARBLE's internal context on the fly.
-19. **Read the documentation** on the *Documentation* tab. Every markdown file
+19. **Manage lobes** on the *Lobe Manager* tab. View attention scores for each
+    lobe, create new lobes from selected neuron IDs, reorganize the current
+    structure or apply self-attention updates with a single click.
+20. **Read the documentation** on the *Documentation* tab. Every markdown file
     in the repository, including the architecture overview, configurable
     parameters list and machine learning handbook, can be opened here for quick
     reference.
-20. **Browse source code** on the *Source Browser* tab. Select any module and
+21. **Browse source code** on the *Source Browser* tab. Select any module and
     click **Show Source** to view its implementation without leaving the
     playground.
-21. **Run unit tests** on the *Tests* tab. Select one or more test files and
+22. **Run unit tests** on the *Tests* tab. Select one or more test files and
     click **Run Tests** to verify everything works as expected.
-22. **Control asynchronous behaviour** on the *Async Training* tab. Start
+23. **Control asynchronous behaviour** on the *Async Training* tab. Start
     background training threads or enable auto-firing so MARBLE keeps learning
     while you explore other tabs. Use **Wait For Training** to block until the
     current session finishes or stop auto-firing at any time.
-23. **Explore reinforcement learning** on the *RL Sandbox* tab. Set the grid
+24. **Explore reinforcement learning** on the *RL Sandbox* tab. Set the grid
     size, number of episodes, step limit and optionally enable double
     Q-learning, then click **Run GridWorld** to train a
     `MarbleQLearningAgent`. The reward curve for each episode is displayed so

--- a/tests/test_streamlit_playground.py
+++ b/tests/test_streamlit_playground.py
@@ -73,6 +73,11 @@ from streamlit_playground import (
     system_stats,
     get_neuromod_state,
     set_neuromod_state,
+    lobe_info,
+    add_lobe,
+    organize_lobes,
+    self_attention_lobes,
+    select_high_attention_neurons,
     list_test_files,
     run_tests,
     list_documentation_files,
@@ -542,3 +547,22 @@ def test_gridworld_helpers(tmp_path):
     assert env.size == 3
     rewards = run_gridworld_episode(marble, episodes=1, max_steps=2, size=3)
     assert isinstance(rewards, list) and len(rewards) == 1
+
+
+def test_lobe_manager_helpers(tmp_path):
+    cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.dump(cfg, f)
+    marble = initialize_marble(str(cfg_path))
+
+    assert lobe_info(marble) == []
+    lid = add_lobe(marble, [0, 1])
+    assert isinstance(lid, int)
+    info = lobe_info(marble)
+    assert len(info) == 1 and info[0]["neurons"] == 2
+    count = organize_lobes(marble)
+    assert isinstance(count, int)
+    self_attention_lobes(marble, loss=1.0)
+    ids = select_high_attention_neurons(marble, threshold=-1.0)
+    assert isinstance(ids, list)


### PR DESCRIPTION
## Summary
- add helper functions for interacting with the lobe manager
- expose a new **Lobe Manager** tab in the Streamlit playground UI
- document the new tab in README and TUTORIAL
- test new lobe manager helpers

## Testing
- `pytest tests/test_streamlit_playground.py::test_lobe_manager_helpers -q`
- `pytest tests/test_streamlit_playground.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687e99613ff48327b758446982ed2025