### PR TITLE
Enhance conceptual learning in Neuronenblitz

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -120,6 +120,8 @@ Each entry is listed under its section heading.
 - context_history_size
 - context_embedding_decay
 - emergent_connection_prob
+- concept_association_threshold
+- concept_learning_rate
 
 ## brain
 - save_threshold

--- a/config.yaml
+++ b/config.yaml
@@ -114,6 +114,8 @@ neuronenblitz:
   context_history_size: 10
   context_embedding_decay: 0.9
   emergent_connection_prob: 0.05
+  concept_association_threshold: 5
+  concept_learning_rate: 0.1
 brain:
   save_threshold: 0.05
   max_saved_models: 5

--- a/tests/test_concept_association.py
+++ b/tests/test_concept_association.py
@@ -1,0 +1,22 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from tests.test_core_functions import minimal_params
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+
+
+def test_concept_neuron_created_after_threshold():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(
+        core,
+        concept_association_threshold=2,
+        concept_learning_rate=1.0,
+        split_probability=0.0,
+        alternative_connection_prob=0.0,
+        structural_plasticity_enabled=False,
+    )
+    start = len(core.neurons)
+    nb.dynamic_wander(1.0)
+    nb.dynamic_wander(1.0)
+    assert len(core.neurons) > start

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -277,6 +277,12 @@ neuronenblitz:
     adds a random synapse connecting two neurons after each call. Higher values
     encourage spontaneous cross-links, increasing the chance of unexpected
     behaviours. Recommended range is 0.0–0.2.
+  concept_association_threshold: Number of times a specific neuron pair must
+    appear consecutively in a wander path before a new concept neuron is
+    inserted to bridge them. Higher values create concepts more conservatively.
+  concept_learning_rate: Initial weight assigned to each side of a newly
+    created concept neuron. This determines how strongly the new concept
+    influences signal flow right after insertion.
 
 brain:
   save_threshold: Minimum improvement in validation loss required before the


### PR DESCRIPTION
## Summary
- add concept pair tracking and association creation in `Neuronenblitz`
- expose `concept_association_threshold` and `concept_learning_rate` parameters
- document new parameters in config and manuals
- test automatic creation of concept neurons

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(all tests: 235 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68835f3792a0832785786e4503011153