### PR TITLE
Implement dynamic representation resizing and quantization

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -37,6 +37,7 @@ Each entry is listed under its section heading.
 - representation_activation
 - apply_layer_norm
 - use_mixed_precision
+- quantization_bits
 - weight_init_mean
 - weight_init_std
 - weight_init_type
@@ -164,6 +165,7 @@ Each entry is listed under its section heading.
 - subpath_cache_size
 - subpath_cache_ttl
 - use_mixed_precision
+- quantization_bits
 
 ## brain
 - save_threshold

--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -1,2 +1,3 @@
 All tests passed
 - tests/test_continual_learning.py failed due to ModuleNotFoundError before adding tests/__init__.py
+- tests/test_streamlit_all_buttons.py::test_click_all_buttons failed during CI

--- a/TODO.md
+++ b/TODO.md
@@ -23,7 +23,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 16. Provide PyTorch interoperability layers for easier adoption.
 17. [x] Improve the `MetricsVisualizer` to log to TensorBoard and CSV.
 18. [x] Add memory usage tracking to the core.
-19. Support dynamic resizing of neuron representations at runtime.
+19. [x] Support dynamic resizing of neuron representations at runtime.
 20. [x] Implement gradient clipping utilities within Neuronenblitz.
 21. [x] Add a learning rate scheduler with cosine and exponential options.
 22. [x] Document all YAML parameters in `yaml-manual.txt` with examples.
@@ -52,7 +52,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 45. Provide conversion tools between Marble Core and other frameworks.
 46. [x] Implement an extensible metrics aggregation system.
 47. Improve code style consistency with automated formatting checks.
-48. Add support for quantization and model compression.
+48. [x] Add support for quantization and model compression.
 49. Implement a plugin-based remote tier for custom hardware.
 50. [x] Create visualization utilities for neuron activation patterns.
 51. [x] Add parameter scheduling for exploration/exploitation trade-offs.

--- a/config.yaml
+++ b/config.yaml
@@ -44,6 +44,7 @@ core:
   representation_activation: "tanh"
   apply_layer_norm: true
   use_mixed_precision: false
+  quantization_bits: 0
   weight_init_mean: 0.0
   weight_init_std: 1.0
   weight_init_type: "uniform"

--- a/config_loader.py
+++ b/config_loader.py
@@ -55,6 +55,7 @@ def create_marble_from_config(
         load_plugins(plugin_dirs)
 
     core_params = cfg.get("core", {})
+    qbits = core_params.get("quantization_bits", 0)
     nb_params = cfg.get("neuronenblitz", {})
     brain_params = cfg.get("brain", {})
     initial_neurogenesis_factor = brain_params.pop("initial_neurogenesis_factor", 1.0)
@@ -173,6 +174,9 @@ def create_marble_from_config(
         pytorch_challenge_params=pytorch_challenge_params,
         hybrid_memory_params=hybrid_memory_params,
     )
+    if qbits:
+        from model_quantization import quantize_core_weights
+        quantize_core_weights(int(qbits))
     if remote_server is not None:
         marble.remote_server = remote_server
 

--- a/config_schema.py
+++ b/config_schema.py
@@ -18,6 +18,7 @@ CONFIG_SCHEMA = {
                     "maximum": 1,
                 },
                 "use_mixed_precision": {"type": "boolean"},
+                "quantization_bits": {"type": "integer", "minimum": 0, "maximum": 16},
             },
         },
         "neuronenblitz": {"type": "object"},

--- a/marble_core.py
+++ b/marble_core.py
@@ -70,6 +70,26 @@ def configure_representation_size(
     )
 
 
+def resize_neuron_representations(core: "Core", new_size: int) -> None:
+    """Resize all neuron representations in ``core`` to ``new_size``.
+
+    This updates the global representation configuration and preserves existing
+    values by truncation or zero-padding as needed.
+    """
+    old_size = core.rep_size
+    if new_size == old_size:
+        return
+    configure_representation_size(new_size)
+    for neuron in core.neurons:
+        rep = neuron.representation
+        if new_size > rep.size:
+            padded = np.zeros(new_size, dtype=rep.dtype)
+            padded[: rep.size] = rep
+            neuron.representation = padded
+        else:
+            neuron.representation = rep[:new_size]
+
+
 def _apply_activation(arr: np.ndarray, activation: str) -> np.ndarray:
     """Return ``arr`` passed through the given activation function."""
     if activation == "relu":

