### PR TITLE
Implement PyTorch adapter and checkpointing

### DIFF
--- a/marble_brain.py
+++ b/marble_brain.py
@@ -579,6 +579,36 @@ class Brain:
             self.neuronenblitz = data["neuronenblitz"]
         print(f"Model loaded from {filepath}")
 
+    def save_checkpoint(self, path: str, epoch: int) -> None:
+        """Persist full training state and epoch to ``path``."""
+        state = {
+            "epoch": epoch,
+            "core": self.core,
+            "neuronenblitz": self.neuronenblitz,
+            "meta_controller": self.meta_controller,
+            "memory_system": self.memory_system,
+            "lobe_manager": self.lobe_manager,
+            "random_state": random.getstate(),
+            "numpy_state": np.random.get_state(),
+        }
+        with open(path, "wb") as f:
+            pickle.dump(state, f)
+        print(f"Checkpoint saved to {path}")
+
+    def load_checkpoint(self, path: str) -> int:
+        """Load training state from ``path`` and return last epoch."""
+        with open(path, "rb") as f:
+            state = pickle.load(f)
+        self.core = state["core"]
+        self.neuronenblitz = state["neuronenblitz"]
+        self.meta_controller = state["meta_controller"]
+        self.memory_system = state["memory_system"]
+        self.lobe_manager = state["lobe_manager"]
+        random.setstate(state["random_state"])
+        np.random.set_state(state["numpy_state"])
+        print(f"Checkpoint loaded from {path}")
+        return int(state["epoch"])
+
     def infer(self, input_value):
         """Return the output of the trained model for ``input_value``."""
         key = round(float(input_value), 6)

--- a/tests/test_torch_interop.py
+++ b/tests/test_torch_interop.py
@@ -1,0 +1,32 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import torch
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from marble_brain import Brain
+from torch_interop import MarbleTorchAdapter, core_to_torch
+from tests.test_core_functions import minimal_params
+
+
+def test_marble_torch_adapter_forward():
+    params = minimal_params()
+    core = Core(params)
+    adapter = core_to_torch(core)
+    x = torch.randn(len(core.neurons), core.rep_size)
+    out = adapter(x)
+    assert out.shape == (len(core.neurons), core.rep_size)
+
+
+def test_brain_checkpoint(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, None, save_dir=str(tmp_path))
+    ckpt = tmp_path / "ckpt.pkl"
+    brain.save_checkpoint(str(ckpt), epoch=3)
+    new_brain = Brain(core, nb, None, save_dir=str(tmp_path))
+    loaded_epoch = new_brain.load_checkpoint(str(ckpt))
+    assert loaded_epoch == 3
+    assert isinstance(new_brain.core, Core)

--- a/torch_interop.py
+++ b/torch_interop.py
@@ -1,0 +1,22 @@
+import torch
+from marble_core import _W1, _B1, _W2, _B2, Core
+
+class MarbleTorchAdapter(torch.nn.Module):
+    """PyTorch module mirroring Marble's message passing MLP."""
+
+    def __init__(self, core: Core) -> None:
+        super().__init__()
+        self.core = core
+        self.w1 = torch.nn.Parameter(torch.tensor(_W1, dtype=torch.float32))
+        self.b1 = torch.nn.Parameter(torch.tensor(_B1, dtype=torch.float32))
+        self.w2 = torch.nn.Parameter(torch.tensor(_W2, dtype=torch.float32))
+        self.b2 = torch.nn.Parameter(torch.tensor(_B2, dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover
+        h = torch.tanh(x @ self.w1 + self.b1)
+        return torch.tanh(h @ self.w2 + self.b2)
+
+
+def core_to_torch(core: Core) -> MarbleTorchAdapter:
+    """Return a ``MarbleTorchAdapter`` wrapping ``core`` for inference."""
+    return MarbleTorchAdapter(core)


### PR DESCRIPTION
## Summary
- add `MarbleTorchAdapter` for basic PyTorch interoperability
- implement `Brain.save_checkpoint` and `Brain.load_checkpoint`
- test new adapter and checkpointing

## Testing
- `pytest -k "torch_interop or checkpoint" -q`

------
https://chatgpt.com/codex/tasks/task_e_68862d72a2d08327844f092e011c8496