### PR TITLE
Enhance Neuronenblitz context awareness

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -117,6 +117,8 @@ Each entry is listed under its section heading.
 - chaotic_gating_enabled
 - chaotic_gating_param
 - chaotic_gate_init
+- context_history_size
+- context_embedding_decay
 
 ## brain
 - save_threshold

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1327,17 +1327,21 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
 21. **Tune neuromodulatory signals** on the *Neuromodulation* tab. Adjust the
     sliders for arousal, stress and reward or set an emotion string, then press
     **Update Signals** to modify MARBLE's internal context on the fly.
-22. **Manage lobes** on the *Lobe Manager* tab. View attention scores for each
+22. **Experiment with context history** by adjusting `context_history_size` and
+    `context_embedding_decay` on the *Settings* tab. These options control how
+    many neuromodulatory states influence wandering and how quickly older
+    signals fade.
+23. **Manage lobes** on the *Lobe Manager* tab. View attention scores for each
     lobe, create new lobes from selected neuron IDs, reorganize the current
     structure or apply self-attention updates with a single click.
-23. **Read the documentation** on the *Documentation* tab. Every markdown file
+24. **Read the documentation** on the *Documentation* tab. Every markdown file
     in the repository, including the architecture overview, configurable
     parameters list and machine learning handbook, can be opened here for quick
     reference.
-24. **Browse source code** on the *Source Browser* tab. Select any module and
+25. **Browse source code** on the *Source Browser* tab. Select any module and
     click **Show Source** to view its implementation without leaving the
     playground.
-25. **Run unit tests** on the *Tests* tab. Select one or more test files and
+26. **Run unit tests** on the *Tests* tab. Select one or more test files and
     click **Run Tests** to verify everything works as expected.
 26. **Control asynchronous behaviour** on the *Async Training* tab. Start
     background training threads or enable auto-firing so MARBLE keeps learning

--- a/config.yaml
+++ b/config.yaml
@@ -111,6 +111,8 @@ neuronenblitz:
   chaotic_gating_enabled: false
   chaotic_gating_param: 3.7
   chaotic_gate_init: 0.5
+  context_history_size: 10
+  context_embedding_decay: 0.9
 brain:
   save_threshold: 0.05
   max_saved_models: 5

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -267,6 +267,12 @@ neuronenblitz:
     Values between ``3.6`` and ``4.0`` produce strong chaotic behaviour.
   chaotic_gate_init: Starting value for the gate. Must lie between ``0`` and
     ``1`` and determines the initial update scale.
+  context_history_size: Number of recent neuromodulatory contexts to keep
+    in memory. Larger values allow long-term trends to influence wandering but
+    consume more memory. Typical range is 5–20.
+  context_embedding_decay: Multiplicative decay applied when computing the
+    context embedding from history. ``1.0`` weights all contexts equally while
+    lower values emphasise more recent entries.
 
 brain:
   save_threshold: Minimum improvement in validation loss required before the


### PR DESCRIPTION
## Summary
- extend Neuronenblitz with context history tracking
- bias wandering with context embeddings
- document new parameters and add defaults
- mention context options in tutorial
- test context history behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_async_training.py::test_training_and_inference_simultaneous -q`
- `pytest -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6883555d36848327bf642aeab98831e3