### PR TITLE
Add autoencoder training via GUI

### DIFF
--- a/marble_interface.py
+++ b/marble_interface.py
@@ -11,6 +11,7 @@ from config_loader import create_marble_from_config, load_config
 from marble_main import MARBLE
 from marble_autograd import MarbleAutogradLayer
 from marble_utils import core_to_json, core_from_json
+from autoencoder_learning import AutoencoderLearner
 import torch
 from datasets import load_dataset
 import warnings
@@ -401,3 +402,23 @@ def randomize_core_representations(marble: MARBLE, std: float = 1.0) -> None:
 def count_marble_synapses(marble: MARBLE) -> int:
     """Return the number of synapses in ``marble``."""
     return len(marble.get_core().synapses)
+
+
+def train_autoencoder(
+    marble: MARBLE,
+    values: Iterable[float],
+    epochs: int = 1,
+    noise_std: float = 0.1,
+    noise_decay: float = 0.99,
+) -> float:
+    """Train a denoising autoencoder and return the final loss."""
+
+    learner = AutoencoderLearner(
+        marble.get_core(),
+        marble.get_neuronenblitz(),
+        noise_std=float(noise_std),
+        noise_decay=float(noise_decay),
+    )
+    learner.train(list(map(float, values)), epochs=int(epochs))
+    return float(learner.history[-1]["loss"]) if learner.history else 0.0
+

--- a/tests/test_marble_interface.py
+++ b/tests/test_marble_interface.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import marble_imports
 import marble_brain
 import marble_main
+import marble_interface
 from marble_base import MetricsVisualizer
 from tqdm import tqdm as std_tqdm
 from tests.test_core_functions import minimal_params
@@ -111,3 +112,19 @@ def test_export_and_import_core(tmp_path):
     js = export_core_to_json(m)
     m2 = import_core_from_json(js)
     assert len(m2.get_core().neurons) == len(m.get_core().neurons)
+
+
+def test_train_autoencoder_runs(tmp_path):
+    marble_imports.tqdm = std_tqdm
+    marble_brain.tqdm = std_tqdm
+    marble_main.MetricsVisualizer = MetricsVisualizer
+
+    cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}
+    cfg_path = tmp_path / "cfg.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.dump(cfg, f)
+
+    m = new_marble_system(str(cfg_path))
+    loss = marble_interface.train_autoencoder(m, [0.1, 0.2], epochs=1)
+    assert isinstance(loss, float)
+    assert loss >= 0.0

--- a/tests/test_streamlit_gui.py
+++ b/tests/test_streamlit_gui.py
@@ -943,3 +943,14 @@ def test_about_dialog():
     about_btn = next(b for b in at.button if b.label == "About")
     at = about_btn.click().run(timeout=20)
     assert any("MARBLE" in md.value for md in at.markdown)
+
+
+def test_autoencoder_tab_training(monkeypatch):
+    monkeypatch.setattr("streamlit_playground.train_autoencoder", lambda *a, **k: 0.0)
+    at = _setup_advanced_playground()
+    auto_tab = next(t for t in at.tabs if t.label == "Autoencoder")
+    auto_tab.file_uploader[0].upload(("vals.csv", "value\n0.1\n0.2\n"))
+    train_btn = next(b for b in auto_tab.button if b.label == "Train Autoencoder")
+    at = train_btn.click().run(timeout=20)
+    auto_tab = next(t for t in at.tabs if t.label == "Autoencoder")
+    assert any("Training complete" in s.value for s in auto_tab.success)


### PR DESCRIPTION
## Summary
- enable training AutoencoderLearner through `train_autoencoder`
- load value lists in GUI and expose new **Autoencoder** tab
- extend streamlit tests for the new tab
- add unit test for `train_autoencoder`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68821747ac8c8327bba0424411b9049f