### PR TITLE
Add phase-gated synapse modulation to Neuronenblitz

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -100,6 +100,8 @@ Each entry is listed under its section heading.
 - parallel_wanderers
 - beam_width
 - wander_cache_ttl
+- phase_rate
+- phase_adaptation_rate
 - synaptic_fatigue_enabled
 - fatigue_increase
 - fatigue_decay

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1068,6 +1068,27 @@ learner.train(samples, epochs=2)
 ```
 Run `python project24_cwfl.py` to see the field adapt across the dataset.
 
+## Project 24b – Phase-Gated Neuronenblitz (Experimental)
+
+**Goal:** Explore oscillatory modulation of synaptic updates.**
+
+1. **Enable phase gating** by setting `neuronenblitz.phase_rate` and
+   `neuronenblitz.phase_adaptation_rate` in `config.yaml`.
+2. **Instantiate MARBLE** as usual and train on a small numeric dataset:
+   ```python
+   from config_loader import load_config
+   from marble_main import MARBLE
+
+   cfg = load_config()
+   marble = MARBLE(cfg['core'])
+   examples = [(0.1, 0.2), (0.3, 0.5)]
+   marble.neuronenblitz.train(examples, epochs=3)
+   ```
+3. **Inspect phases** via `syn.phase` on any synapse to see how they
+   gradually synchronise with the global oscillator.
+
+Run `python project24b_phase_gated.py` to experiment with phase-based gating.
+
 ## Project 25 – Neural Schema Induction (Theory)
 
 **Goal:** Demonstrate structural learning of repeated reasoning patterns.**

--- a/config.yaml
+++ b/config.yaml
@@ -94,6 +94,8 @@ neuronenblitz:
   parallel_wanderers: 1
   beam_width: 1
   wander_cache_ttl: 300
+  phase_rate: 0.1
+  phase_adaptation_rate: 0.05
   synaptic_fatigue_enabled: true
   fatigue_increase: 0.05
   fatigue_decay: 0.95

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -221,6 +221,13 @@ neuronenblitz:
   wander_cache_ttl: Time-to-live in seconds for ``dynamic_wander`` cache
     entries. Cached paths older than this value are removed before reuse.
     Values above ``0`` enable expiration while ``0`` keeps results indefinitely.
+  phase_rate: Amount added to ``global_phase`` each time ``dynamic_wander``
+    runs. Higher values make the oscillator advance more quickly, altering
+    the cosine gating applied to every synapse.
+  phase_adaptation_rate: Step size used to adjust each synapse's individual
+    ``phase`` after a weight update. Positive error values push phases
+    forward while negative errors pull them backward. The value should
+    typically stay below ``1.0`` to prevent rapid oscillations.
   synaptic_fatigue_enabled: When true each synapse maintains a temporary
     fatigue value that reduces its effective weight after repeated use. This
     models biological short-term depression and can help prevent domination by


### PR DESCRIPTION
## Summary
- implement per-synapse phase and global oscillator
- expose `phase_rate` and `phase_adaptation_rate` configuration
- modulate weight updates and values by cosine of phase difference
- document parameters in yaml manual and tutorial
- update tests for new behaviour and add phase gating test

## Testing
- `pytest tests/test_neuronenblitz_enhancements.py::test_phase_gated_updates_modulate_direction -q`
- `pytest tests/test_neuronenblitz_enhancements.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68833e099d888327b92df0c834504b62