### PR TITLE
Implement config validation and parameter checks

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import yaml
+from config_schema import validate_config_schema
 
 from marble_main import MARBLE
 from neuromodulatory_system import NeuromodulatorySystem
@@ -16,6 +17,7 @@ def load_config(path: str | None = None) -> dict:
     cfg_path = Path(path) if path is not None else DEFAULT_CONFIG_FILE
     with open(cfg_path, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
+    validate_config_schema(data)
     return data
 
 

--- a/config_schema.py
+++ b/config_schema.py
@@ -1,0 +1,22 @@
+import jsonschema
+
+CONFIG_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "core": {"type": "object"},
+        "neuronenblitz": {"type": "object"},
+        "brain": {
+            "type": "object",
+            "properties": {
+                "early_stopping_patience": {"type": "integer", "minimum": 0},
+                "early_stopping_delta": {"type": "number", "minimum": 0},
+            },
+        },
+    },
+    "required": ["core"],
+}
+
+
+def validate_config_schema(data: dict) -> None:
+    """Validate configuration dict using JSON schema."""
+    jsonschema.validate(instance=data, schema=CONFIG_SCHEMA)

--- a/marble_core.py
+++ b/marble_core.py
@@ -1535,6 +1535,28 @@ class Core:
         target_tier=None,
         neuron_types=None,
     ):
+        if not isinstance(num_new_neurons, int) or not isinstance(
+            num_new_synapses, int
+        ):
+            raise TypeError("num_new_neurons and num_new_synapses must be integers")
+        if num_new_neurons < 0 or num_new_synapses < 0:
+            raise ValueError(
+                "num_new_neurons and num_new_synapses must be non-negative"
+            )
+        if not 0.0 <= alternative_connection_prob <= 1.0:
+            raise ValueError("alternative_connection_prob must be between 0 and 1")
+        if target_tier is not None and target_tier not in TIER_REGISTRY:
+            raise ValueError(f"Unknown target_tier '{target_tier}'")
+        if neuron_types is not None:
+            if isinstance(neuron_types, list):
+                if not neuron_types:
+                    raise ValueError("neuron_types list cannot be empty")
+                for n_type in neuron_types:
+                    if n_type not in NEURON_TYPES:
+                        raise ValueError(f"Unknown neuron type: {n_type}")
+            else:
+                if neuron_types not in NEURON_TYPES:
+                    raise ValueError(f"Unknown neuron type: {neuron_types}")
         self.cleanup_unused_neurons()
         if target_tier is None:
             target_tier = self.choose_new_tier()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,9 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from config_loader import load_config, create_marble_from_config
+from config_schema import validate_config_schema
+import pytest
+import jsonschema
 import yaml
 from marble_main import MARBLE
 from remote_offload import RemoteBrainClient
@@ -194,3 +197,13 @@ def test_new_nb_parameters_configurable(tmp_path):
     assert marble.neuronenblitz._cache_max_size == 7
     assert marble.neuronenblitz._rmsprop_beta == 0.8
     assert marble.neuronenblitz._grad_epsilon == 1e-6
+
+
+def test_invalid_config_raises(tmp_path):
+    cfg = load_config()
+    cfg["brain"]["early_stopping_patience"] = -1
+    cfg_path = tmp_path / "bad.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(cfg, f)
+    with pytest.raises(jsonschema.ValidationError):
+        load_config(str(cfg_path))

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -100,6 +100,17 @@ def test_core_expand_assigns_types():
     assert types == {'excitatory'}
 
 
+def test_core_expand_invalid_params():
+    params = minimal_params()
+    core = Core(params)
+    with pytest.raises(ValueError):
+        core.expand(num_new_neurons=-1)
+    with pytest.raises(ValueError):
+        core.expand(num_new_neurons=1, target_tier="unknown")
+    with pytest.raises(ValueError):
+        core.expand(num_new_neurons=1, neuron_types="badtype")
+
+
 def test_file_tier_path_configurable(tmp_path):
     params = minimal_params()
     custom_path = tmp_path / "tier.dat"

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -1,6 +1,7 @@
 The configuration YAML file controls all components of MARBLE.  Each top-level
 section corresponds to a subsystem and exposes parameters that can be tuned to
-alter its behaviour.
+alter its behaviour.  When the file is loaded it is validated against an
+internal JSON schema to catch missing sections or invalid values early.
 
 core:
   xmin: Minimum X coordinate for the Mandelbrot seed. Defines the left boundary


### PR DESCRIPTION
## Summary
- validate YAML config using a new JSON schema
- guard `Core.expand` against invalid parameters
- add tests for config validation and invalid expand usage
- mention schema validation in `yaml-manual.txt`

## Testing
- `pytest tests/test_config.py tests/test_core_functions.py tests/test_cli.py -q`
- `pytest -q` *(partial output shown)*

------
https://chatgpt.com/codex/tasks/task_e_6883eea56a148327a56a9dcf3c5bfc7a