### PR TITLE
Enhance Neuronenblitz momentum

### DIFF
--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -688,10 +688,10 @@ class Neuronenblitz:
             clip = getattr(self.core, "gradient_clip_value", None)
             if clip is not None:
                 delta = float(np.clip(delta, -clip, clip))
-            mom = self._momentum.get(syn, 0.0)
-            mom = self.momentum_coefficient * mom + delta
+            mom_prev = self._momentum.get(syn, 0.0)
+            mom = self.momentum_coefficient * mom_prev + delta
             self._momentum[syn] = mom
-            update = self.learning_rate * mom
+            update = self.learning_rate * (self.momentum_coefficient * mom + delta)
             if abs(update) > self.synapse_update_cap:
                 update = math.copysign(self.synapse_update_cap, update)
             syn.weight += update

--- a/tests/test_neuronenblitz_enhancements.py
+++ b/tests/test_neuronenblitz_enhancements.py
@@ -173,7 +173,7 @@ def test_weight_update_momentum():
     nb.apply_weight_updates_and_attention([syn], error=1.0)
     core.neurons[0].value = 1.0
     nb.apply_weight_updates_and_attention([syn], error=1.0)
-    assert np.isclose(syn.weight, 2.5)
+    assert np.isclose(syn.weight, 2.75)
 
 
 def test_eligibility_traces_accumulate():


### PR DESCRIPTION
## Summary
- implement Nesterov-style momentum in Neuronenblitz
- adjust test to reflect new momentum behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68825656965c8327992c952457b21d86