### PR TITLE
Implement dataset sharding and NaN checks

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -340,6 +340,10 @@ Each entry is listed under its section heading.
 - dataset_path
 - batch_size
 
+## dataset
+- num_shards
+- shard_index
+
 ## distillation
 - enabled
 - alpha

--- a/TODO.md
+++ b/TODO.md
@@ -55,9 +55,9 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 51. Add parameter scheduling for exploration/exploitation trade-offs.
 52. Support hierarchical reinforcement learning in Neuronenblitz.
 53. Implement efficient memory management for huge graphs.
-54. Add checks for NaN/Inf propagation throughout the core.
+54. [x] Add checks for NaN/Inf propagation throughout the core.
 55. Provide an option to profile CPU and GPU usage during training.
-56. Integrate dataset sharding for distributed training.
+56. [x] Integrate dataset sharding for distributed training.
 57. Create a cross-platform installer script.
 58. Provide a simple web API for remote inference.
 59. [x] Add command line tools to export trained models.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1285,6 +1285,14 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
    ```python
    pairs = load_dataset("data.zip")
    ```
+4. **Load a specific shard of a dataset** for distributed training:
+   ```python
+   pairs = load_dataset(
+       "https://example.com/big.csv",
+       num_shards=4,
+       shard_index=1,
+   )
+   ```
 4. **Create and train a MARBLE system** using a pandas dataframe:
    ```python
    import pandas as pd

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,10 @@
 # Default configuration for MARBLE
 # Core parameters controlling neuron grid and message passing
 
+dataset:
+  num_shards: 1
+  shard_index: 0
+
 core:
   xmin: -2.0
   xmax: 1.0

--- a/config_schema.py
+++ b/config_schema.py
@@ -27,6 +27,13 @@ CONFIG_SCHEMA = {
                 "profile_interval": {"type": "integer", "minimum": 1},
             },
         },
+        "dataset": {
+            "type": "object",
+            "properties": {
+                "num_shards": {"type": "integer", "minimum": 1},
+                "shard_index": {"type": "integer", "minimum": 0},
+            },
+        },
     },
     "required": ["core"],
 }

--- a/marble_core.py
+++ b/marble_core.py
@@ -1894,6 +1894,17 @@ class Core:
                 subcore.synapses.append(ns)
         return subcore
 
+    def check_finite_state(self) -> None:
+        """Raise ``ValueError`` if any representation, value or weight is NaN/Inf."""
+        for n in self.neurons:
+            if not np.all(np.isfinite(n.representation)):
+                raise ValueError("NaN or Inf encountered in neuron representation")
+            if n.value is not None and not np.isfinite(n.value):
+                raise ValueError("NaN or Inf encountered in neuron value")
+        for s in self.synapses:
+            if not np.isfinite(s.weight):
+                raise ValueError("NaN or Inf encountered in synapse weight")
+
     def run_message_passing(
         self,
         metrics_visualizer: "MetricsVisualizer | None" = None,
@@ -1947,4 +1958,5 @@ class Core:
         avg_change = total_change / max(int(iterations), 1)
         if metrics_visualizer is not None:
             metrics_visualizer.update({"avg_message_passing_change": avg_change})
+        self.check_finite_state()
         return avg_change

--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -88,3 +88,10 @@ def test_load_zipped_json(tmp_path):
     pairs = load_dataset(str(zip_path))
     assert pairs == [(1, 2)]
 
+
+def test_dataset_sharding(tmp_path):
+    csv_path = tmp_path / "shard.csv"
+    csv_path.write_text("input,target\n1,2\n3,4\n5,6\n7,8\n")
+    pairs = load_dataset(str(csv_path), num_shards=2, shard_index=1)
+    assert pairs == [(3, 4), (7, 8)]
+

--- a/tests/test_nan_checks.py
+++ b/tests/test_nan_checks.py
@@ -16,3 +16,11 @@ def test_nan_detection():
     core.synapses.append(Synapse(0, 0, weight=np.nan))
     with pytest.raises(ValueError):
         nb.dynamic_wander(0.1)
+
+
+def test_core_finite_check():
+    params = minimal_params()
+    core = Core(params)
+    core.neurons[0].representation[0] = float("inf")
+    with pytest.raises(ValueError):
+        core.check_finite_state()

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -3,6 +3,15 @@ section corresponds to a subsystem and exposes parameters that can be tuned to
 alter its behaviour.  When the file is loaded it is validated against an
 internal JSON schema to catch missing sections or invalid values early.
 
+dataset:
+  num_shards: Number of shards the training dataset is split into. When greater
+    than ``1`` each training worker should set ``shard_index`` to a unique value
+    between ``0`` and ``num_shards - 1`` so that only a subset of samples is
+    processed. This enables distributed training without duplicating effort.
+  shard_index: Index of the shard this instance will process. Set to ``0`` when
+    running on a single machine. Values outside the valid range raise an error
+    during dataset loading.
+
 core:
   xmin: Minimum X coordinate for the Mandelbrot seed. Defines the left boundary
     of the complex plane used when initializing neuron values.


### PR DESCRIPTION
## Summary
- integrate dataset sharding in dataset_loader
- add check_finite_state to Core and call after message passing
- document new dataset parameters and defaults
- update TODO list
- add tests for dataset sharding and NaN checks

## Testing
- `pytest tests/test_streamlit_all_buttons.py::test_click_all_buttons -q`
- `pytest tests/test_dataset_loader.py tests/test_nan_checks.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6885ef5a90d8832798aef313436fb907