### PR TITLE
Enhance playground with hybrid memory UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ other features.
 An **Adaptive Control** tab exposes the MetaParameterController and
 SuperEvolutionController so you can fine-tune plasticity behaviour, inspect
 parameter changes and run dimensional search or n-dimensional topology updates.
+The interface now includes a **Hybrid Memory** tab as well. This lets you
+initialize a vector store and symbolic memory, store new values, query for the
+closest matches and prune old entries directly from the playground.
 
 ## Possible MARBLE Backcronyms
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1303,6 +1303,9 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
     meta-controller's loss history and adjust its parameters, review super
     evolution metrics and apply dimensional search or n-dimensional topology
     evaluations with a single click.
+29. **Manage hybrid memory** on the *Hybrid Memory* tab. Initialize the vector
+    and symbolic stores, add new key/value pairs, query for similar entries and
+    prune older items without leaving the UI.
 
 Uploaded datasets are previewed directly in the sidebar so you can verify their
 contents before training. The currently active YAML configuration is also shown

--- a/tests/test_streamlit_playground.py
+++ b/tests/test_streamlit_playground.py
@@ -101,6 +101,10 @@ from streamlit_playground import (
     save_config_yaml,
     search_repository_functions,
     find_repository_functions,
+    create_hybrid_memory,
+    hybrid_memory_store,
+    hybrid_memory_retrieve,
+    hybrid_memory_forget,
 )
 
 
@@ -684,3 +688,23 @@ def test_save_config_yaml_and_search(tmp_path):
 def test_find_repository_functions():
     res = find_repository_functions("count_marble_syn")
     assert ("marble_interface", "count_marble_synapses") in res
+
+
+def test_hybrid_memory_helpers(tmp_path):
+    cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.dump(cfg, f)
+    marble = initialize_marble(str(cfg_path))
+
+    hm = create_hybrid_memory(
+        marble,
+        vector_path=str(tmp_path / "vec.pkl"),
+        symbolic_path=str(tmp_path / "sym.pkl"),
+    )
+    assert hm is marble.hybrid_memory
+
+    hybrid_memory_store(marble, "k", 1.0)
+    res = hybrid_memory_retrieve(marble, 1.0, top_k=1)
+    assert res and res[0][0] == "k"
+    hybrid_memory_forget(marble, max_entries=1)


### PR DESCRIPTION
## Summary
- expand streamlit playground with Hybrid Memory tab
- implement helper functions for HybridMemory
- document new tab in README and tutorial
- test hybrid memory helpers

## Testing
- `pytest tests/test_streamlit_playground.py::test_hybrid_memory_helpers -q`
- `pytest tests/test_streamlit_playground.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f2a7a6cfc83278b7ea433e7f738b9