### PR TITLE
Fix progress callback tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -367,3 +367,10 @@ __pycache__/
 
 .pytest_cache/
 
+
+# Test artifacts
+metrics.csv
+metrics.jsonl
+symbolic_memory.pkl
+vector_store.pkl
+tb_logs/

--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -1,1 +1,1 @@
-pytest run interrupted
+All tests passed

--- a/marble_brain.py
+++ b/marble_brain.py
@@ -537,8 +537,7 @@ class Brain:
                 self.benchmark_step(example)
             if self.profiler and epoch % self.profile_interval == 0:
                 self.profiler.log_epoch(epoch)
-        if progress_callback is not None:
-            progress_callback(1.0)
+
 
         pbar.close()
 


### PR DESCRIPTION
## Summary
- fix progress callback count by removing duplicate final callback
- ignore metrics artifacts

## Testing
- `pytest -q tests/test_progress_callback.py`
- `pytest -q` *(batched)*

------
https://chatgpt.com/codex/tasks/task_e_68860147950c832790d0008d33d98e63