### PR TITLE
Fix benchmark tests

### DIFF
--- a/marble_autograd.py
+++ b/marble_autograd.py
@@ -18,6 +18,8 @@ class MarbleAutogradFunction(torch.autograd.Function):
         wrapper = ctx.wrapper
         for syn in ctx.path:
             source_val = wrapper.brain.core.neurons[syn.source].value
+            if source_val is None:
+                source_val = 0.0
             grad = float(grad_output) * source_val
             syn.weight -= wrapper.learning_rate * grad
         return None, grad_output.clone()

--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -374,7 +374,7 @@ class Neuronenblitz:
                 k: (v * self.forgetting_rate if isinstance(v, (int, float)) else v)
                 for k, v in ctx.items()
             }
-            if any(abs(v) > 1e-6 for v in decayed.values()):
+            if any(isinstance(v, (int, float)) and abs(v) > 1e-6 for v in decayed.values()):
                 new_hist.append(decayed)
         self.context_history = new_hist
 


### PR DESCRIPTION
## Summary
- handle string entries in `active_forgetting`
- guard against `None` neuron values during autograd backward

## Testing
- `pytest tests/test_benchmark_autograd_vs_marble.py::test_train_marble_returns_floats tests/test_benchmark_autograd_vs_marble.py::test_train_autograd_returns_floats -q`
- `pytest -q` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6884ee1bf7388327b3b1443aa02f7a41