### PR TITLE
Add wander cache TTL

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -99,6 +99,7 @@ Each entry is listed under its section heading.
 - top_k_paths
 - parallel_wanderers
 - beam_width
+- wander_cache_ttl
 - synaptic_fatigue_enabled
 - fatigue_increase
 - fatigue_decay

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -98,12 +98,13 @@ This project introduces the **Core**, **Neuronenblitz** and **Brain** objects al
    ```
    Training now runs in a background thread so you can execute other code in the meantime. When you need to wait for completion call `marble.brain.wait_for_training()`.
 4. **Run inference concurrently** with `marble.brain.dynamic_wander(sample)` to test the partially trained network while training is still running.
-5. **Experiment with evolutionary functions** to mutate or prune synapses:
+5. **Tune caching** using the ``wander_cache_ttl`` parameter in ``config.yaml`` to control how long ``dynamic_wander`` results remain valid. Increasing the value reuses paths more aggressively while ``0`` disables expiry.
+6. **Experiment with evolutionary functions** to mutate or prune synapses:
    ```python
    mutated, pruned = marble.brain.evolve(mutation_rate=0.02, prune_threshold=0.05)
    ```
    Mutations add noise to synapses while pruning removes the least useful ones.
-6. **Enable dreaming** by setting `dream_enabled: true` in `config.yaml`. Parameters like `dream_num_cycles` and `dream_interval` determine how often memory consolidation happens in the background.
+7. **Enable dreaming** by setting `dream_enabled: true` in `config.yaml`. Parameters like `dream_num_cycles` and `dream_interval` determine how often memory consolidation happens in the background.
 
 **Complete Example**
 ```python

--- a/config.yaml
+++ b/config.yaml
@@ -93,6 +93,7 @@ neuronenblitz:
   top_k_paths: 5
   parallel_wanderers: 1
   beam_width: 1
+  wander_cache_ttl: 300
   synaptic_fatigue_enabled: true
   fatigue_increase: 0.05
   fatigue_decay: 0.95

--- a/tests/test_neuronenblitz_enhancements.py
+++ b/tests/test_neuronenblitz_enhancements.py
@@ -4,6 +4,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 import random
 import numpy as np
+import time
 from marble_core import Core, Neuron
 from marble_neuronenblitz import Neuronenblitz
 from tests.test_core_functions import minimal_params
@@ -414,6 +415,18 @@ def test_dynamic_wander_cache_size_limit():
     for i in range(nb._cache_max_size + 10):
         nb.dynamic_wander(float(i), apply_plasticity=False)
     assert len(nb.wander_cache) == nb._cache_max_size
+
+
+def test_dynamic_wander_cache_ttl_expiration():
+    random.seed(0)
+    np.random.seed(0)
+    core, syn = create_simple_core()
+    nb = Neuronenblitz(core, wander_cache_ttl=0.1)
+    out1, path1 = nb.dynamic_wander(1.0, apply_plasticity=False)
+    time.sleep(0.2)
+    syn.weight = 2.0
+    out2, path2 = nb.dynamic_wander(1.0, apply_plasticity=False)
+    assert out1 != out2 or path1 != path2
 
 
 def test_rmsprop_adaptive_scaling():

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -218,6 +218,9 @@ neuronenblitz:
     beam search variant of ``dynamic_wander``. Wider beams explore more options
     but increase computation time. A value of ``1`` disables beam search and
     reverts to the original recursive wander.
+  wander_cache_ttl: Time-to-live in seconds for ``dynamic_wander`` cache
+    entries. Cached paths older than this value are removed before reuse.
+    Values above ``0`` enable expiration while ``0`` keeps results indefinitely.
   synaptic_fatigue_enabled: When true each synapse maintains a temporary
     fatigue value that reduces its effective weight after repeated use. This
     models biological short-term depression and can help prevent domination by


### PR DESCRIPTION
## Summary
- allow configuring `wander_cache_ttl` for Neuronenblitz
- expire cached wander results after TTL and clean old entries
- document the new option and update tutorial
- test cache expiration logic

## Testing
- `pytest tests/test_neuronenblitz_enhancements.py::test_dynamic_wander_cache_ttl_expiration -q`

------
https://chatgpt.com/codex/tasks/task_e_688325ccb8c0832781b274c46f7fda32