### PR TITLE
Improve parameter validation and CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,7 +1,7 @@
 import argparse
 from config_loader import create_marble_from_config
 from dataset_loader import load_dataset
-from marble_interface import save_marble_system
+from marble_interface import save_marble_system, evaluate_marble_system
 
 
 def main() -> None:
@@ -10,6 +10,7 @@ def main() -> None:
     parser.add_argument("--train", help="Path or URL to training dataset")
     parser.add_argument("--epochs", type=int, default=1, help="Number of training epochs")
     parser.add_argument("--validate", help="Optional validation dataset path")
+    parser.add_argument("--evaluate", help="Evaluation dataset for measuring MSE")
     parser.add_argument("--save", help="Path to save trained model")
     args = parser.parse_args()
 
@@ -18,6 +19,10 @@ def main() -> None:
         train_data = load_dataset(args.train)
         val_data = load_dataset(args.validate) if args.validate else None
         marble.get_brain().train(train_data, epochs=args.epochs, validation_examples=val_data)
+    if args.evaluate:
+        eval_data = load_dataset(args.evaluate)
+        mse = evaluate_marble_system(marble, eval_data)
+        print(f"Evaluation MSE: {mse:.6f}")
     if args.save:
         save_marble_system(marble, args.save)
 

--- a/config_schema.py
+++ b/config_schema.py
@@ -3,7 +3,14 @@ import jsonschema
 CONFIG_SCHEMA = {
     "type": "object",
     "properties": {
-        "core": {"type": "object"},
+        "core": {
+            "type": "object",
+            "properties": {
+                "representation_size": {"type": "integer", "minimum": 1},
+                "message_passing_alpha": {"type": "number", "minimum": 0, "maximum": 1},
+                "message_passing_beta": {"type": "number", "minimum": 0, "maximum": 1},
+            },
+        },
         "neuronenblitz": {"type": "object"},
         "brain": {
             "type": "object",

--- a/marble_core.py
+++ b/marble_core.py
@@ -341,6 +341,10 @@ class RemoteTier(Tier):
         self.limit_mb = None
 
 
+class InvalidNeuronParamsError(ValueError):
+    """Raised when neuron parameters fail validation."""
+
+
 class Neuron:
     def __init__(
         self,
@@ -354,7 +358,7 @@ class Neuron:
         self.value = value
         self.tier = tier
         if neuron_type not in NEURON_TYPES:
-            raise ValueError(
+            raise InvalidNeuronParamsError(
                 f"Unknown neuron_type '{neuron_type}'. Valid options are: {', '.join(NEURON_TYPES)}"
             )
         self.neuron_type = neuron_type
@@ -364,6 +368,8 @@ class Neuron:
         self.cluster_id = None
         self.attention_score = 0.0
         self.energy = 1.0
+        if rep_size <= 0:
+            raise InvalidNeuronParamsError("rep_size must be positive")
         self.representation = np.zeros(rep_size, dtype=float)
         self.params = {}
         self.value_history = []
@@ -375,19 +381,19 @@ class Neuron:
         if "stride" in self.params and (
             not isinstance(self.params["stride"], int) or self.params["stride"] <= 0
         ):
-            raise ValueError("stride must be a positive integer")
+            raise InvalidNeuronParamsError("stride must be a positive integer")
         if "p" in self.params:
             p = float(self.params["p"])
             if not 0.0 <= p <= 1.0:
-                raise ValueError("dropout probability must be between 0 and 1")
+                raise InvalidNeuronParamsError("dropout probability must be between 0 and 1")
         if "kernel" in self.params and not isinstance(
             self.params["kernel"], np.ndarray
         ):
-            raise ValueError("kernel must be a numpy.ndarray")
+            raise InvalidNeuronParamsError("kernel must be a numpy.ndarray")
         if "padding" in self.params and (
             not isinstance(self.params["padding"], int) or self.params["padding"] < 0
         ):
-            raise ValueError("padding must be a non-negative integer")
+            raise InvalidNeuronParamsError("padding must be a non-negative integer")
         if "output_padding" in self.params:
             op = self.params["output_padding"]
             stride = self.params.get("stride", 1)
@@ -396,23 +402,23 @@ class Neuron:
                 or op < 0
                 or (isinstance(stride, int) and op >= stride)
             ):
-                raise ValueError("output_padding must be >=0 and less than stride")
+                raise InvalidNeuronParamsError("output_padding must be >=0 and less than stride")
         if "negative_slope" in self.params and self.params["negative_slope"] < 0:
-            raise ValueError("negative_slope must be non-negative")
+            raise InvalidNeuronParamsError("negative_slope must be non-negative")
         if "alpha" in self.params and self.params["alpha"] <= 0:
-            raise ValueError("alpha must be positive")
+            raise InvalidNeuronParamsError("alpha must be positive")
         if "momentum" in self.params:
             mom = float(self.params["momentum"])
             if not 0.0 < mom < 1.0:
-                raise ValueError("momentum must be between 0 and 1")
+                raise InvalidNeuronParamsError("momentum must be between 0 and 1")
         if "eps" in self.params and self.params["eps"] <= 0:
-            raise ValueError("eps must be positive")
+            raise InvalidNeuronParamsError("eps must be positive")
         if "size" in self.params and (
             not isinstance(self.params["size"], int) or self.params["size"] <= 0
         ):
-            raise ValueError("size must be a positive integer")
+            raise InvalidNeuronParamsError("size must be a positive integer")
         if "axis" in self.params and not isinstance(self.params["axis"], int):
-            raise ValueError("axis must be an integer")
+            raise InvalidNeuronParamsError("axis must be an integer")
         if {
             "num_embeddings",
             "embedding_dim",
@@ -421,13 +427,13 @@ class Neuron:
             dim = self.params["embedding_dim"]
             weights = self.params.get("weights")
             if not isinstance(num, int) or num <= 0:
-                raise ValueError("num_embeddings must be a positive integer")
+                raise InvalidNeuronParamsError("num_embeddings must be a positive integer")
             if not isinstance(dim, int) or dim <= 0:
-                raise ValueError("embedding_dim must be a positive integer")
+                raise InvalidNeuronParamsError("embedding_dim must be a positive integer")
             if weights is not None and (
                 not isinstance(weights, np.ndarray) or weights.shape != (num, dim)
             ):
-                raise ValueError(
+                raise InvalidNeuronParamsError(
                     "weights shape must match (num_embeddings, embedding_dim)"
                 )
 

--- a/tests/test_neuron_validation.py
+++ b/tests/test_neuron_validation.py
@@ -3,27 +3,27 @@ import sys
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from marble_core import Neuron
+from marble_core import Neuron, InvalidNeuronParamsError
 
 
 def test_invalid_stride():
     n = Neuron(0, neuron_type="conv1d")
     n.params["stride"] = 0
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidNeuronParamsError):
         n.validate_params()
 
 
 def test_invalid_dropout_prob():
     n = Neuron(1, neuron_type="dropout")
     n.params["p"] = 1.5
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidNeuronParamsError):
         n.validate_params()
 
 
 def test_negative_padding():
     n = Neuron(2, neuron_type="conv2d")
     n.params["padding"] = -1
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidNeuronParamsError):
         n.validate_params()
 
 
@@ -31,37 +31,42 @@ def test_output_padding_gte_stride():
     n = Neuron(3, neuron_type="convtranspose1d")
     n.params["stride"] = 2
     n.params["output_padding"] = 2
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidNeuronParamsError):
         n.validate_params()
 
 
 def test_unknown_neuron_type():
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidNeuronParamsError):
         Neuron(4, neuron_type="unknown")
 
 def test_invalid_momentum():
     n = Neuron(5, neuron_type="batchnorm")
     n.params["momentum"] = 1.5
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidNeuronParamsError):
         n.validate_params()
 
 
 def test_invalid_eps():
     n = Neuron(6, neuron_type="batchnorm")
     n.params["eps"] = 0
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidNeuronParamsError):
         n.validate_params()
 
 
 def test_invalid_alpha():
     n = Neuron(7, neuron_type="elu")
     n.params["alpha"] = -0.1
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidNeuronParamsError):
         n.validate_params()
 
 
 def test_invalid_size():
     n = Neuron(8, neuron_type="maxpool1d")
     n.params["size"] = 0
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidNeuronParamsError):
         n.validate_params()
+
+
+def test_invalid_rep_size():
+    with pytest.raises(InvalidNeuronParamsError):
+        Neuron(9, rep_size=0)


### PR DESCRIPTION
## Summary
- add `InvalidNeuronParamsError` for clearer validation failures
- use new exception in neuron validation checks
- validate representation size at Neuron initialization
- extend config schema to cover several core parameters
- enhance CLI with an evaluation option
- update neuron validation tests for new exception

## Testing
- `pytest tests/test_neuron_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68847801c8c88327bfa4ea63fcb75042