### PR TITLE
Enhance neuronenblitz with adaptive dropout

### DIFF
--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -294,6 +294,12 @@ class Neuronenblitz:
                 self.min_learning_rate,
             )
 
+    def adjust_dropout_rate(self, avg_error: float) -> None:
+        """Dynamically adapt dropout probability based on training error."""
+        self.dropout_probability *= self.dropout_decay_rate
+        self.dropout_probability += 0.1 * (avg_error - 0.5)
+        self.dropout_probability = float(max(0.0, min(1.0, self.dropout_probability)))
+
     # Reinforcement learning utilities
     def enable_rl(self) -> None:
         """Enable built-in reinforcement learning."""
@@ -867,11 +873,7 @@ class Neuronenblitz:
             self.last_message_passing_change = change
             self.decide_synapse_action()
             self.adjust_learning_rate()
-            if self.dropout_decay_rate != 1.0:
-                self.dropout_probability *= self.dropout_decay_rate
-                self.dropout_probability = float(
-                    max(0.0, min(1.0, self.dropout_probability))
-                )
+            self.adjust_dropout_rate(avg_error)
 
     def get_training_history(self):
         return self.training_history

--- a/tests/test_neuronenblitz_enhancements.py
+++ b/tests/test_neuronenblitz_enhancements.py
@@ -248,8 +248,17 @@ def test_dropout_probability_decays():
         backtrack_enabled=False,
     )
     nb.train([(1.0, 0.0)], epochs=2)
-    expected = 0.5 * 0.8 * 0.8
-    assert np.isclose(nb.dropout_probability, expected)
+    assert 0.0 <= nb.dropout_probability < 0.5
+
+
+def test_adjust_dropout_rate_increases_and_decreases():
+    core, _ = create_simple_core()
+    nb = Neuronenblitz(core, dropout_probability=0.2, dropout_decay_rate=0.9)
+    nb.adjust_dropout_rate(1.0)
+    assert nb.dropout_probability > 0.2
+    prev = nb.dropout_probability
+    nb.adjust_dropout_rate(0.0)
+    assert nb.dropout_probability < prev
 
 
 def test_synapse_update_cap_limits_change():


### PR DESCRIPTION
## Summary
- implement adaptive dropout adjustment
- invoke dropout adaptation during training
- test adaptive dropout behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882aafe15e8832787ebf4b4cc61aebd