### PR TITLE
Improve Neuronenblitz stability

### DIFF
--- a/distillation_trainer.py
+++ b/distillation_trainer.py
@@ -31,8 +31,12 @@ class DistillationTrainer:
         validation_examples: Iterable[Any] | None = None,
     ) -> None:
         """Train ``self.student`` using teacher-guided targets."""
-        blended = self._blend_targets(train_examples)
         pbar = tqdm(range(epochs), desc="DistillationEpochs", ncols=100)
         for _ in pbar:
-            self.student.train(blended, epochs=1, validation_examples=validation_examples)
+            blended = self._blend_targets(train_examples)
+            self.student.train(
+                blended,
+                epochs=1,
+                validation_examples=validation_examples,
+            )
         pbar.close()

--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -340,7 +340,12 @@ class Neuronenblitz:
         scores_arr = np.array(scores, dtype=float)
         if np.all(scores_arr == 0.0):
             return random.choice(synapses)
-        probs = np.exp(scores_arr) / np.sum(np.exp(scores_arr))
+        max_score = np.max(scores_arr)
+        exp_scores = np.exp(scores_arr - max_score)
+        sum_exp = np.sum(exp_scores)
+        if sum_exp == 0 or np.isnan(sum_exp):
+            return random.choice(synapses)
+        probs = exp_scores / sum_exp
         idx = np.random.choice(len(synapses), p=probs)
         return synapses[idx]
 

--- a/tests/test_benchmark_autograd_vs_marble.py
+++ b/tests/test_benchmark_autograd_vs_marble.py
@@ -1,4 +1,8 @@
+import os
+import sys
 import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from benchmark_autograd_vs_marble import (
     generate_dataset,

--- a/tests/test_neuronenblitz_enhancements.py
+++ b/tests/test_neuronenblitz_enhancements.py
@@ -373,3 +373,14 @@ def test_visit_count_decay_and_bias():
     assert syn_a.visit_count == 5
     selections = [nb.weighted_choice(core.neurons[0].synapses) for _ in range(50)]
     assert selections.count(syn_b) > selections.count(syn_a)
+
+
+def test_weighted_choice_handles_large_scores():
+    random.seed(0)
+    np.random.seed(0)
+    core, _ = create_simple_core()
+    syn_a = core.add_synapse(0, 1, weight=1e9)
+    syn_b = core.add_synapse(0, 1, weight=1e9 + 1)
+    nb = Neuronenblitz(core)
+    choice = nb.weighted_choice([syn_a, syn_b])
+    assert choice in (syn_a, syn_b)


### PR DESCRIPTION
## Summary
- stabilize synapse selection to prevent NaNs
- update distillation trainer to refresh blended targets each epoch
- adjust benchmark test path setup
- add test for large value handling in weighted_choice

## Testing
- `pytest tests/test_neuronenblitz_enhancements.py -q`
- `pytest tests/test_benchmark_autograd_vs_marble.py::test_run_benchmark_structure tests/test_benchmark_super_evolution.py::test_super_evolution_benchmark_structure tests/test_distillation.py::test_distillation_reduces_student_error -q`

------
https://chatgpt.com/codex/tasks/task_e_68827bae71188327b54c67410bb80f77