### PR TITLE
Implement structured metrics logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.7
+    hooks:
+      - id: ruff

--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -272,6 +272,7 @@ Each entry is listed under its section heading.
 - track_memory_usage
 - log_dir
 - csv_log_path
+- json_log_path
 ## metrics_dashboard
 - enabled
 - host

--- a/README.md
+++ b/README.md
@@ -154,3 +154,13 @@ If training diverges or produces NaNs:
 
 For CUDA related errors confirm that your GPU drivers and PyTorch build match.
 
+## Code Style
+This repository includes a pre-commit configuration using **black**, **isort**
+and **ruff**. After installing the `pre-commit` package run:
+
+```bash
+pre-commit install
+```
+
+to automatically format and lint changes before each commit.
+

--- a/config.yaml
+++ b/config.yaml
@@ -263,6 +263,7 @@ metrics_visualizer:
   track_memory_usage: false
   log_dir: "logs"
   csv_log_path: "metrics.csv"
+  json_log_path: "metrics.jsonl"
 metrics_dashboard:
   enabled: false
   host: "localhost"

--- a/marble_main.py
+++ b/marble_main.py
@@ -45,6 +45,9 @@ class MARBLE:
             "show_neuron_ids": False,
             "dpi": 100,
             "track_memory_usage": False,
+            "log_dir": None,
+            "csv_log_path": None,
+            "json_log_path": None,
         }
         if mv_params is not None:
             mv_defaults.update(mv_params)
@@ -56,6 +59,9 @@ class MARBLE:
             show_neuron_ids=mv_defaults["show_neuron_ids"],
             dpi=mv_defaults["dpi"],
             track_memory_usage=mv_defaults["track_memory_usage"],
+            log_dir=mv_defaults["log_dir"],
+            csv_log_path=mv_defaults["csv_log_path"],
+            json_log_path=mv_defaults["json_log_path"],
         )
         self.metrics_dashboard = None
         if dashboard_params is not None and dashboard_params.get("enabled", False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -124,3 +124,4 @@ widgetsnbextension==4.0.14
 xxhash==3.5.0
 yarl==1.20.1
 zipp==3.23.0
+pre-commit==3.7.1

--- a/tests/test_brain_io.py
+++ b/tests/test_brain_io.py
@@ -47,7 +47,7 @@ def test_brain_save_and_load(tmp_path):
 
 def test_metrics_visualizer_update():
     from marble_base import MetricsVisualizer
-    mv = MetricsVisualizer(log_dir="tb_logs", csv_log_path="metrics.csv")
+    mv = MetricsVisualizer(log_dir="tb_logs", csv_log_path="metrics.csv", json_log_path="metrics.jsonl")
     mv.update({'loss': 0.5, 'vram_usage': 0.1, 'arousal': 0.2,
                'stress': 0.1, 'reward': 0.3,
                'plasticity_threshold': 5.0,
@@ -59,6 +59,10 @@ def test_metrics_visualizer_update():
     assert mv.metrics['plasticity_threshold'][-1] == 5.0
     mv.close()
     assert os.path.exists("metrics.csv")
+    assert os.path.exists("metrics.jsonl")
+    with open("metrics.jsonl", "r", encoding="utf-8") as f:
+        line = f.readline()
+        assert "\"loss\": 0.5" in line
     assert any(p.name.startswith("events.out.tfevents") for p in Path("tb_logs").iterdir())
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,6 +98,7 @@ def test_load_config_defaults():
     assert cfg["remote_server"]["enabled"] is False
     assert cfg["metrics_visualizer"]["fig_width"] == 10
     assert cfg["metrics_visualizer"]["fig_height"] == 6
+    assert cfg["metrics_visualizer"]["json_log_path"] == "metrics.jsonl"
     assert cfg["brain"]["super_evolution_mode"] is False
 
 

--- a/tests/test_core_performance.py
+++ b/tests/test_core_performance.py
@@ -1,0 +1,9 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from core_benchmark import run_benchmark
+
+
+def test_message_passing_speed():
+    _, sec = run_benchmark(num_neurons=50, iterations=20)
+    assert sec < 0.05
+

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -614,6 +614,8 @@ metrics_visualizer:
     you can run ``tensorboard --logdir=<log_dir>`` to monitor metrics.
   csv_log_path: Path to a CSV file receiving all metric values after each
     update. Useful for analysis with spreadsheet tools.
+  json_log_path: Path to a JSON lines file where each update is appended as a
+    single JSON object. This provides structured logs for downstream tools.
 
 metrics_dashboard:
   # Optional web dashboard built with Plotly Dash for real-time monitoring.


### PR DESCRIPTION
## Summary
- log metrics as JSONL via `MetricsVisualizer`
- expose `json_log_path` setting in config
- document pre-commit code style and json logging options
- add pre-commit configuration
- test JSON metrics logging and add performance regression test

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68849e11b9c48327861ba600915200f5