### PR TITLE
Add shortcut synapse mechanism to Neuronenblitz

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -113,6 +113,7 @@ Each entry is listed under its section heading.
 - rl_epsilon
 - rl_epsilon_decay
 - rl_min_epsilon
+- shortcut_creation_threshold
 
 ## brain
 - save_threshold

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1089,6 +1089,21 @@ Run `python project24_cwfl.py` to see the field adapt across the dataset.
 
 Run `python project24b_phase_gated.py` to experiment with phase-based gating.
 
+## Project 24c – Shortcut Synapse Formation (Experimental)
+
+**Goal:** Automatically create direct connections along heavily traversed paths.**
+
+1. **Set a threshold** by adjusting `neuronenblitz.shortcut_creation_threshold`
+   in `config.yaml`. A value of ``0`` disables shortcut creation.
+2. **Train or repeatedly call** `dynamic_wander` on the same inputs. Once the
+   identical path has been taken enough times, MARBLE will insert a new synapse
+   from the first to the last neuron of that path.
+3. **Observe** the console for "Shortcut created" messages or inspect the core's
+   synapse list to verify the new connection.
+
+Run `python project24c_shortcuts.py` to watch shortcuts appear in a minimal
+network.
+
 ## Project 25 – Neural Schema Induction (Theory)
 
 **Goal:** Demonstrate structural learning of repeated reasoning patterns.**

--- a/config.yaml
+++ b/config.yaml
@@ -107,6 +107,7 @@ neuronenblitz:
   rl_epsilon: 1.0
   rl_epsilon_decay: 0.95
   rl_min_epsilon: 0.1
+  shortcut_creation_threshold: 5
 brain:
   save_threshold: 0.05
   max_saved_models: 5

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -257,6 +257,9 @@ neuronenblitz:
   rl_epsilon_decay: Multiplicative decay applied to ``rl_epsilon`` each time an
     update occurs.
   rl_min_epsilon: Smallest allowed exploration rate once decay has taken place.
+  shortcut_creation_threshold: Number of times the exact synapse path must be
+    observed before a direct shortcut connection from the first to the last
+    neuron is added. Set ``0`` to disable automatic shortcut formation.
 
 brain:
   save_threshold: Minimum improvement in validation loss required before the


### PR DESCRIPTION
## Summary
- introduce `shortcut_creation_threshold` to Neuronenblitz
- track path usage and create direct shortcut synapses
- document new option in config, YAML manual, configurable parameters
- expand tutorial with experimental shortcut project
- add unit test covering shortcut creation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883420e70b08327905a4ebbdedd42c8