### PR TITLE
Implement preprocessing pipeline

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,7 +33,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 29. Introduce dropout and batch normalization synapse types.
 30. Create a graphical configuration editor in the Streamlit GUI.
 31. Enhance the GUI with dark/light mode and mobile layout tweaks.
-32. Add a data pre-processing pipeline with caching.
+32. [x] Add a data pre-processing pipeline with caching.
 33. Integrate a remote experiment tracker (e.g., Weights & Biases).
 34. Provide example projects for image and text domains.
 35. Implement a caching layer for expensive computations.

--- a/preprocessing_pipeline.py
+++ b/preprocessing_pipeline.py
@@ -1,0 +1,30 @@
+import os
+import pickle
+import hashlib
+from typing import Callable, Iterable, Sequence, Any, List
+
+
+class PreprocessingPipeline:
+    """Apply preprocessing functions to data with result caching."""
+
+    def __init__(self, steps: Sequence[Callable[[Any], Any]], cache_dir: str = "preproc_cache") -> None:
+        self.steps = list(steps)
+        self.cache_dir = cache_dir
+
+    def _cache_path(self, dataset_id: str) -> str:
+        os.makedirs(self.cache_dir, exist_ok=True)
+        hashed = hashlib.md5(dataset_id.encode("utf-8")).hexdigest()
+        return os.path.join(self.cache_dir, f"{hashed}.pkl")
+
+    def process(self, data: Iterable[Any], dataset_id: str) -> List[Any]:
+        """Process ``data`` and return the cached result if available."""
+        path = self._cache_path(dataset_id)
+        if os.path.exists(path):
+            with open(path, "rb") as f:
+                return pickle.load(f)
+        processed = list(data)
+        for step in self.steps:
+            processed = [step(item) for item in processed]
+        with open(path, "wb") as f:
+            pickle.dump(processed, f)
+        return processed

--- a/tests/test_preprocessing_pipeline.py
+++ b/tests/test_preprocessing_pipeline.py
@@ -1,0 +1,14 @@
+import sys, os; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from preprocessing_pipeline import PreprocessingPipeline
+
+
+def test_preprocessing_pipeline(tmp_path):
+    data = [1, 2, 3]
+    steps = [lambda x: x * 2, lambda x: x + 1]
+    cache_dir = tmp_path / "cache"
+    pp = PreprocessingPipeline(steps, cache_dir=str(cache_dir))
+    result1 = pp.process(data, dataset_id="test")
+    assert result1 == [3, 5, 7]
+    # Run again to use cache
+    result2 = pp.process(data, dataset_id="test")
+    assert result2 == result1


### PR DESCRIPTION
## Summary
- add a `PreprocessingPipeline` utility that caches results
- test the preprocessing pipeline
- mark TODO item about preprocessing pipeline as completed

## Testing
- `pytest tests/test_preprocessing_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688498cd6edc8327bb68a44b83f3e696