### PR TITLE
Implement CLI export feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ Any Python object can serve as an ``input`` or ``target`` because the built-in
 possible to train on multimodal pairs such as text-to-image, image-to-text or
 even audio and arbitrary byte blobs without additional conversion steps.
 
+### Command Line Usage
+
+Common tasks can be performed via ``cli.py``. Train a model, evaluate it and
+export the core JSON with:
+
+```bash
+python cli.py --config path/to/cfg.yaml --train data.csv --epochs 10 \
+    --export-core trained_core.json
+```
+
+Use ``--save`` to persist the entire MARBLE object with pickle and
+``--export-core`` to write just the core for later loading via
+``import_core_from_json``.
+
 ### Playground
 
 An interactive Streamlit playground allows quick experimentation with all of

--- a/TODO.md
+++ b/TODO.md
@@ -60,7 +60,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 56. Integrate dataset sharding for distributed training.
 57. Create a cross-platform installer script.
 58. Provide a simple web API for remote inference.
-59. Add command line tools to export trained models.
+59. [x] Add command line tools to export trained models.
 60. Implement automatic synchronization of config files across nodes.
 61. Enhance constant-time operations for cryptographic safety.
 62. Add more comprehensive adversarial training examples.

--- a/cli.py
+++ b/cli.py
@@ -1,7 +1,11 @@
 import argparse
 from config_loader import create_marble_from_config
 from dataset_loader import load_dataset
-from marble_interface import save_marble_system, evaluate_marble_system
+from marble_interface import (
+    save_marble_system,
+    evaluate_marble_system,
+    save_core_json_file,
+)
 
 
 def main() -> None:
@@ -12,6 +16,10 @@ def main() -> None:
     parser.add_argument("--validate", help="Optional validation dataset path")
     parser.add_argument("--evaluate", help="Evaluation dataset for measuring MSE")
     parser.add_argument("--save", help="Path to save trained model")
+    parser.add_argument(
+        "--export-core",
+        help="Path to export the core JSON after training",
+    )
     args = parser.parse_args()
 
     marble = create_marble_from_config(args.config)
@@ -25,6 +33,8 @@ def main() -> None:
         print(f"Evaluation MSE: {mse:.6f}")
     if args.save:
         save_marble_system(marble, args.save)
+    if args.export_core:
+        save_core_json_file(marble, args.export_core)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,3 +25,21 @@ def test_cli_no_train(tmp_path):
         str(cfg),
     ])
     assert result.returncode == 0
+
+
+def test_cli_export_core(tmp_path):
+    cfg = Path(tmp_path) / "cfg.yaml"
+    import yaml
+
+    cfg.write_text(yaml.safe_dump({"core": minimal_params()}))
+    export_path = tmp_path / "core.json"
+    result = subprocess.run([
+        sys.executable,
+        "cli.py",
+        "--config",
+        str(cfg),
+        "--export-core",
+        str(export_path),
+    ])
+    assert result.returncode == 0
+    assert export_path.exists()


### PR DESCRIPTION
## Summary
- add `--export-core` option to `cli.py`
- document CLI usage in README
- mark TODO item 59 complete
- test CLI export functionality

## Testing
- `pytest -k test_cli_export_core tests/test_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6884ac54b27083278b2b86f918078f60