### PR TITLE
Add emergent connection probability

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -119,6 +119,7 @@ Each entry is listed under its section heading.
 - chaotic_gate_init
 - context_history_size
 - context_embedding_decay
+- emergent_connection_prob
 
 ## brain
 - save_threshold

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1331,7 +1331,11 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
     `context_embedding_decay` on the *Settings* tab. These options control how
     many neuromodulatory states influence wandering and how quickly older
     signals fade.
-23. **Manage lobes** on the *Lobe Manager* tab. View attention scores for each
+23. **Encourage emergent connections** by increasing
+    `neuronenblitz.emergent_connection_prob` on the *Settings* tab. A value near
+    `0.1` lets `dynamic_wander` occasionally create new random synapses, which
+    can foster unexpected network behaviour.
+24. **Manage lobes** on the *Lobe Manager* tab. View attention scores for each
     lobe, create new lobes from selected neuron IDs, reorganize the current
     structure or apply self-attention updates with a single click.
 24. **Read the documentation** on the *Documentation* tab. Every markdown file

--- a/config.yaml
+++ b/config.yaml
@@ -113,6 +113,7 @@ neuronenblitz:
   chaotic_gate_init: 0.5
   context_history_size: 10
   context_embedding_decay: 0.9
+  emergent_connection_prob: 0.05
 brain:
   save_threshold: 0.05
   max_saved_models: 5

--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -123,6 +123,7 @@ class Neuronenblitz:
         chaotic_gate_init=0.5,
         context_history_size=10,
         context_embedding_decay=0.9,
+        emergent_connection_prob=0.05,
         remote_client=None,
         torrent_client=None,
         torrent_map=None,
@@ -195,6 +196,7 @@ class Neuronenblitz:
         self.chaotic_gate = chaotic_gate_init
         self.context_history_size = int(context_history_size)
         self.context_embedding_decay = float(context_embedding_decay)
+        self.emergent_connection_prob = float(emergent_connection_prob)
 
         self.combine_fn = combine_fn if combine_fn is not None else default_combine_fn
         self.loss_fn = loss_fn if loss_fn is not None else default_loss_fn
@@ -677,6 +679,7 @@ class Neuronenblitz:
             if apply_plasticity:
                 self.apply_structural_plasticity(final_path)
                 self._record_path_usage([s for (_, s) in final_path if s is not None])
+                self.maybe_create_emergent_synapse()
             result_path = [s for (_, s) in final_path if s is not None]
             if not apply_plasticity:
                 now = datetime.now(timezone.utc)
@@ -1115,3 +1118,21 @@ class Neuronenblitz:
                 synapse_type=random.choice(SYNAPSE_TYPES),
             )
         print(f"Shortcut created from {src} to {tgt}")
+
+    def maybe_create_emergent_synapse(self):
+        """Randomly create a new synapse to encourage emergent structure."""
+        if random.random() >= self.emergent_connection_prob:
+            return None
+        if len(self.core.neurons) < 2:
+            return None
+        src, tgt = random.sample(range(len(self.core.neurons)), 2)
+        if src == tgt:
+            return None
+        weight = random.uniform(0.1, 1.0)
+        syn = self.core.add_synapse(
+            src,
+            tgt,
+            weight=weight,
+            synapse_type=random.choice(SYNAPSE_TYPES),
+        )
+        return syn

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -79,6 +79,7 @@ def test_load_config_defaults():
     assert cfg["neuronenblitz"]["dynamic_attention_enabled"] is True
     assert cfg["neuronenblitz"]["backtrack_depth_limit"] == 10
     assert cfg["neuronenblitz"]["synapse_update_cap"] == 1.0
+    assert cfg["neuronenblitz"]["emergent_connection_prob"] == 0.05
     assert cfg["memory_system"]["threshold"] == 0.5
     assert cfg["neuronenblitz"]["max_wander_depth"] == 100
     assert cfg["memory_system"]["consolidation_interval"] == 10

--- a/tests/test_neuronenblitz_enhancements.py
+++ b/tests/test_neuronenblitz_enhancements.py
@@ -633,3 +633,21 @@ def test_context_history_size_limit_and_embedding():
     assert len(nb.context_history) == 2
     emb = nb.get_context_embedding()
     assert np.allclose(emb, [0.5, 1.0, 1.0])
+
+
+def test_emergent_connection_creation(monkeypatch):
+    random.seed(0)
+    core, _ = create_simple_core()
+    nb = Neuronenblitz(
+        core,
+        emergent_connection_prob=1.0,
+        split_probability=0.0,
+        alternative_connection_prob=0.0,
+        backtrack_probability=0.0,
+        backtrack_enabled=False,
+    )
+    monkeypatch.setattr(nb, "decide_synapse_action", lambda: None)
+    prev = len(core.synapses)
+    monkeypatch.setattr(random, "random", lambda: 0.0)
+    nb.dynamic_wander(1.0)
+    assert len(core.synapses) == prev + 1

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -273,6 +273,10 @@ neuronenblitz:
   context_embedding_decay: Multiplicative decay applied when computing the
     context embedding from history. ``1.0`` weights all contexts equally while
     lower values emphasise more recent entries.
+  emergent_connection_prob: Probability between 0 and 1 that ``dynamic_wander``
+    adds a random synapse connecting two neurons after each call. Higher values
+    encourage spontaneous cross-links, increasing the chance of unexpected
+    behaviours. Recommended range is 0.0–0.2.
 
 brain:
   save_threshold: Minimum improvement in validation loss required before the


### PR DESCRIPTION
## Summary
- add `emergent_connection_prob` parameter to Neuronenblitz
- randomly create new synapses during wandering when enabled
- document parameter in yaml manual and tutorial
- update config and list of configurable parameters
- test emergent synapse creation and config loading

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails to complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_688359bd2a28832781c1e8520b9c5403