### PR TITLE
Implement CLI overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ reduced.
 MARBLE can train on datasets provided as lists of ``(input, target)`` pairs or using PyTorch-style ``Dataset``/``DataLoader`` objects. Each sample must expose an ``input`` and ``target`` field. After training and saving a model, ``Brain.infer`` generates outputs when given only an input value.
 For quick experiments without external files you can generate synthetic regression pairs using ``synthetic_dataset.generate_sine_wave_dataset``.
 
+## Command Line Interface
+
+The ``cli.py`` script offers a convenient way to train and evaluate MARBLE directly
+from the terminal.  It supports overriding key configuration parameters such as
+learning rate scheduler and early stopping without editing ``config.yaml``.
+
+Example usage:
+
+```bash
+python cli.py --config config.yaml --train data.csv --epochs 5 \
+    --lr-scheduler cosine --scheduler-steps 10 --save marble.pkl
+```
+
+See ``python cli.py --help`` for the full list of options.
+
 Any Python object can serve as an ``input`` or ``target`` because the built-in
 ``DataLoader`` serializes data through ``DataCompressor``. This makes it
 possible to train on multimodal pairs such as text-to-image, image-to-text or

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 3. [x] Improve error handling in `marble_core` for invalid neuron parameters.
 4. Add type hints to all functions for better static analysis.
 5. Integrate GPU acceleration into all neural computations.
-6. Provide a command line interface for common training tasks.
+6. [x] Provide a command line interface for common training tasks.
 7. Refactor `marble_neuronenblitz.py` into logical submodules.
 8. Document all public APIs with docstrings and examples.
 9. Create tutorials that walk through real-world datasets.
@@ -22,7 +22,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 18. Add memory usage tracking to the core.
 19. Support dynamic resizing of neuron representations at runtime.
 20. [x] Implement gradient clipping utilities within Neuronenblitz.
-21. Add a learning rate scheduler with cosine and exponential options.
+21. [x] Add a learning rate scheduler with cosine and exponential options.
 22. Document all YAML parameters in `yaml-manual.txt` with examples.
 23. Provide GPU/CPU fallbacks for all heavy computations.
 24. Add tests ensuring compatibility with PyTorch 2.7 and higher.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -12,9 +12,12 @@ This tutorial demonstrates every major component of MARBLE through a series of p
 2. **Review the documentation**. Read [ARCHITECTURE_OVERVIEW.md](ARCHITECTURE_OVERVIEW.md) for a high level view of MARBLE and consult [yaml-manual.txt](yaml-manual.txt) for an explanation of every configuration option.
 
 3. **Use the command line interface**. The `cli.py` script allows training from
-   the terminal without writing custom code:
+   the terminal without writing custom code. Scheduler and early-stopping
+   parameters can be specified on the command line:
    ```bash
-   python cli.py --config config.yaml --train path/to/data.csv --epochs 10 --save trained_marble.pkl
+   python cli.py --config config.yaml --train path/to/data.csv --epochs 10 \
+       --lr-scheduler cosine --scheduler-steps 20 --early-stopping-patience 5 \
+       --save trained_marble.pkl
    ```
    Replace the dataset path with your own CSV or JSON file. The optional
    `--validate` flag specifies a validation dataset.

--- a/cli.py
+++ b/cli.py
@@ -1,18 +1,18 @@
 import argparse
+
 from config_loader import create_marble_from_config
 from dataset_loader import load_dataset
-from marble_interface import (
-    save_marble_system,
-    evaluate_marble_system,
-    save_core_json_file,
-)
+from marble_interface import (evaluate_marble_system, save_core_json_file,
+                              save_marble_system)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="MARBLE command line interface")
     parser.add_argument("--config", "-c", help="Path to config YAML", default=None)
     parser.add_argument("--train", help="Path or URL to training dataset")
-    parser.add_argument("--epochs", type=int, default=1, help="Number of training epochs")
+    parser.add_argument(
+        "--epochs", type=int, default=1, help="Number of training epochs"
+    )
     parser.add_argument("--validate", help="Optional validation dataset path")
     parser.add_argument("--evaluate", help="Evaluation dataset for measuring MSE")
     parser.add_argument("--save", help="Path to save trained model")
@@ -20,13 +20,52 @@ def main() -> None:
         "--export-core",
         help="Path to export the core JSON after training",
     )
+    parser.add_argument(
+        "--lr-scheduler",
+        choices=["none", "cosine", "exponential", "cyclic"],
+        help="Learning rate scheduler to use",
+    )
+    parser.add_argument("--scheduler-steps", type=int, help="Scheduler cycle length")
+    parser.add_argument(
+        "--scheduler-gamma", type=float, help="Gamma for exponential scheduler"
+    )
+    parser.add_argument("--min-lr", type=float, help="Minimum learning rate")
+    parser.add_argument("--max-lr", type=float, help="Maximum learning rate")
+    parser.add_argument(
+        "--early-stopping-patience", type=int, help="Patience for early stopping"
+    )
+    parser.add_argument(
+        "--early-stopping-delta", type=float, help="Delta for early stopping"
+    )
+    parser.add_argument(
+        "--no-early-stop", action="store_true", help="Disable early stopping"
+    )
     args = parser.parse_args()
 
