### PR TITLE
Improve Neuronenblitz beam search

### DIFF
--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -455,7 +455,11 @@ class Neuronenblitz:
                     else:
                         next_neuron.value = val
                     new_path = path + [(next_neuron, syn)]
-                    new_score = score + syn.potential
+                    fatigue_factor = 1.0
+                    if self.synaptic_fatigue_enabled:
+                        fatigue_factor -= getattr(syn, "fatigue", 0.0)
+                        fatigue_factor = max(0.0, fatigue_factor)
+                    new_score = score + syn.potential * fatigue_factor
                     candidates.append((next_neuron, new_path, new_score))
             if not candidates:
                 break

--- a/tests/test_neuronenblitz_enhancements.py
+++ b/tests/test_neuronenblitz_enhancements.py
@@ -270,3 +270,28 @@ def test_beam_wander_selects_best_path():
     assert isinstance(out, float)
     assert path
 
+
+def test_beam_wander_penalizes_fatigue():
+    random.seed(0)
+    np.random.seed(0)
+    params = minimal_params()
+    core = Core(params)
+    core.neurons = [Neuron(0, value=0.0), Neuron(1, value=0.0)]
+    core.synapses = []
+    syn_fatigued = core.add_synapse(0, 1, weight=1.0)
+    syn_fatigued.fatigue = 0.9
+    syn_fresh = core.add_synapse(0, 1, weight=1.0)
+    syn_fresh.fatigue = 0.0
+    nb = Neuronenblitz(
+        core,
+        beam_width=2,
+        max_wander_depth=1,
+        split_probability=0.0,
+        alternative_connection_prob=0.0,
+        backtrack_probability=0.0,
+        backtrack_enabled=False,
+    )
+    _, path = nb.dynamic_wander(1.0)
+    assert path
+    assert path[0] is syn_fresh
+


### PR DESCRIPTION
## Summary
- account for synaptic fatigue when scoring candidates in `_beam_wander`
- add test ensuring beam search prefers low-fatigue synapses

## Testing
- `pytest -vv tests/test_neuronenblitz_enhancements.py::test_beam_wander_penalizes_fatigue`
- `pytest -q` *(all tests)*

------
https://chatgpt.com/codex/tasks/task_e_688239b7de6083278aceae39b768eb41