### PR TITLE
Implement Neuronenblitz plugin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,3 +239,4 @@ pre-commit install
 to automatically format and lint changes before each commit.
 
 \nMARBLE can be extended via a simple plugin system. Specify directories in the `plugins` list of the configuration and each module's `register` function will be invoked to add custom neuron or synapse types.
+Neuronenblitz exposes a runtime plugin API. After creating a `Neuronenblitz` instance you may activate modules via `n_plugin.activate("my_plugin")`. The plugin\x27s `activate(nb)` function receives the instance and can freely read or modify any attributes or methods.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1513,6 +1513,9 @@ Additional experiments can enable **prioritized experience replay** by setting `
    ```
 3. Initialize MARBLE via `create_marble_from_config` and your new types will be
    available for use when modifying the core or Neuronenblitz.
+4. After creating a `Neuronenblitz` instance you can activate plugins with
+   `n_plugin.activate("my_plugin")`. The plugin's `activate(nb)` function
+   receives the instance for unrestricted access.
 
 
 ## Organising Multiple Experiments

--- a/marble_neuronenblitz.py
+++ b/marble_neuronenblitz.py
@@ -324,6 +324,12 @@ class Neuronenblitz:
         self.gradient_accumulation_steps = int(max(1, gradient_accumulation_steps))
         self._accum_step = 0
         self._accum_updates = {}
+        try:
+            import n_plugin
+
+            n_plugin.register(self)
+        except Exception:
+            pass
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/n_plugin.py
+++ b/n_plugin.py
@@ -1,0 +1,30 @@
+"""Neuronenblitz plugin management."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import Dict, Optional
+
+# Active plugin modules keyed by name
+_active_plugins: Dict[str, ModuleType] = {}
+# Currently registered Neuronenblitz instance
+_nb_instance: Optional[object] = None
+
+
+def register(nb: object) -> None:
+    """Register a ``Neuronenblitz`` instance for plugin access."""
+    global _nb_instance
+    _nb_instance = nb
+    for module in _active_plugins.values():
+        if hasattr(module, "activate"):
+            module.activate(nb)
+
+
+def activate(name: str) -> ModuleType:
+    """Import and activate plugin ``name``."""
+    module = import_module(name)
+    _active_plugins[name] = module
+    if _nb_instance is not None and hasattr(module, "activate"):
+        module.activate(_nb_instance)
+    return module

--- a/tests/test_n_plugin.py
+++ b/tests/test_n_plugin.py
@@ -1,0 +1,38 @@
+import importlib
+import os
+import sys
+
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from tests.test_core_functions import minimal_params
+import n_plugin
+
+
+def test_neuronenblitz_plugin_activation(tmp_path):
+    importlib.reload(n_plugin)
+    plugin_code = "def activate(nb):\n    nb.plugin_value = 42\n"
+    p = tmp_path / "nb_plugin.py"
+    p.write_text(plugin_code)
+    sys.path.insert(0, str(tmp_path))
+    try:
+        core = Core(minimal_params())
+        nb = Neuronenblitz(core)
+        n_plugin.activate("nb_plugin")
+        assert getattr(nb, "plugin_value", None) == 42
+    finally:
+        sys.path.remove(str(tmp_path))
+
+
+def test_activate_before_register(tmp_path):
+    importlib.reload(n_plugin)
+    plugin_code = "def activate(nb):\n    nb.plugin_value = 99\n"
+    p = tmp_path / "nb_plugin2.py"
+    p.write_text(plugin_code)
+    sys.path.insert(0, str(tmp_path))
+    try:
+        n_plugin.activate("nb_plugin2")
+        core = Core(minimal_params())
+        nb = Neuronenblitz(core)
+        assert getattr(nb, "plugin_value", None) == 99
+    finally:
+        sys.path.remove(str(tmp_path))


### PR DESCRIPTION
## Summary
- add runtime plugin module `n_plugin` exposing activate/register functions
- register Neuronenblitz instance with the plugin system on init
- document plugin activation in README and TUTORIAL
- test activation order with new `tests/test_n_plugin.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: RuntimeError in streamlit tests)*

------
https://chatgpt.com/codex/tasks/task_e_68867051f31c83279fc510d6a9746d62