### PR TITLE
Implement roadmap features

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -37,6 +37,8 @@ Each entry is listed under its section heading.
 - weight_init_mean
 - weight_init_std
 - weight_init_type
+- weight_init_strategy
+- show_message_progress
 - message_passing_beta
 - attention_temperature
 - attention_dropout

--- a/TODO.md
+++ b/TODO.md
@@ -44,10 +44,10 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 40. Document best practices for hyperparameter tuning.
 41. [x] Improve remote offload logic with retry and timeout strategies.
 42. Add robust serialization for checkpointing training state.
-43. Integrate a progress bar for long-running operations.
+43. [x] Integrate a progress bar for long-running operations.
 44. Expand the `examples` directory with end‑to‑end scripts.
 45. Provide conversion tools between Marble Core and other frameworks.
-46. Implement an extensible metrics aggregation system.
+46. [x] Implement an extensible metrics aggregation system.
 47. Improve code style consistency with automated formatting checks.
 48. Add support for quantization and model compression.
 49. Implement a plugin-based remote tier for custom hardware.
@@ -68,7 +68,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 64. Integrate a simple hyperparameter search framework.
 65. [x] Add tests verifying deterministic behaviour with fixed seeds.
 66. Improve readability of configuration files with comments and sections.
-67. Implement graph pruning utilities to remove unused neurons.
+67. [x] Implement graph pruning utilities to remove unused neurons.
 68. Create a repository of reusable neuron/synapse templates.
 69. Add support for mixed precision training when GPUs are available.
 70. Provide dynamic graph visualisation within the GUI.
@@ -82,13 +82,13 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 78. Add performance regression tests for critical functions.
 79. Integrate basic anomaly detection on training metrics.
 80. [x] Expand the scheduler with cyclic learning rate support.
-81. Implement custom weight initialisation strategies.
+81. [x] Implement custom weight initialisation strategies.
 82. Provide a structured logging interface for the GUI.
 83. Add latency tracking when using remote tiers.
 84. Implement automatic graph visualisation for debugging.
-85. Provide wrappers to convert Marble models to ONNX.
+85. [x] Provide wrappers to convert Marble models to ONNX.
 86. Improve the hybrid memory system for balanced usage.
-87. Add a mechanism to export and import neuron state snapshots.
+87. [x] Add a mechanism to export and import neuron state snapshots.
 88. Document the mathematics behind synaptic echo learning.
 89. Implement context-aware attention mechanisms.
 90. Add unit tests ensuring backward compatibility between versions.

--- a/config.yaml
+++ b/config.yaml
@@ -35,6 +35,8 @@ core:
   weight_init_mean: 0.0
   weight_init_std: 1.0
   weight_init_type: "uniform"
+  weight_init_strategy: "uniform"
+  show_message_progress: false
   message_passing_beta: 1.0
   attention_temperature: 1.0
   attention_dropout: 0.0

--- a/config_schema.py
+++ b/config_schema.py
@@ -9,6 +9,8 @@ CONFIG_SCHEMA = {
                 "representation_size": {"type": "integer", "minimum": 1},
                 "message_passing_alpha": {"type": "number", "minimum": 0, "maximum": 1},
                 "message_passing_beta": {"type": "number", "minimum": 0, "maximum": 1},
+                "weight_init_strategy": {"type": "string"},
+                "show_message_progress": {"type": "boolean"},
             },
         },
         "neuronenblitz": {"type": "object"},

--- a/marble_base.py
+++ b/marble_base.py
@@ -239,3 +239,20 @@ class MetricsVisualizer:
 
     def __del__(self) -> None:
         self.close()
+
+
+class MetricsAggregator:
+    """Aggregate metrics from multiple visualizers."""
+
+    def __init__(self) -> None:
+        self.sources: list[MetricsVisualizer] = []
+
+    def add_source(self, source: MetricsVisualizer) -> None:
+        self.sources.append(source)
+
+    def aggregate(self) -> dict[str, float]:
+        combined: dict[str, list[float]] = {}
+        for src in self.sources:
+            for key, values in src.metrics.items():
+                combined.setdefault(key, []).extend(values)
+        return {k: float(np.mean(v)) if v else 0.0 for k, v in combined.items()}

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -1,0 +1,74 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import tempfile
+from marble_core import Core, perform_message_passing
+from marble_utils import (
+    export_core_to_onnx,
+    export_neuron_state,
+    import_neuron_state,
+)
+from marble_base import MetricsVisualizer, MetricsAggregator
+from tests.test_core_functions import minimal_params
+
+
+def test_graph_pruning():
+    params = minimal_params()
+    core = Core(params)
+    # add isolated neuron
+    core.neurons.append(core.neurons[0].__class__(len(core.neurons)))
+    core.prune_unused_neurons()
+    assert len(core.neurons) == params["width"] * params["height"]
+
+
+def test_export_import_neuron_state(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    perform_message_passing(core)
+    path = tmp_path / "state.json"
+    export_neuron_state(core, path)
+    # reset and load
+    core2 = Core(params)
+    import_neuron_state(core2, path)
+    for a, b in zip(core.neurons, core2.neurons):
+        assert (a.representation == b.representation).all()
+
+
+def test_onnx_export(tmp_path):
+    import pytest
+    pytest.importorskip("onnx")
+    params = minimal_params()
+    core = Core(params)
+    file_path = tmp_path / "model.onnx"
+    export_core_to_onnx(core, file_path)
+    assert file_path.exists() and file_path.stat().st_size > 0
+
+
+def test_metrics_aggregator():
+    v1 = MetricsVisualizer()
+    v2 = MetricsVisualizer()
+    v1.update({"loss": 1.0})
+    v2.update({"loss": 3.0})
+    agg = MetricsAggregator()
+    agg.add_source(v1)
+    agg.add_source(v2)
+    metrics = agg.aggregate()
+    assert metrics["loss"] == 2.0
+
+def test_message_passing_progress(monkeypatch):
+    params = minimal_params()
+    core = Core(params)
+    updates = []
+
+    class Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+        def __iter__(self):
+            return iter(core.neurons)
+        def __next__(self):
+            raise StopIteration
+        def close(self):
+            updates.append(True)
+
+    monkeypatch.setattr("marble_core.tqdm", lambda *a, **k: Dummy())
+    perform_message_passing(core, show_progress=True)
+    assert updates

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -85,6 +85,11 @@ core:
     ``"normal"`` draws from a normal distribution with ``weight_init_mean``
     and ``weight_init_std``. ``"xavier_uniform"`` uses Xavier uniform
     initialization based on the connection fan-in and fan-out.
+  weight_init_strategy: Strategy for the message passing MLP weights. Supports
+    ``"uniform"`` and ``"normal"`` with the same semantics as
+    ``weight_init_type``.
+  show_message_progress: When ``true`` ``perform_message_passing`` renders a
+    progress bar so long operations provide visual feedback.
   message_passing_beta: Secondary mixing factor controlling how quickly new
     representations replace old ones when ``alpha`` alone is insufficient.
   attention_temperature: Softmax temperature used by the attention module


### PR DESCRIPTION
## Summary
- add new YAML options `weight_init_strategy` and `show_message_progress`
- support weight init strategies and progress bars in `marble_core`
- implement neuron pruning, ONNX export and neuron state snapshot utilities
- add `MetricsAggregator` for combining metrics
- document new parameters and mark TODO items as done
- test new functionality

## Testing
- `pytest tests/test_new_features.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6885ebc2350c8327aa1d02c79e128c19