--- a/model_quantization.py
+++ b/model_quantization.py
@@ -1,0 +1,27 @@
+import numpy as np
+import marble_core
+from marble_core import _W1, _B1, _W2, _B2
+
+
+def quantize_core_weights(num_bits: int = 8) -> None:
+    """Quantize global MLP weights to the given bit precision.
+
+    Parameters
+    ----------
+    num_bits:
+        Number of bits to use for quantization. Must be between 1 and 16.
+    """
+    if not 1 <= num_bits <= 16:
+        raise ValueError("num_bits must be within [1, 16]")
+    qmax = 2 ** (num_bits - 1) - 1
+    scale = qmax
+
+    def _quant(arr: np.ndarray) -> np.ndarray:
+        clipped = np.clip(arr, -1.0, 1.0)
+        q = np.round(clipped * scale).astype(np.int16)
+        return q.astype(arr.dtype) / scale
+
+    marble_core._W1 = _quant(_W1)
+    marble_core._B1 = _quant(_B1)
+    marble_core._W2 = _quant(_W2)
+    marble_core._B2 = _quant(_B2)

--- a/tests/test_dynamic_resize.py
+++ b/tests/test_dynamic_resize.py
@@ -1,0 +1,15 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import numpy as np
+from marble_core import Core, resize_neuron_representations
+from tests.test_core_functions import minimal_params
+
+
+def test_resize_increases_and_decreases():
+    core = Core(minimal_params())
+    resize_neuron_representations(core, 8)
+    for n in core.neurons:
+        assert n.representation.shape == (8,)
+    resize_neuron_representations(core, 2)
+    for n in core.neurons:
+        assert n.representation.shape == (2,)

--- a/tests/test_model_quantization.py
+++ b/tests/test_model_quantization.py
@@ -1,0 +1,12 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import numpy as np
+import marble_core
+from model_quantization import quantize_core_weights
+
+
+def test_quantize_core_weights_reduces_precision():
+    orig_unique = len(np.unique(marble_core._W1))
+    quantize_core_weights(4)
+    new_unique = len(np.unique(marble_core._W1))
+    assert new_unique <= orig_unique

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -104,6 +104,11 @@ core:
     available, computations run in half precision within a ``torch.autocast``
     context. This can greatly speed up training but may introduce minor numerical
     differences compared to full precision.
+  quantization_bits: Number of bits used to quantize the core MLP weights. When
+    greater than ``0`` the weights of the message passing MLP are uniformly
+    quantized to this precision after loading the configuration. Typical values
+    are ``8`` for moderate compression or ``4`` for aggressive size reduction.
+    Setting ``0`` disables quantization and keeps weights in full precision.
   weight_init_mean: Mean of the normal distribution used to initialize
     synaptic weights.
   weight_init_std: Standard deviation of the normal distribution when
@@ -420,6 +425,10 @@ neuronenblitz:
   use_mixed_precision: Enable PyTorch automatic mixed precision during
     training. This trades some numerical precision for faster execution on
     compatible GPUs.
+  quantization_bits: Bit precision used when quantizing the core weights on
+    start-up. A value of ``0`` disables quantization. Larger values retain more
+    accuracy but provide less compression. Values above ``16`` are not
+    supported.
 
 brain:
   save_threshold: Minimum improvement in validation loss required before the


### PR DESCRIPTION
## Summary
- add `resize_neuron_representations` in `marble_core`
- support optional weight quantization via `quantize_core_weights`
- expose new `quantization_bits` YAML parameter and document it
- update config loader to apply quantization
- add tests for resizing and quantization
- mark related TODO items as complete
- log failing tests in FAILEDTESTS.md

## Testing
- `pytest tests/test_dynamic_resize.py::test_resize_increases_and_decreases -q`
- `pytest tests/test_model_quantization.py::test_quantize_core_weights_reduces_precision -q`
- `pytest -q` *(fails: tests/test_streamlit_all_buttons.py::test_click_all_buttons)*

------
https://chatgpt.com/codex/tasks/task_e_68863dfde4788327a68d78f51bbff9b8