### PR TITLE
Implement neuronenblitz features

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -146,6 +146,10 @@ Each entry is listed under its section heading.
 - episodic_memory_size
 - episodic_memory_threshold
 - episodic_memory_prob
+- curiosity_strength
+- depth_clip_scaling
+- forgetting_rate
+- structural_dropout_prob
 
 ## brain
 - save_threshold

--- a/config.yaml
+++ b/config.yaml
@@ -145,6 +145,10 @@ neuronenblitz:
   episodic_memory_size: 50
   episodic_memory_threshold: 0.1
   episodic_memory_prob: 0.1
+  curiosity_strength: 0.0
+  depth_clip_scaling: 1.0
+  forgetting_rate: 0.99
+  structural_dropout_prob: 0.0
 brain:
   save_threshold: 0.05
   max_saved_models: 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ black==25.1.0
 blinker==1.9.0
 cachetools==5.5.2
 certifi==2025.7.14
+cfgv==3.4.0
 charset-normalizer==3.4.2
 click==8.2.1
 comm==0.2.2
@@ -19,6 +20,7 @@ datasets==4.0.0
 decorator==5.2.1
 diffusers==0.34.0
 dill==0.3.8
+distlib==0.4.0
 executing==2.2.0
 filelock==3.13.1
 Flask==3.1.1
@@ -30,6 +32,7 @@ GitPython==3.1.44
 grpcio==1.74.0
 hf-xet==1.1.5
 huggingface-hub==0.33.4
+identify==2.6.12
 idna==3.10
 importlib_metadata==8.7.0
 iniconfig==2.1.0
@@ -70,6 +73,7 @@ pillow==10.3.0
 platformdirs==4.3.8
 plotly==6.2.0
 pluggy==1.6.0
+pre-commit==3.7.1
 prompt_toolkit==3.0.51
 propcache==0.3.2
 protobuf==4.25.8
@@ -117,6 +121,7 @@ transformers==4.40.1
 typing_extensions==4.14.1
 tzdata==2025.2
 urllib3==2.5.0
+virtualenv==20.32.0
 watchdog==6.0.0
 wcwidth==0.2.13
 Werkzeug==3.1.3
@@ -124,4 +129,3 @@ widgetsnbextension==4.0.14
 xxhash==3.5.0
 yarl==1.20.1
 zipp==3.23.0
-pre-commit==3.7.1

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -350,6 +350,17 @@ neuronenblitz:
     in episodic memory.
   episodic_memory_prob: Probability that wandering will be biased by episodic
     memory on a given call.
+  curiosity_strength: Weight of novelty-driven curiosity in ``weighted_choice``.
+    Higher values encourage exploring rarely visited synapses.
+  depth_clip_scaling: Scaling factor controlling how strongly gradient clipping
+    tightens for long wander paths.  ``1.0`` halves the update cap at maximum
+    depth.
+  forgetting_rate: Multiplicative decay applied to stored context history on
+    each wander. Values below ``1.0`` gradually forget old neuromodulatory
+    signals.
+  structural_dropout_prob: Probability that a qualified synapse is skipped
+    during structural plasticity. Increasing this value reduces the frequency
+    of structural changes.
 
 brain:
   save_threshold: Minimum improvement in validation loss required before the


### PR DESCRIPTION
## Summary
- add curiosity-driven exploration and active forgetting
- scale gradient clipping with wander depth
- allow dropout in structural plasticity
- document new YAML parameters and defaults
- extend neuronenblitz tests for new behaviour

## Testing
- `pytest tests/test_neuronenblitz_enhancements.py::test_curiosity_strength_biases_toward_novel_synapse -q`
- `pytest tests/test_neuronenblitz_enhancements.py::test_depth_clip_scaling_reduces_update_for_deep_paths -q`
- `pytest tests/test_neuronenblitz_enhancements.py::test_active_forgetting_decays_context -q`
- `pytest tests/test_neuronenblitz_enhancements.py::test_structural_dropout_skips_plasticity -q`


------
https://chatgpt.com/codex/tasks/task_e_6884c106dcc8832791494dbcd573e076