### PR TITLE
Implement remote inference API

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,33 @@ Use ``--save`` to persist the entire MARBLE object with pickle and
 ``--export-core`` to write just the core for later loading via
 ``import_core_from_json``.
 
+### Remote Inference API
+
+MARBLE can be exposed through a lightweight HTTP API. Launch the server with:
+
+```python
+from marble_core import Core, DataLoader
+from marble_neuronenblitz import Neuronenblitz
+from marble_brain import Brain
+from web_api import InferenceServer
+from tests.test_core_functions import minimal_params
+
+core = Core(minimal_params())
+nb = Neuronenblitz(core)
+brain = Brain(core, nb, DataLoader())
+server = InferenceServer(brain)
+server.start()
+```
+
+Query the API using ``curl``:
+
+```bash
+curl -X POST http://localhost:5000/infer -H 'Content-Type: application/json' \
+     -d '{"input": 0.5}'
+```
+
+Call ``server.stop()`` to shut it down.
+
 ### Playground
 
 An interactive Streamlit playground allows quick experimentation with all of

--- a/TODO.md
+++ b/TODO.md
@@ -59,7 +59,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 55. [x] Provide an option to profile CPU and GPU usage during training.
 56. [x] Integrate dataset sharding for distributed training.
 57. Create a cross-platform installer script.
-58. Provide a simple web API for remote inference.
+58. [x] Provide a simple web API for remote inference.
 59. [x] Add command line tools to export trained models.
 60. Implement automatic synchronization of config files across nodes.
 61. Enhance constant-time operations for cryptographic safety.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -231,6 +231,31 @@ Execute the file on each machine as indicated to experiment with remote offloadi
 
 Remote offloading demonstrates **RemoteBrainServer**, **RemoteBrainClient** and the optional torrent‑based distribution.
 
+## Project 3b – Remote Inference API (Medium)
+
+**Goal:** Serve a trained MARBLE brain over HTTP for lightweight inference.
+
+1. **Create a brain** and start the API:
+   ```python
+   from tests.test_core_functions import minimal_params
+   from marble_core import Core, DataLoader
+   from marble_neuronenblitz import Neuronenblitz
+   from marble_brain import Brain
+   from web_api import InferenceServer
+
+   core = Core(minimal_params())
+   nb = Neuronenblitz(core)
+   brain = Brain(core, nb, DataLoader())
+   server = InferenceServer(brain)
+   server.start()
+   ```
+2. **Send requests** to `http://localhost:5000/infer` with JSON
+   `{"input": 0.42}` and read back the numeric output.
+3. **Stop the server** by calling `server.stop()` when finished.
+
+This project highlights how MARBLE can integrate with external services through
+a minimal web API.
+
 ## Project 4 – Autograd and PyTorch Challenge (Advanced)
 
 **Goal:** Combine MARBLE with a PyTorch model and compare results.

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -1,0 +1,30 @@
+import os, sys, time
+from threading import Thread
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import requests
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from marble_brain import Brain
+from marble_core import DataLoader
+from tests.test_core_functions import minimal_params
+from web_api import InferenceServer
+
+
+def test_inference_server(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader())
+    server = InferenceServer(brain, host="localhost", port=5090)
+    server.start()
+    try:
+        # wait briefly for server
+        time.sleep(0.5)
+        resp = requests.post("http://localhost:5090/infer", json={"input": 0.1}, timeout=5)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "output" in data
+        assert isinstance(data["output"], float)
+    finally:
+        server.stop()

--- a/web_api.py
+++ b/web_api.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from flask import Flask, request, jsonify
+
+
+class InferenceServer:
+    """Expose a MARBLE brain for remote inference via HTTP."""
+
+    def __init__(self, brain, host: str = "localhost", port: int = 5000) -> None:
+        self.brain = brain
+        self.host = host
+        self.port = port
+        self.app = Flask(__name__)
+        self.thread: threading.Thread | None = None
+        self._setup_routes()
+
+    def _setup_routes(self) -> None:
+        @self.app.post("/infer")
+        def infer():
+            data: dict[str, Any] = request.get_json(force=True) or {}
+            value = float(data.get("input", 0.0))
+            output, _ = self.brain.neuronenblitz.dynamic_wander(value)
+            return jsonify({"output": output})
+
+        @self.app.post("/shutdown")
+        def shutdown():
+            request.environ.get("werkzeug.server.shutdown", lambda: None)()
+            return "OK"
+
+    def start(self) -> None:
+        if self.thread is None:
+            self.thread = threading.Thread(
+                target=self.app.run,
+                kwargs={"host": self.host, "port": self.port, "debug": False},
+                daemon=True,
+            )
+            self.thread.start()
+
+    def stop(self) -> None:
+        if self.thread is not None:
+            try:
+                import requests
+
+                requests.post(f"http://{self.host}:{self.port}/shutdown", timeout=1)
+            except Exception:
+                pass
+            self.thread.join(timeout=5)
+            self.thread = None


### PR DESCRIPTION
## Summary
- add `InferenceServer` for lightweight HTTP inference
- mark TODO item as complete
- document new API in README and TUTORIAL
- add unit test for `InferenceServer`

## Testing
- `pytest tests/test_web_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68860ff92c4483279022f5da4f615fc0