### PR TITLE
Add config generator script

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -117,8 +117,8 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 66. Improve readability of configuration files with comments and sections.
    - [ ] Group related config parameters into sections.
    - [ ] Add descriptive comments for each parameter.
-   - [ ] Provide script to auto-generate sample config with comments.
-   - [ ] Update YAML manual accordingly.
+   - [x] Provide script to auto-generate sample config with comments.
+   - [x] Update YAML manual accordingly.
 67. [x] Implement graph pruning utilities to remove unused neurons.
 68. [x] Create a repository of reusable neuron/synapse templates.
 69. [x] Add support for mixed precision training when GPUs are available.

--- a/config_generator.py
+++ b/config_generator.py
@@ -1,0 +1,67 @@
+import yaml
+import argparse
+from typing import Dict, Any
+
+
+def parse_manual(manual_path: str) -> Dict[str, str]:
+    """Parse yaml-manual.txt and return mapping of section.param to description."""
+    param_desc: Dict[str, str] = {}
+    current_section = ""
+    current_key = None
+    with open(manual_path, "r") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            if not line.startswith("  ") and line.rstrip().endswith(":"):
+                current_section = line.strip().rstrip(":")
+                current_key = None
+                continue
+            if line.startswith("  ") and not line.startswith("    "):
+                # new parameter
+                key, desc = line.strip().split(":", 1)
+                current_key = f"{current_section}.{key}"
+                param_desc[current_key] = desc.strip()
+            elif line.startswith("    ") and current_key:
+                param_desc[current_key] += " " + line.strip()
+    return param_desc
+
+
+def _generate_lines(data: Any, descs: Dict[str, str], section: str = "", indent: int = 0) -> list[str]:
+    lines = []
+    prefix = " " * indent
+    if isinstance(data, dict):
+        for key, val in data.items():
+            full = f"{section}.{key}" if section else key
+            desc = descs.get(full)
+            if desc:
+                lines.append(f"{prefix}# {desc}")
+            if isinstance(val, dict):
+                lines.append(f"{prefix}{key}:")
+                lines.extend(_generate_lines(val, descs, full, indent + 2))
+            else:
+                dumped = yaml.safe_dump(val, default_flow_style=True).strip()
+                lines.append(f"{prefix}{key}: {dumped}")
+    return lines
+
+
+def generate_commented_config(config_path: str, manual_path: str, output_path: str) -> None:
+    """Generate a YAML config with inline comments from manual descriptions."""
+    with open(config_path, "r") as f:
+        config = yaml.safe_load(f)
+    descs = parse_manual(manual_path)
+    lines = []
+    for section, content in config.items():
+        lines.append(f"{section}:")
+        lines.extend(_generate_lines(content, descs, section, 2))
+        lines.append("")
+    with open(output_path, "w") as f:
+        f.write("\n".join(lines))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate commented config")
+    parser.add_argument("--config", default="config.yaml")
+    parser.add_argument("--manual", default="yaml-manual.txt")
+    parser.add_argument("--output", default="sample_config_with_comments.yaml")
+    args = parser.parse_args()
+    generate_commented_config(args.config, args.manual, args.output)

--- a/tests/test_config_generator.py
+++ b/tests/test_config_generator.py
@@ -1,0 +1,16 @@
+import yaml
+from config_generator import parse_manual, generate_commented_config
+
+
+def test_generate_commented_config(tmp_path):
+    manual = tmp_path / "manual.txt"
+    manual.write_text("""section:\n  param: Example parameter.""")
+    config = {'section': {'param': 1}}
+    cfg = tmp_path / "config.yaml"
+    with cfg.open('w') as f:
+        yaml.safe_dump(config, f)
+    out = tmp_path / "out.yaml"
+    generate_commented_config(str(cfg), str(manual), str(out))
+    contents = out.read_text()
+    assert "# Example parameter." in contents
+    assert "param: 1" in contents

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -2,6 +2,8 @@ The configuration YAML file controls all components of MARBLE.  Each top-level
 section corresponds to a subsystem and exposes parameters that can be tuned to
 alter its behaviour.  When the file is loaded it is validated against an
 internal JSON schema to catch missing sections or invalid values early.
+A sample configuration with inline comments can be generated using the
+`config_generator.py` script. Run `python config_generator.py` to create `sample_config_with_comments.yaml` which mirrors `config.yaml` but includes descriptions for each parameter.
 
 dataset:
   num_shards: Number of shards the training dataset is split into. When greater


### PR DESCRIPTION
## Summary
- implement `config_generator.py` for auto-generating configuration files with comments
- document generator in `yaml-manual.txt`
- mark TODO items as done
- add test for config generator

## Testing
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6886fc4209788327b60ef504579406ce