### PR TITLE
Add global phase for message passing

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -52,6 +52,7 @@ Each entry is listed under its section heading.
 - cross_tier_migration
 - synapse_echo_length
 - synapse_echo_decay
+- global_phase_rate
 - interconnection_prob
 
 ## neuronenblitz

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -36,6 +36,7 @@ This tutorial demonstrates every major component of MARBLE through a series of p
    ```
 4. **Edit configuration**. Open `config.yaml` and modify the values under `core` to adjust the representation size and other parameters. Save the file after your edits.
    To experiment with sparser communication set `attention_dropout` to a value between `0.0` and `1.0`. Higher values randomly ignore more incoming messages during attention-based updates.
+   You can also introduce oscillatory gating of synaptic weights by setting `global_phase_rate` to a value above `0.0`. Each call to `run_message_passing` then advances the internal `global_phase`, modulating every synapse via a cosine of its individual `phase`.
 5. **Create a MARBLE instance** from the configuration:
    ```python
    from marble_main import MARBLE

--- a/config.yaml
+++ b/config.yaml
@@ -47,6 +47,7 @@ core:
   cross_tier_migration: true
   synapse_echo_length: 5
   synapse_echo_decay: 0.9
+  global_phase_rate: 0.0
   interconnection_prob: 0.05
 neuronenblitz:
   backtrack_probability: 0.3

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -91,6 +91,11 @@ core:
     while ``1.0`` results in no neighbours being considered. When messages are
     dropped the remaining attention weights are renormalized so the sum equals
     one.
+  global_phase_rate: Amount added to ``global_phase`` every time
+    ``run_message_passing`` executes. Combined with each synapse's individual
+    ``phase`` value, this creates oscillatory gating via the cosine in
+    ``Synapse.effective_weight``. Set to ``0.0`` to disable phase-based
+    modulation or increase toward ``math.pi`` for quicker oscillations.
   energy_threshold: Minimum energy level required before neurons participate in
     message passing. Helps filter out inactive units.
   reinforcement_learning_enabled: Enable or disable the internal Q-learning


### PR DESCRIPTION
## Summary
- extend message passing to support a configurable global phase
- increment global phase on each run
- document `global_phase_rate`
- mention oscillatory gating in the tutorial
- add tests for phase behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d1f997548327982bb2d859d2100d