### PR TITLE
Implement dataset loader and metrics logging features

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -264,6 +264,8 @@ Each entry is listed under its section heading.
 - show_neuron_ids
 - dpi
 - track_memory_usage
+- log_dir
+- csv_log_path
 ## metrics_dashboard
 - enabled
 - host

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1239,7 +1239,16 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
        "mnist", "train[:100]", input_key="image", target_key="label"
    )
    ```
-2. **Create and train a MARBLE system** using a pandas dataframe:
+2. **Load a CSV dataset from a URL** using the `dataset_loader` utility:
+   ```python
+   from dataset_loader import load_dataset
+
+   pairs = load_dataset(
+       "https://example.com/data.csv",
+       cache_dir="cached_datasets",
+   )
+   ```
+3. **Create and train a MARBLE system** using a pandas dataframe:
    ```python
    import pandas as pd
    from marble_interface import new_marble_system, train_from_dataframe

--- a/config.yaml
+++ b/config.yaml
@@ -255,6 +255,8 @@ metrics_visualizer:
   show_neuron_ids: false
   dpi: 100
   track_memory_usage: false
+  log_dir: "logs"
+  csv_log_path: "metrics.csv"
 metrics_dashboard:
   enabled: false
   host: "localhost"

--- a/dataset_loader.py
+++ b/dataset_loader.py
@@ -1,0 +1,50 @@
+import os
+import hashlib
+import requests
+import pandas as pd
+from typing import Any
+
+
+def _download_file(url: str, path: str) -> None:
+    """Download ``url`` to ``path`` creating parent directories if needed."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with requests.get(url, stream=True, timeout=30) as r:
+        r.raise_for_status()
+        with open(path, "wb") as f:
+            for chunk in r.iter_content(chunk_size=8192):
+                f.write(chunk)
+
+
+def load_dataset(
+    source: str,
+    *,
+    cache_dir: str = "dataset_cache",
+    input_col: str = "input",
+    target_col: str = "target",
+    limit: int | None = None,
+    force_refresh: bool = False,
+) -> list[tuple[Any, Any]]:
+    """Load a CSV or JSON dataset from ``source`` which may be a local path or URL."""
+    if source.startswith("http://") or source.startswith("https://"):
+        name = os.path.basename(source)
+        if not name:
+            name = hashlib.md5(source.encode("utf-8")).hexdigest() + ".dat"
+        cached = os.path.join(cache_dir, name)
+        if force_refresh or not os.path.exists(cached):
+            _download_file(source, cached)
+        path = cached
+    else:
+        path = source
+    ext = os.path.splitext(path)[1].lower()
+    if ext in {".csv", ""}:
+        df = pd.read_csv(path)
+    elif ext in {".json", ".jsonl"}:
+        df = pd.read_json(path, lines=ext == ".jsonl")
+    else:
+        raise ValueError("Unsupported dataset format")
+    pairs: list[tuple[Any, Any]] = []
+    for _, row in df.iterrows():
+        pairs.append((row[input_col], row[target_col]))
+        if limit is not None and len(pairs) >= limit:
+            break
+    return pairs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+absl-py==2.3.1
 aiohappyeyeballs==2.6.1
 aiohttp==3.12.14
 aiosignal==1.4.0
@@ -26,6 +27,7 @@ frozenlist==1.7.0
 fsspec==2024.6.1
 gitdb==4.0.12
 GitPython==3.1.44
+grpcio==1.74.0
 hf-xet==1.1.5
 huggingface-hub==0.33.4
 idna==3.10
@@ -43,6 +45,7 @@ jsonschema==4.25.0
 jsonschema-specifications==2025.4.1
 jupyterlab_widgets==3.0.15
 kiwisolver==1.4.8
+Markdown==3.8.2
 markdown-it-py==3.0.0
 MarkupSafe==2.1.5
 matplotlib==3.10.3
@@ -99,6 +102,8 @@ stack-data==0.6.3
 streamlit==1.35.0
 sympy==1.13.3
 tenacity==8.5.0
+tensorboard==2.20.0
+tensorboard-data-server==0.7.2
 threadpoolctl==3.6.0
 tokenizers==0.19.1
 toml==0.10.2

--- a/tests/test_brain_io.py
+++ b/tests/test_brain_io.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import random
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -46,7 +47,7 @@ def test_brain_save_and_load(tmp_path):
 
 def test_metrics_visualizer_update():
     from marble_base import MetricsVisualizer
-    mv = MetricsVisualizer()
+    mv = MetricsVisualizer(log_dir="tb_logs", csv_log_path="metrics.csv")
     mv.update({'loss': 0.5, 'vram_usage': 0.1, 'arousal': 0.2,
                'stress': 0.1, 'reward': 0.3,
                'plasticity_threshold': 5.0,
@@ -56,6 +57,9 @@ def test_metrics_visualizer_update():
     assert mv.metrics['vram_usage'][-1] == 0.1
     assert mv.metrics['arousal'][-1] == 0.2
     assert mv.metrics['plasticity_threshold'][-1] == 5.0
+    mv.close()
+    assert os.path.exists("metrics.csv")
+    assert any(p.name.startswith("events.out.tfevents") for p in Path("tb_logs").iterdir())
 
 
 def test_brain_neuromodulatory_system_integration():

--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import threading
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from functools import partial
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dataset_loader import load_dataset
+
+
+def _serve_directory(directory, port):
+    handler = partial(SimpleHTTPRequestHandler, directory=directory)
+    httpd = HTTPServer(("localhost", port), handler)
+    thread = threading.Thread(target=httpd.serve_forever)
+    thread.daemon = True
+    thread.start()
+    return httpd, thread
+
+
+def test_load_local_csv(tmp_path):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("input,target\n1,2\n3,4\n")
+    pairs = load_dataset(str(csv_path))
+    assert pairs == [(1, 2), (3, 4)]
+
+
+def test_load_remote_csv(tmp_path):
+    csv_path = tmp_path / "remote.csv"
+    csv_path.write_text("input,target\n5,6\n7,8\n")
+    httpd, thread = _serve_directory(tmp_path, 9000)
+    try:
+        url = f"http://localhost:9000/{csv_path.name}"
+        pairs = load_dataset(url, cache_dir=tmp_path / "cache")
+        assert pairs == [(5, 6), (7, 8)]
+    finally:
+        httpd.shutdown()
+        thread.join()

--- a/tests/test_neuron_validation.py
+++ b/tests/test_neuron_validation.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from marble_core import Neuron
+
+
+def test_invalid_stride():
+    n = Neuron(0, neuron_type="conv1d")
+    n.params["stride"] = 0
+    with pytest.raises(ValueError):
+        n.validate_params()
+
+
+def test_invalid_dropout_prob():
+    n = Neuron(1, neuron_type="dropout")
+    n.params["p"] = 1.5
+    with pytest.raises(ValueError):
+        n.validate_params()

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -590,6 +590,10 @@ metrics_visualizer:
   track_memory_usage: When true the visualizer records both system RAM and GPU
     memory consumption after each training epoch. This requires the ``psutil``
     package and uses ``torch.cuda`` when a CUDA-capable device is available.
+  log_dir: Directory where TensorBoard event files are written. When set,
+    you can run ``tensorboard --logdir=<log_dir>`` to monitor metrics.
+  csv_log_path: Path to a CSV file receiving all metric values after each
+    update. Useful for analysis with spreadsheet tools.
 
 metrics_dashboard:
   # Optional web dashboard built with Plotly Dash for real-time monitoring.


### PR DESCRIPTION
## Summary
- add a small dataset loader that supports local and remote CSV/JSON files
- extend `MetricsVisualizer` with TensorBoard and CSV logging
- validate neuron parameters and add GPU-aware `_simple_mlp`
- document new metrics options in `config.yaml`, `CONFIGURABLE_PARAMETERS.md` and `yaml-manual.txt`
- update tutorial with dataset loader usage
- add tests for dataset loader, neuron validation and metrics logging
- update dependencies

## Testing
- `pytest tests/test_brain_io.py -k test_metrics_visualizer_update -q`
- `pytest tests/test_dataset_loader.py tests/test_neuron_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e16892c88327aa738639cdee7ca1