### PR TITLE
Implement gradient accumulation

### DIFF
--- a/tests/test_neuronenblitz_enhancements.py
+++ b/tests/test_neuronenblitz_enhancements.py
@@ -247,6 +247,30 @@ def test_eligibility_traces_accumulate():
     assert np.isclose(syn.weight, 2.45470864944, atol=1e-6)
 
 
+def test_gradient_accumulation_steps():
+    random.seed(0)
+    core, syn = create_simple_core()
+    nb = Neuronenblitz(
+        core,
+        consolidation_probability=0.0,
+        weight_decay=0.0,
+        momentum_coefficient=0.0,
+        structural_plasticity_enabled=False,
+        synaptic_fatigue_enabled=False,
+        split_probability=0.0,
+        alternative_connection_prob=0.0,
+        gradient_accumulation_steps=2,
+    )
+    nb.learning_rate = 1.0
+    core.neurons[0].value = 1.0
+    prev = syn.weight
+    nb.apply_weight_updates_and_attention([syn], error=1.0)
+    assert syn.weight == pytest.approx(prev)
+    core.neurons[0].value = 1.0
+    nb.apply_weight_updates_and_attention([syn], error=1.0)
+    assert syn.weight != pytest.approx(prev)
+
+
 def test_dropout_prevents_synapse_use():
     random.seed(0)
     np.random.seed(0)

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -779,7 +779,7 @@ lobe_manager:
 autograd:
   enabled: Set to true to wrap the Brain with a transparent PyTorch autograd layer. When enabled, gradients from PyTorch operations are applied to MARBLE synapse weights without altering the underlying architecture.
   learning_rate: Step size used when the autograd layer applies gradient updates to synapse weights during backward passes. Typical values range from 0.001 to 0.1.
-  gradient_accumulation_steps: Number of backward passes to accumulate before applying weight updates. This enables effective large batch sizes even when GPU memory is limited. Values between ``2`` and ``32`` are common.
+  gradient_accumulation_steps: Number of training examples to process before applying weight updates. MARBLE accumulates gradients from each call to ``train_example`` and only updates synapse weights once this many examples have been seen. This allows effectively larger batch sizes even when GPU memory is limited. Values between ``1`` and ``32`` are common.
 pytorch_challenge:
   enabled: If true the training loop compares MARBLE with a pretrained PyTorch model after every training example. When MARBLE's validation loss, inference speed or model size exceed the PyTorch model, neuromodulatory stress is increased which lowers plasticity on subsequent updates.
   loss_penalty: Amount of stress added when MARBLE's loss is worse than the PyTorch baseline. Values around 0.1 provide noticeable pressure without overwhelming the system.


### PR DESCRIPTION
## Summary
- support accumulating weight updates in `Neuronenblitz`
- document new training behaviour in `yaml-manual.txt`
- test gradient accumulation in enhancement tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688664e62c6883278489eedb602f9a9a