### PR TITLE
Implement prioritized replay and exploration schedule

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -133,6 +133,19 @@ Each entry is listed under its section heading.
 - wander_cache_size
 - rmsprop_beta
 - grad_epsilon
+- use_experience_replay
+- replay_buffer_size
+- replay_alpha
+- replay_beta
+- replay_batch_size
+- exploration_entropy_scale
+- exploration_entropy_shift
+- gradient_score_scale
+- memory_gate_decay
+- memory_gate_strength
+- episodic_memory_size
+- episodic_memory_threshold
+- episodic_memory_prob
 
 ## brain
 - save_threshold

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1420,3 +1420,5 @@ data and settings are correct before experimenting.
 
 The playground provides toggles for dreaming and autograd features so you can
 experiment with MARBLE's advanced capabilities without writing code.
+
+Additional experiments can enable **prioritized experience replay** by setting `neuronenblitz.use_experience_replay` to `true` in `config.yaml`. This stores recent training examples and replays them based on their errors, improving convergence on challenging datasets.

--- a/config.yaml
+++ b/config.yaml
@@ -132,6 +132,19 @@ neuronenblitz:
 # Brain-level training configuration
 
   grad_epsilon: 1.0e-08
+  use_experience_replay: false
+  replay_buffer_size: 1000
+  replay_alpha: 0.6
+  replay_beta: 0.4
+  replay_batch_size: 32
+  exploration_entropy_scale: 1.0
+  exploration_entropy_shift: 0.0
+  gradient_score_scale: 1.0
+  memory_gate_decay: 0.99
+  memory_gate_strength: 1.0
+  episodic_memory_size: 50
+  episodic_memory_threshold: 0.1
+  episodic_memory_prob: 0.1
 brain:
   save_threshold: 0.05
   max_saved_models: 5

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -324,6 +324,32 @@ neuronenblitz:
     0.9–0.99.
   grad_epsilon: Small constant added when normalising gradients to avoid
     division by zero.
+  use_experience_replay: Enable prioritized experience replay. When true
+    Neuronenblitz keeps past training examples with their errors and samples
+    them again according to those errors after each epoch.
+  replay_buffer_size: Maximum number of experiences retained for replay. Old
+    entries are discarded once this limit is exceeded.
+  replay_alpha: Exponent determining how strongly error magnitude influences
+    sampling probability. ``0`` gives uniform sampling while ``1.0`` weights
+    fully by error.
+  replay_beta: Importance sampling correction applied to replay updates. Values
+    near ``1.0`` reduce bias from prioritisation.
+  replay_batch_size: Number of stored experiences replayed after each epoch
+    when experience replay is active.
+  exploration_entropy_scale: Multiplier applied to the entropy of synapse visit
+    counts when computing adaptive dropout rates.
+  exploration_entropy_shift: Constant offset added after scaling the entropy.
+  gradient_score_scale: Factor converting gradient magnitude into additional
+    synapse potential during weight updates.
+  memory_gate_decay: Multiplicative decay applied to memory-based gating scores
+    that bias ``weighted_choice``. Lower values make memories fade quickly.
+  memory_gate_strength: Amount added to a synapse's gating score whenever a
+    path yields an error below ``episodic_memory_threshold``.
+  episodic_memory_size: Number of recent successful paths stored for gating.
+  episodic_memory_threshold: Maximum absolute error for a path to be recorded
+    in episodic memory.
+  episodic_memory_prob: Probability that wandering will be biased by episodic
+    memory on a given call.
 
 brain:
   save_threshold: Minimum improvement in validation loss required before the


### PR DESCRIPTION
## Summary
- add prioritized experience replay, adaptive exploration and memory-gated attention
- update config with new neuronenblitz parameters
- document new YAML parameters
- mention prioritized replay in the tutorial
- extend neuronenblitz tests

## Testing
- `pytest tests/test_neuronenblitz_enhancements.py::test_experience_replay_buffer_fills_and_replays -q`
- `pytest tests/test_neuronenblitz_enhancements.py::test_memory_gate_biases_selection -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884b5e26ee88327b48f2a0def1844de