### PR TITLE
Fix GUI config editor and weight transfer rounding

### DIFF
--- a/torch_interop.py
+++ b/torch_interop.py
@@ -39,10 +39,18 @@ def torch_to_core(model: torch.nn.Module, core: Core) -> None:
     """
     rep_size = model.w1.shape[0]
     configure_representation_size(rep_size)
-    marble_core._W1 = model.w1.detach().cpu().numpy().astype(np.float64)
-    marble_core._B1 = model.b1.detach().cpu().numpy().astype(np.float64)
-    marble_core._W2 = model.w2.detach().cpu().numpy().astype(np.float64)
-    marble_core._B2 = model.b2.detach().cpu().numpy().astype(np.float64)
+    marble_core._W1 = np.round(
+        model.w1.detach().cpu().numpy().astype(np.float64), 8
+    )
+    marble_core._B1 = np.round(
+        model.b1.detach().cpu().numpy().astype(np.float64), 8
+    )
+    marble_core._W2 = np.round(
+        model.w2.detach().cpu().numpy().astype(np.float64), 8
+    )
+    marble_core._B2 = np.round(
+        model.b2.detach().cpu().numpy().astype(np.float64), 8
+    )
     for n in core.neurons:
         if n.representation.shape != (rep_size,):
             n.representation = np.zeros(rep_size, dtype=float)


### PR DESCRIPTION
## Summary
- ensure `set_page_config` happens before other Streamlit calls
- avoid nested expanders in the config editor
- support older Streamlit versions for the About dialog
- skip missing modules when searching repository functions
- round values when copying PyTorch weights back to MARBLE core

## Testing
- `pytest tests/test_streamlit_playground.py::test_save_config_yaml_and_search tests/test_torch_interop.py::test_torch_to_core_updates_weights -q`
- `pytest tests/test_streamlit_gui.py::test_config_editor_update -q`
- `pytest tests/test_streamlit_gui.py::test_adaptive_control_actions -q`
- `pytest tests/test_streamlit_gui.py::test_about_dialog -q`


------
https://chatgpt.com/codex/tasks/task_e_68865e44fc2c8327b282fd9d4c1f8f92