### PR TITLE
Implement experiment tracking and latency tracking

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -250,11 +250,13 @@ Each entry is listed under its section heading.
 ## hybrid_memory
 - vector_store_path
 - symbolic_store_path
+- max_entries
 
 ## remote_client
 - url
 - timeout
 - max_retries
+- track_latency
 - auth_token
 - ssl_verify
 - connect_retry_interval
@@ -273,6 +275,12 @@ Each entry is listed under its section heading.
 
 ## dataloader
 - tensor_dtype
+
+## experiment_tracker
+- enabled
+- project
+- entity
+- run_name
 
 ## formula
 - formula

--- a/README.md
+++ b/README.md
@@ -172,6 +172,15 @@ Tuning MARBLE effectively requires balancing learning stability with network pla
 5. Enable `lr_scheduler` with `scheduler_gamma` around `0.99` for long runs.
 
 These heuristics work well across the provided examples but every dataset benefits from its own small grid search.
+When tuning a new task consider the following workflow:
+
+1. Start with the default configuration and run a short training job to verify that the loss decreases.
+2. Perform a coarse grid search over `learning_rate` and `lr_scheduler` settings using the helper functions in `hyperparameter_search.py`.
+3. Once a stable range is found, explore `representation_size` and `message_passing_alpha` which strongly influence capacity and convergence speed.
+4. Monitor GPU and CPU usage using the metrics dashboard to ensure batch size and dimensionality fit your hardware budget.
+5. Keep `gradient_clip_value` low (around `1.0`) when experimenting with very large learning rates or aggressive neurogenesis.
+
+Documenting the parameters of each run with the new experiment tracker makes it easy to compare results later.
 
 ## Troubleshooting
 If training diverges or produces NaNs:

--- a/TODO.md
+++ b/TODO.md
@@ -34,14 +34,14 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 30. Create a graphical configuration editor in the Streamlit GUI.
 31. Enhance the GUI with dark/light mode and mobile layout tweaks.
 32. [x] Add a data pre-processing pipeline with caching.
-33. Integrate a remote experiment tracker (e.g., Weights & Biases).
+33. [x] Integrate a remote experiment tracker (e.g., Weights & Biases).
 34. Provide example projects for image and text domains.
 35. Implement a caching layer for expensive computations.
 36. Expand YAML configuration to allow hierarchical experiment setups.
 37. [x] Add early stopping based on validation metrics.
 38. [x] Provide utilities for synthetic dataset generation.
 39. Implement curriculum learning helpers in Neuronenblitz.
-40. Document best practices for hyperparameter tuning.
+40. [x] Document best practices for hyperparameter tuning.
 41. [x] Improve remote offload logic with retry and timeout strategies.
 42. Add robust serialization for checkpointing training state.
 43. [x] Integrate a progress bar for long-running operations.
@@ -84,10 +84,10 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 80. [x] Expand the scheduler with cyclic learning rate support.
 81. [x] Implement custom weight initialisation strategies.
 82. [x] Provide a structured logging interface for the GUI.
-83. Add latency tracking when using remote tiers.
+83. [x] Add latency tracking when using remote tiers.
 84. [x] Implement automatic graph visualisation for debugging.
 85. [x] Provide wrappers to convert Marble models to ONNX.
-86. Improve the hybrid memory system for balanced usage.
+86. [x] Improve the hybrid memory system for balanced usage.
 87. [x] Add a mechanism to export and import neuron state snapshots.
 88. [x] Document the mathematics behind synaptic echo learning.
 89. Implement context-aware attention mechanisms.

--- a/config.yaml
+++ b/config.yaml
@@ -264,10 +264,12 @@ memory_system:
 hybrid_memory:
   vector_store_path: "vector_store.pkl"
   symbolic_store_path: "symbolic_memory.pkl"
+  max_entries: 1000
 remote_client:
   url: "http://localhost:8001"
   timeout: 5.0
   max_retries: 3
+  track_latency: true
   auth_token: null
   ssl_verify: true
   connect_retry_interval: 5
@@ -283,6 +285,11 @@ data_compressor:
   delta_encoding: false
 dataloader:
   tensor_dtype: "uint8"
+experiment_tracker:
+  enabled: false
+  project: "marble"
+  entity: null
+  run_name: null
 remote_server:
   enabled: false
   host: "localhost"

--- a/experiment_tracker.py
+++ b/experiment_tracker.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+class ExperimentTracker:
+    """Abstract base class for experiment trackers."""
+
+    def log_metrics(self, metrics: dict[str, float], step: int) -> None:
+        """Log a metrics dictionary for the given step."""
+        raise NotImplementedError
+
+    def finish(self) -> None:
+        """Finish the tracking session."""
+        pass
+
+
+class WandbTracker(ExperimentTracker):
+    """Weights & Biases experiment tracker."""
+
+    def __init__(self, project: str, entity: str | None = None, run_name: str | None = None) -> None:
+        import wandb
+
+        self.run = wandb.init(project=project, entity=entity, name=run_name, reinit=True)
+
+    def log_metrics(self, metrics: dict[str, float], step: int) -> None:
+        import wandb
+
+        wandb.log(metrics, step=step)
+
+    def finish(self) -> None:
+        import wandb
+
+        wandb.finish()

--- a/hybrid_memory.py
+++ b/hybrid_memory.py
@@ -88,11 +88,13 @@ class HybridMemory:
         neuronenblitz: Neuronenblitz,
         vector_path: str = "vector_store.pkl",
         symbolic_path: str = "symbolic_memory.pkl",
