### PR TITLE
Add early cleanup to Marble Core

### DIFF
--- a/tests/test_core_cleanup.py
+++ b/tests/test_core_cleanup.py
@@ -1,0 +1,16 @@
+import random
+from marble_core import Core
+from tests.test_core_functions import minimal_params
+
+
+def test_early_cleanup_removes_unused_neurons():
+    params = minimal_params()
+    params["early_cleanup_enabled"] = True
+    params["memory_cleanup_interval"] = 0
+    core = Core(params)
+    core.neurons[0].synapses.clear()
+    core.synapses = [s for s in core.synapses if s.source != 0 and s.target != 0]
+    core.neurons[0].energy = 0.0
+    before = len(core.neurons)
+    core.cleanup_unused_neurons()
+    assert len(core.neurons) == before - 1


### PR DESCRIPTION
## Summary
- implement `cleanup_unused_neurons` in `marble_core.py`
- invoke cleanup during expansion and message passing
- add unit test covering early cleanup behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883cd5d84f88327b693afda3a73e4fd