### PR TITLE
Add configurable weight initialization types

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -34,6 +34,8 @@ Each entry is listed under its section heading.
 - representation_activation
 - apply_layer_norm
 - weight_init_mean
+- weight_init_std
+- weight_init_type
 - message_passing_beta
 - attention_temperature
 - attention_dropout

--- a/config.yaml
+++ b/config.yaml
@@ -29,6 +29,8 @@ core:
   representation_activation: "tanh"
   apply_layer_norm: true
   weight_init_mean: 0.0
+  weight_init_std: 1.0
+  weight_init_type: "uniform"
   message_passing_beta: 1.0
   attention_temperature: 1.0
   attention_dropout: 0.0

--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -1077,7 +1077,7 @@ class Neuronenblitz:
                 self.core.add_synapse(
                     src,
                     tgt,
-                    weight=random.uniform(0.1, 1.0),
+                    weight=self.core._init_weight(),
                     synapse_type=create_type,
                 )
         else:
@@ -1139,7 +1139,7 @@ class Neuronenblitz:
         src, tgt = random.sample(range(len(self.core.neurons)), 2)
         if src == tgt:
             return None
-        weight = random.uniform(0.1, 1.0)
+        weight = self.core._init_weight()
         syn = self.core.add_synapse(
             src,
             tgt,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,6 +20,8 @@ def test_load_config_defaults():
     assert cfg["core"]["init_noise_std"] == 0.0
     assert cfg["core"]["weight_init_min"] == 0.5
     assert cfg["core"]["weight_init_max"] == 1.5
+    assert cfg["core"]["weight_init_std"] == 1.0
+    assert cfg["core"]["weight_init_type"] == "uniform"
     assert cfg["core"]["mandelbrot_escape_radius"] == 2.0
     assert cfg["core"]["mandelbrot_power"] == 2
     assert cfg["core"]["tier_autotune_enabled"] is True

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -28,6 +28,8 @@ def minimal_params():
         'attention_dropout': 0.0,
         'energy_threshold': 0.0,
         'representation_noise_std': 0.0,
+        'weight_init_type': 'uniform',
+        'weight_init_std': 1.0,
     }
 
 
@@ -152,6 +154,18 @@ def test_core_uses_mandelbrot_parameters():
     values_alt = [n.value for n in core_alt.neurons]
     values_default = [n.value for n in core_default.neurons]
     assert values_alt != values_default
+
+
+def test_weight_initialization_types():
+    random.seed(0)
+    params = minimal_params()
+    params["weight_init_type"] = "normal"
+    params["weight_init_mean"] = 2.0
+    params["weight_init_std"] = 0.1
+    core = Core(params)
+    weights = [s.weight for s in core.synapses]
+    avg = sum(weights) / len(weights)
+    assert abs(avg - 2.0) < 0.1
 
 
 def test_simple_mlp_handles_invalid_input():

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -72,6 +72,14 @@ core:
     stabilises training dynamics. Set ``false`` to disable.
   weight_init_mean: Mean of the normal distribution used to initialize
     synaptic weights.
+  weight_init_std: Standard deviation of the normal distribution when
+    ``weight_init_type`` is set to ``"normal"``. Higher values produce a
+    wider spread of initial weights.
+  weight_init_type: Distribution used for initial synapse weights. ``"uniform"``
+    samples values between ``weight_init_min`` and ``weight_init_max``.
+    ``"normal"`` draws from a normal distribution with ``weight_init_mean``
+    and ``weight_init_std``. ``"xavier_uniform"`` uses Xavier uniform
+    initialization based on the connection fan-in and fan-out.
   message_passing_beta: Secondary mixing factor controlling how quickly new
     representations replace old ones when ``alpha`` alone is insufficient.
   attention_temperature: Softmax temperature used by the attention module


### PR DESCRIPTION
## Summary
- allow choosing synapse weight initialization strategy
- document new `weight_init_std` and `weight_init_type` parameters
- test normal initialization and new defaults

## Testing
- `pytest tests/test_core_functions.py::test_weight_initialization_types -q`
- `pytest tests/test_async_training.py::test_training_and_inference_simultaneous -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c427a7f08327988a510bf67cfa08