### PR TITLE
Add configurable Neuronenblitz parameters

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -122,6 +122,10 @@ Each entry is listed under its section heading.
 - emergent_connection_prob
 - concept_association_threshold
 - concept_learning_rate
+- weight_limit
+- wander_cache_size
+- rmsprop_beta
+- grad_epsilon
 
 ## brain
 - save_threshold

--- a/config.yaml
+++ b/config.yaml
@@ -116,6 +116,10 @@ neuronenblitz:
   emergent_connection_prob: 0.05
   concept_association_threshold: 5
   concept_learning_rate: 0.1
+  weight_limit: 1000000.0
+  wander_cache_size: 50
+  rmsprop_beta: 0.99
+  grad_epsilon: 1.0e-08
 brain:
   save_threshold: 0.05
   max_saved_models: 5

--- a/marble_main.py
+++ b/marble_main.py
@@ -116,6 +116,10 @@ class MARBLE:
             "exploration_bonus": 0.0,
             "synapse_potential_cap": 100.0,
             "attention_update_scale": 1.0,
+            "weight_limit": 1e6,
+            "wander_cache_size": 50,
+            "rmsprop_beta": 0.99,
+            "grad_epsilon": 1e-8,
         }
         if nb_params is not None:
             nb_defaults.update(nb_params)

--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -126,6 +126,10 @@ class Neuronenblitz:
         emergent_connection_prob=0.05,
         concept_association_threshold=5,
         concept_learning_rate=0.1,
+        weight_limit=1e6,
+        wander_cache_size=50,
+        rmsprop_beta=0.99,
+        grad_epsilon=1e-8,
         remote_client=None,
         torrent_client=None,
         torrent_map=None,
@@ -202,6 +206,8 @@ class Neuronenblitz:
         self.concept_association_threshold = int(concept_association_threshold)
         self.concept_learning_rate = float(concept_learning_rate)
 
+        self._weight_limit = float(weight_limit)
+
         self.combine_fn = combine_fn if combine_fn is not None else default_combine_fn
         self.loss_fn = loss_fn if loss_fn is not None else default_loss_fn
         self.loss_module = loss_module
@@ -210,8 +216,6 @@ class Neuronenblitz:
             if weight_update_fn is not None
             else default_weight_update_fn
         )
-
-        self._weight_limit = 1e6
 
         self.training_history = []
         self.global_activation_count = 0
@@ -232,12 +236,12 @@ class Neuronenblitz:
         self._eligibility_traces = {}
         self.wander_cache = {}
         self._cache_order = deque()
-        self._cache_max_size = 50
+        self._cache_max_size = int(wander_cache_size)
         self.wander_cache_ttl = wander_cache_ttl
         self.q_encoding = default_q_encoding
         self._grad_sq = {}
-        self._rmsprop_beta = 0.99
-        self._grad_epsilon = 1e-8
+        self._rmsprop_beta = float(rmsprop_beta)
+        self._grad_epsilon = float(grad_epsilon)
         # Store previous gradients per synapse for alignment-based gating
         self._prev_gradients = {}
         # Track path usage for shortcut creation

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -173,3 +173,20 @@ def test_synapse_update_cap_configurable(tmp_path):
         yaml.safe_dump(cfg, f)
     marble = create_marble_from_config(str(cfg_path))
     assert marble.neuronenblitz.synapse_update_cap == 0.5
+
+
+def test_new_nb_parameters_configurable(tmp_path):
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg = load_config()
+    nb = cfg["neuronenblitz"]
+    nb["weight_limit"] = 123.0
+    nb["wander_cache_size"] = 7
+    nb["rmsprop_beta"] = 0.8
+    nb["grad_epsilon"] = 1e-6
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(cfg, f)
+    marble = create_marble_from_config(str(cfg_path))
+    assert marble.neuronenblitz._weight_limit == 123.0
+    assert marble.neuronenblitz._cache_max_size == 7
+    assert marble.neuronenblitz._rmsprop_beta == 0.8
+    assert marble.neuronenblitz._grad_epsilon == 1e-6

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -283,6 +283,15 @@ neuronenblitz:
   concept_learning_rate: Initial weight assigned to each side of a newly
     created concept neuron. This determines how strongly the new concept
     influences signal flow right after insertion.
+  weight_limit: Upper bound applied to every synapse weight. Any update that
+    would exceed this magnitude is clipped to maintain numerical stability.
+  wander_cache_size: Maximum number of recent ``dynamic_wander`` results kept
+    in the cache. Older entries are discarded once this count is exceeded.
+  rmsprop_beta: Exponential decay factor used by the RMSProp-like gradient
+    smoothing in ``apply_weight_updates_and_attention``. Typical values are
+    0.9–0.99.
+  grad_epsilon: Small constant added when normalising gradients to avoid
+    division by zero.
 
 brain:
   save_threshold: Minimum improvement in validation loss required before the


### PR DESCRIPTION
## Summary
- expose weight limit, wander cache size and RMSProp parameters via YAML
- document the new options and defaults
- test configuring the new parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a17f318883279c2e2feb70cde3b4