-    marble = create_marble_from_config(args.config)
+    overrides: dict[str, dict] = {"neuronenblitz": {}, "brain": {}}
+    if args.lr_scheduler:
+        overrides["neuronenblitz"]["lr_scheduler"] = args.lr_scheduler
+    if args.scheduler_steps is not None:
+        overrides["neuronenblitz"]["scheduler_steps"] = args.scheduler_steps
+    if args.scheduler_gamma is not None:
+        overrides["neuronenblitz"]["scheduler_gamma"] = args.scheduler_gamma
+    if args.min_lr is not None:
+        overrides["neuronenblitz"]["min_learning_rate"] = args.min_lr
+    if args.max_lr is not None:
+        overrides["neuronenblitz"]["max_learning_rate"] = args.max_lr
+    if args.early_stopping_patience is not None:
+        overrides["brain"]["early_stopping_patience"] = args.early_stopping_patience
+    if args.early_stopping_delta is not None:
+        overrides["brain"]["early_stopping_delta"] = args.early_stopping_delta
+    marble = create_marble_from_config(args.config, overrides=overrides)
+    if args.no_early_stop:
+        marble.get_brain().early_stop_enabled = False
     if args.train:
         train_data = load_dataset(args.train)
         val_data = load_dataset(args.validate) if args.validate else None
-        marble.get_brain().train(train_data, epochs=args.epochs, validation_examples=val_data)
+        marble.get_brain().train(
+            train_data, epochs=args.epochs, validation_examples=val_data
+        )
     if args.evaluate:
         eval_data = load_dataset(args.evaluate)
         mse = evaluate_marble_system(marble, eval_data)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 import os
-import sys
 import subprocess
+import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -18,12 +18,14 @@ def test_cli_no_train(tmp_path):
     import yaml
 
     cfg.write_text(yaml.safe_dump({"core": minimal_params()}))
-    result = subprocess.run([
-        sys.executable,
-        "cli.py",
-        "--config",
-        str(cfg),
-    ])
+    result = subprocess.run(
+        [
+            sys.executable,
+            "cli.py",
+            "--config",
+            str(cfg),
+        ]
+    )
     assert result.returncode == 0
 
 
@@ -33,13 +35,35 @@ def test_cli_export_core(tmp_path):
 
     cfg.write_text(yaml.safe_dump({"core": minimal_params()}))
     export_path = tmp_path / "core.json"
-    result = subprocess.run([
-        sys.executable,
-        "cli.py",
-        "--config",
-        str(cfg),
-        "--export-core",
-        str(export_path),
-    ])
+    result = subprocess.run(
+        [
+            sys.executable,
+            "cli.py",
+            "--config",
+            str(cfg),
+            "--export-core",
+            str(export_path),
+        ]
+    )
     assert result.returncode == 0
     assert export_path.exists()
+
+
+def test_cli_scheduler_override(tmp_path):
+    cfg = Path(tmp_path) / "cfg.yaml"
+    import yaml
+
+    cfg.write_text(yaml.safe_dump({"core": minimal_params()}))
+    result = subprocess.run(
+        [
+            sys.executable,
+            "cli.py",
+            "--config",
+            str(cfg),
+            "--lr-scheduler",
+            "exponential",
+            "--scheduler-gamma",
+            "0.9",
+        ]
+    )
+    assert result.returncode == 0

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -265,11 +265,14 @@ neuronenblitz:
     ``"exponential"`` multiplies the rate by ``scheduler_gamma`` each epoch, and
     ``"cyclic"`` oscillates the rate between ``min_learning_rate`` and
     ``max_learning_rate`` every ``scheduler_steps`` epochs.
-  scheduler_steps: Number of epochs over which the cosine scheduler decays the
-    learning rate from ``max_learning_rate`` down to ``min_learning_rate``.
+  scheduler_steps: Number of epochs governing scheduler behaviour. For the
+    cosine scheduler this is the decay period. For the cyclic scheduler it is
+    half of a full up/down cycle. Typical values range between ``10`` and ``100``
+    depending on dataset size.
   scheduler_gamma: Multiplicative factor used by the exponential scheduler each
     epoch. Values below ``1.0`` decay the rate while values above ``1.0``
-    increase it.
+    increase it. ``0.95`` is a gentle decay while ``0.5`` halves the rate every
+    epoch.
   momentum_coefficient: Coefficient used to blend the previous weight update
     with the current gradient. ``0.0`` disables momentum while values between
     ``0.0`` and ``1.0`` accelerate training by smoothing updates. Momentum is


### PR DESCRIPTION
## Summary
- allow overriding YAML parameters with `create_marble_from_config`
- extend CLI with learning rate scheduler and early stopping options
- document CLI usage in README and tutorial
- mark completed TODO items
- expand YAML manual scheduler docs
- add CLI test covering scheduler override

## Testing
- `pre-commit run --files cli.py config_loader.py tests/test_cli.py README.md TUTORIAL.md TODO.md yaml-manual.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884b23544488327a18f4789a650a2cf