### PR TITLE
Add chaotic gating feature to Neuronenblitz

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -114,6 +114,9 @@ Each entry is listed under its section heading.
 - rl_epsilon_decay
 - rl_min_epsilon
 - shortcut_creation_threshold
+- chaotic_gating_enabled
+- chaotic_gating_param
+- chaotic_gate_init
 
 ## brain
 - save_threshold

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1104,6 +1104,18 @@ Run `python project24b_phase_gated.py` to experiment with phase-based gating.
 Run `python project24c_shortcuts.py` to watch shortcuts appear in a minimal
 network.
 
+## Project 24d – Chaotic Update Gating (Experimental)
+
+**Goal:** Explore logistic-map modulation of weight updates.**
+
+1. **Enable chaotic gating** by setting `neuronenblitz.chaotic_gating_enabled: true`
+   in `config.yaml`. Adjust `chaotic_gating_param` and `chaotic_gate_init` to tune
+   the behaviour.
+2. **Train a small model** as in previous projects and observe
+   `neuronenblitz.get_current_gate()` after each epoch to see how the gate evolves.
+
+Run `python project24d_chaotic_gating.py` to test the effect on learning.
+
 ## Project 25 – Neural Schema Induction (Theory)
 
 **Goal:** Demonstrate structural learning of repeated reasoning patterns.**

--- a/config.yaml
+++ b/config.yaml
@@ -108,6 +108,9 @@ neuronenblitz:
   rl_epsilon_decay: 0.95
   rl_min_epsilon: 0.1
   shortcut_creation_threshold: 5
+  chaotic_gating_enabled: false
+  chaotic_gating_param: 3.7
+  chaotic_gate_init: 0.5
 brain:
   save_threshold: 0.05
   max_saved_models: 5

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -260,6 +260,13 @@ neuronenblitz:
   shortcut_creation_threshold: Number of times the exact synapse path must be
     observed before a direct shortcut connection from the first to the last
     neuron is added. Set ``0`` to disable automatic shortcut formation.
+  chaotic_gating_enabled: Enables logistic-map scaling of each weight update.
+    When true the gate evolves chaotically and multiplies the computed update
+    value, introducing non-linear training dynamics.
+  chaotic_gating_param: Bifurcation parameter for the logistic gate update.
+    Values between ``3.6`` and ``4.0`` produce strong chaotic behaviour.
+  chaotic_gate_init: Starting value for the gate. Must lie between ``0`` and
+    ``1`` and determines the initial update scale.
 
 brain:
   save_threshold: Minimum improvement in validation loss required before the


### PR DESCRIPTION
## Summary
- introduce logistic-map based chaotic gating in `Neuronenblitz`
- document new `chaotic_gating_*` options in YAML config and manual
- list parameters in `CONFIGURABLE_PARAMETERS.md`
- add tutorial project for chaotic gating
- test weight updates scaled by the new gate

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(partial run due to time)*

------
https://chatgpt.com/codex/tasks/task_e_6883470fce9c8327b2124950689cecc3