+        max_entries: int = 1000,
     ) -> None:
         self.core = core
         self.nb = neuronenblitz
         self.vector_store = VectorStore(vector_path, core.rep_size)
         self.symbolic_memory = SymbolicMemory(symbolic_path)
+        self.max_entries = int(max_entries)
 
     def _embed(self, value: float) -> np.ndarray:
         self.nb.dynamic_wander(value, apply_plasticity=False)
@@ -104,6 +106,7 @@ class HybridMemory:
         vec = self._embed(value)
         self.vector_store.add(key, vec)
         self.symbolic_memory.store(key, value)
+        self.forget_old(self.max_entries)
 
     def retrieve(self, query: float, top_k: int = 3) -> List[Tuple[Any, Any]]:
         q_vec = self._embed(query)

--- a/requirements.txt
+++ b/requirements.txt
@@ -129,3 +129,4 @@ widgetsnbextension==4.0.14
 xxhash==3.5.0
 yarl==1.20.1
 zipp==3.23.0
+wandb==0.17.0

--- a/tests/test_experiment_tracker.py
+++ b/tests/test_experiment_tracker.py
@@ -1,0 +1,19 @@
+from experiment_tracker import ExperimentTracker
+from marble_base import MetricsVisualizer
+
+class DummyTracker(ExperimentTracker):
+    def __init__(self):
+        self.logged = []
+
+    def log_metrics(self, metrics, step):
+        self.logged.append((step, metrics))
+
+
+def test_metrics_visualizer_logs_to_tracker():
+    tracker = DummyTracker()
+    mv = MetricsVisualizer(tracker=tracker)
+    mv.update({"loss": 0.5, "vram_usage": 10})
+    mv.update({"loss": 0.4, "vram_usage": 11})
+    assert len(tracker.logged) == 2
+    assert tracker.logged[0][1]["loss"] == 0.5
+    mv.close()

--- a/tests/test_hybrid_memory_eviction.py
+++ b/tests/test_hybrid_memory_eviction.py
@@ -1,0 +1,16 @@
+from hybrid_memory import HybridMemory
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from tests.test_core_functions import minimal_params
+
+
+def test_hybrid_memory_eviction(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    hm = HybridMemory(core, nb, vector_path=str(tmp_path / "vec.pkl"), symbolic_path=str(tmp_path / "sym.pkl"), max_entries=2)
+    hm.store("a", 0.1)
+    hm.store("b", 0.2)
+    hm.store("c", 0.3)
+    assert len(hm.vector_store.keys) == 2
+    assert "a" not in hm.symbolic_memory.data

--- a/tests/test_remote_latency.py
+++ b/tests/test_remote_latency.py
@@ -1,0 +1,20 @@
+import time
+import types
+from remote_offload import RemoteBrainClient
+
+
+def test_remote_client_latency_tracking(monkeypatch):
+    def fake_post(url, json=None, timeout=0):
+        time.sleep(0.01)
+        class Res:
+            def json(self):
+                return {"output": 1.0}
+        return Res()
+
+    monkeypatch.setattr("requests.post", fake_post)
+    client = RemoteBrainClient("http://localhost", track_latency=True, compression_enabled=False)
+    client.process(0.2)
+    client.process(0.3)
+    assert len(client.latencies) == 2
+    assert all(lat >= 0.01 for lat in client.latencies)
+    assert client.average_latency >= 0.01

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -606,6 +606,9 @@ hybrid_memory:
     directory.
   symbolic_store_path: File used to persist key/value pairs and timestamps.
     This mirrors the vector store so recalls can return the original data.
+  max_entries: Maximum number of items retained in the vector and symbolic
+    stores. When the count exceeds this limit the oldest entries are removed
+    to keep memory usage bounded.
 
 remote_client:
   # Configuration for forwarding parts of the brain to a remote server. When
@@ -615,6 +618,8 @@ remote_client:
   timeout: Seconds to wait for remote requests before they are aborted. Values
     between 5 and 30 are typical depending on network latency.
   max_retries: Number of times a remote operation is retried upon failure.
+  track_latency: When true the client records the time taken for each
+    request so average latency can be inspected through the API.
   auth_token: Optional token sent as an ``Authorization`` header on each
     request.
   ssl_verify: Whether HTTPS certificates should be verified. Set to ``false``
@@ -655,6 +660,16 @@ dataloader:
   # valid dtype name like ``"uint8"`` or ``"int16"``. Wider dtypes can prevent
   # overflow with exceptionally large payloads but increase memory usage.
   tensor_dtype: String specifying the dtype of encoded tensors.
+
+experiment_tracker:
+  # Optional integration with external experiment tracking services such as
+  # Weights & Biases. When ``enabled`` is true a ``WandbTracker`` is created
+  # and attached to the :class:`MetricsVisualizer` so that training metrics are
+  # streamed to the configured project.
+  enabled: Activate experiment tracking when set to ``true``.
+  project: Name of the remote project used by the tracker.
+  entity: Optional account or team under which the run is recorded.
+  run_name: Custom name assigned to the run. If ``null`` Wandb generates one.
 
 remote_server:
   # Launches an optional local ``RemoteBrainServer`` so this MARBLE instance can


### PR DESCRIPTION
## Summary
- integrate `WandbTracker` experiment tracker
- allow `MetricsVisualizer` to log metrics via tracker
- track request latency in `RemoteBrainClient`
- add capacity limit to `HybridMemory`
- document new YAML parameters and update default config
- expand hyperparameter tuning guidelines
- add tests for tracker, latency and hybrid memory eviction

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_experiment_tracker.py tests/test_remote_latency.py tests/test_hybrid_memory_eviction.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68860bade2388327b673f0956d8e0371