### PR TITLE
Implement CLI and validation improvements

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -11,6 +11,14 @@ This tutorial demonstrates every major component of MARBLE through a series of p
    After the packages are installed you can verify the environment by running `python -c "import marble_main"` which should finish silently.
 2. **Review the documentation**. Read [ARCHITECTURE_OVERVIEW.md](ARCHITECTURE_OVERVIEW.md) for a high level view of MARBLE and consult [yaml-manual.txt](yaml-manual.txt) for an explanation of every configuration option.
 
+3. **Use the command line interface**. The `cli.py` script allows training from
+   the terminal without writing custom code:
+   ```bash
+   python cli.py --config config.yaml --train path/to/data.csv --epochs 10 --save trained_marble.pkl
+   ```
+   Replace the dataset path with your own CSV or JSON file. The optional
+   `--validate` flag specifies a validation dataset.
+
 ## Project 1 – Numeric Regression (Easy)
 
 **Goal:** Train MARBLE on a simple numeric dataset.

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,26 @@
+import argparse
+from config_loader import create_marble_from_config
+from dataset_loader import load_dataset
+from marble_interface import save_marble_system
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="MARBLE command line interface")
+    parser.add_argument("--config", "-c", help="Path to config YAML", default=None)
+    parser.add_argument("--train", help="Path or URL to training dataset")
+    parser.add_argument("--epochs", type=int, default=1, help="Number of training epochs")
+    parser.add_argument("--validate", help="Optional validation dataset path")
+    parser.add_argument("--save", help="Path to save trained model")
+    args = parser.parse_args()
+
+    marble = create_marble_from_config(args.config)
+    if args.train:
+        train_data = load_dataset(args.train)
+        val_data = load_dataset(args.validate) if args.validate else None
+        marble.get_brain().train(train_data, epochs=args.epochs, validation_examples=val_data)
+    if args.save:
+        save_marble_system(marble, args.save)
+
+
+if __name__ == "__main__":
+    main()

--- a/marble_core.py
+++ b/marble_core.py
@@ -370,6 +370,37 @@ class Neuron:
                 raise ValueError("dropout probability must be between 0 and 1")
         if "kernel" in self.params and not isinstance(self.params["kernel"], np.ndarray):
             raise ValueError("kernel must be a numpy.ndarray")
+        if "padding" in self.params and (
+            not isinstance(self.params["padding"], int) or self.params["padding"] < 0
+        ):
+            raise ValueError("padding must be a non-negative integer")
+        if "output_padding" in self.params:
+            op = self.params["output_padding"]
+            stride = self.params.get("stride", 1)
+            if (
+                not isinstance(op, int)
+                or op < 0
+                or (isinstance(stride, int) and op >= stride)
+            ):
+                raise ValueError("output_padding must be >=0 and less than stride")
+        if "negative_slope" in self.params and self.params["negative_slope"] < 0:
+            raise ValueError("negative_slope must be non-negative")
+        if {
+            "num_embeddings",
+            "embedding_dim",
+        }.issubset(self.params):
+            num = self.params["num_embeddings"]
+            dim = self.params["embedding_dim"]
+            weights = self.params.get("weights")
+            if not isinstance(num, int) or num <= 0:
+                raise ValueError("num_embeddings must be a positive integer")
+            if not isinstance(dim, int) or dim <= 0:
+                raise ValueError("embedding_dim must be a positive integer")
+            if weights is not None and (
+                not isinstance(weights, np.ndarray)
+                or weights.shape != (num, dim)
+            ):
+                raise ValueError("weights shape must match (num_embeddings, embedding_dim)")
 
     def initialize_params(self) -> None:
         """Initialize layer-like parameters based on ``neuron_type``."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from tests.test_core_functions import minimal_params
+
+
+def test_cli_help():
+    result = subprocess.run([sys.executable, "cli.py", "--help"], capture_output=True)
+    assert result.returncode == 0
+    assert b"MARBLE command line interface" in result.stdout
+
+
+def test_cli_no_train(tmp_path):
+    cfg = Path(tmp_path) / "cfg.yaml"
+    import yaml
+
+    cfg.write_text(yaml.safe_dump({"core": minimal_params()}))
+    result = subprocess.run([
+        sys.executable,
+        "cli.py",
+        "--config",
+        str(cfg),
+    ])
+    assert result.returncode == 0

--- a/tests/test_neuron_validation.py
+++ b/tests/test_neuron_validation.py
@@ -18,3 +18,18 @@ def test_invalid_dropout_prob():
     n.params["p"] = 1.5
     with pytest.raises(ValueError):
         n.validate_params()
+
+
+def test_negative_padding():
+    n = Neuron(2, neuron_type="conv2d")
+    n.params["padding"] = -1
+    with pytest.raises(ValueError):
+        n.validate_params()
+
+
+def test_output_padding_gte_stride():
+    n = Neuron(3, neuron_type="convtranspose1d")
+    n.params["stride"] = 2
+    n.params["output_padding"] = 2
+    with pytest.raises(ValueError):
+        n.validate_params()


### PR DESCRIPTION
## Summary
- improve `validate_params` with additional checks
- add a new `cli.py` command line interface for training
- document CLI usage in `TUTORIAL.md`
- expand neuron validation tests and add CLI tests

## Testing
- `pytest tests/test_neuron_validation.py tests/test_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e505658c83279a40b557b3d05812