### PR TITLE
Implement policy gradient RL wrapper and packaging

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -375,6 +375,7 @@ Each entry is listed under its section heading.
 
 ## reinforcement_learning
 - enabled
+- algorithm
 - episodes
 - max_steps
 - discount_factor

--- a/README.md
+++ b/README.md
@@ -240,3 +240,12 @@ to automatically format and lint changes before each commit.
 
 \nMARBLE can be extended via a simple plugin system. Specify directories in the `plugins` list of the configuration and each module's `register` function will be invoked to add custom neuron or synapse types.
 Neuronenblitz exposes a runtime plugin API. After creating a `Neuronenblitz` instance you may activate modules via `n_plugin.activate("my_plugin")`. The plugin\x27s `activate(nb)` function receives the instance and can freely read or modify any attributes or methods.
+
+## Release Process
+To publish a new release to PyPI:
+1. Update the version number in `pyproject.toml` and `setup.py`.
+2. Commit all changes and tag the commit with the version.
+3. Run `python -m build` to create source and wheel packages.
+4. Upload to TestPyPI with `twine upload --repository testpypi dist/*` and verify installation.
+5. Once validated, upload to PyPI.
+

--- a/TODO.md
+++ b/TODO.md
@@ -48,10 +48,10 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [ ] Implement distributed training pipeline in `marble_neuronenblitz`.
    - [ ] Write tests using CPU-based simulator.
 27. Provide higher-level wrappers for common reinforcement learning tasks.
-   - [ ] Design RL environment interface.
-   - [ ] Implement wrappers for policy gradient, Q-learning, etc.
-   - [ ] Add examples demonstrating wrappers.
-   - [ ] Document usage in README/TUTORIAL.
+   - [x] Design RL environment interface.
+   - [x] Implement wrappers for policy gradient, Q-learning, etc.
+   - [x] Add examples demonstrating wrappers.
+   - [x] Document usage in README/TUTORIAL.
 28. [x] Add recurrent neural network neuron types to Marble Core.
 29. [x] Introduce dropout and batch normalization synapse types.
 30. [x] Create a graphical configuration editor in the Streamlit GUI.
@@ -132,16 +132,16 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 73. [x] Provide self-contained Docker images for reproducibility.
 74. [x] Implement offline mode with pre-packaged datasets.
 75. Add automated packaging to publish releases on PyPI.
-   - [ ] Create setup.py and pyproject.toml for packaging.
+   - [x] Create setup.py and pyproject.toml for packaging.
    - [ ] Setup CI workflow for building and uploading to TestPyPI.
-   - [ ] Add versioning scheme.
-   - [ ] Document release process.
+   - [x] Add versioning scheme.
+   - [x] Document release process.
 76. [x] Improve data compression for network transfers.
 77. Incorporate gradient accumulation for large batch training.
-   - [ ] Modify training loop to accumulate gradients across steps.
-   - [ ] Expose accumulation steps via config.
+   - [x] Modify training loop to accumulate gradients across steps.
+   - [x] Expose accumulation steps via config.
    - [ ] Update scheduler and optimizer logic.
-   - [ ] Add tests verifying behavior.
+   - [x] Add tests verifying behavior.
 78. [x] Add performance regression tests for critical functions.
 79. [x] Integrate basic anomaly detection on training metrics.
 80. [x] Expand the scheduler with cyclic learning rate support.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -394,6 +394,11 @@ Run `python project05b_rnn_sequence_modeling.py` to train the simple RNN example
    This uses helper functions that drive the environment and update the Q-table stored inside the Neuronenblitz object.
 4. **Check rewards** in `history` after each episode to verify that the policy improves over time.
 
+To experiment with a differentiable approach set ``reinforcement_learning.algorithm``
+to ``"policy_gradient"`` and run ``project06b_policy_gradient.py``. This file
+trains ``MarblePolicyGradientAgent`` using a policy network wrapped with
+``MarbleAutogradLayer``. Rewards should steadily increase across episodes.
+
 **Complete Example**
 ```python
 # project6_reinforcement_learning.py

--- a/config.yaml
+++ b/config.yaml
@@ -369,6 +369,7 @@ distillation:
   teacher_model: null
 reinforcement_learning:
   enabled: false
+  algorithm: q_learning
   episodes: 10
   max_steps: 50
   discount_factor: 0.9

--- a/examples/project06b_policy_gradient.py
+++ b/examples/project06b_policy_gradient.py
@@ -1,0 +1,25 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from reinforcement_learning import (
+    GridWorld,
+    MarblePolicyGradientAgent,
+    train_policy_gradient,
+)
+from tests.test_core_functions import minimal_params
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+
+
+def main() -> None:
+    env = GridWorld(size=4)
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    agent = MarblePolicyGradientAgent(core, nb)
+    rewards = train_policy_gradient(agent, env, episodes=10, max_steps=30)
+    print("Rewards:", rewards)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "marble"
+version = "0.1.0"
+description = "Modular neural architecture with Neuronenblitz"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{name = "Marble Contributors"}]
+license = {text = "MIT"}

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+from setuptools import setup
+
+setup(
+    name="marble",
+    version="0.1.0",
+    py_modules=[
+        "marble_core",
+        "marble_neuronenblitz",
+        "marble",
+        "marble_brain",
+        "reinforcement_learning",
+    ],
+    install_requires=[],
+)

--- a/streamlit_playground.py
+++ b/streamlit_playground.py
@@ -1012,7 +1012,7 @@ def list_learner_modules() -> list[str]:
         if (
             mod.ispkg
             or mod.name.startswith("_")
-            or mod.name in {"streamlit_playground", "tests", "examples"}
+            or mod.name in {"streamlit_playground", "tests", "examples", "setup"}
         ):
             continue
         try:

--- a/tests/test_reinforcement_learning.py
+++ b/tests/test_reinforcement_learning.py
@@ -4,7 +4,13 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from reinforcement_learning import GridWorld, MarbleQLearningAgent, train_gridworld
+from reinforcement_learning import (
+    GridWorld,
+    MarbleQLearningAgent,
+    MarblePolicyGradientAgent,
+    train_gridworld,
+    train_policy_gradient,
+)
 from tests.test_core_functions import minimal_params
 from marble_core import Core
 from marble_neuronenblitz import Neuronenblitz
@@ -57,4 +63,14 @@ def test_double_q_learning_updates_both_tables():
     train_gridworld(agent, env, episodes=2, max_steps=5)
     total_entries = len(agent.q_table_a) + len(agent.q_table_b)
     assert total_entries > 0
+
+
+def test_policy_gradient_improves_reward():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    agent = MarblePolicyGradientAgent(core, nb, lr=0.01, gamma=0.9)
+    env = GridWorld(size=3)
+    rewards = train_policy_gradient(agent, env, episodes=50, max_steps=20, seed=0)
+    assert rewards[-1] >= rewards[0] - 1e-9
 

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -840,6 +840,10 @@ reinforcement_learning:
   enabled: Activate training in a reinforcement learning loop using the MARBLE
     core and Neuronenblitz. Set to ``true`` to begin episodic interaction with
     the environment defined in ``reinforcement_learning.py``.
+  algorithm: Selects the RL algorithm implementation. ``"q_learning"`` runs a
+    tabular Q-learning agent while ``"policy_gradient"`` trains a small
+    differentiable policy network integrated with MARBLE via
+    ``MarblePolicyGradientAgent``.
   episodes: Number of training episodes to run. More episodes generally yield
     better policies but increase computation time.
   max_steps: Maximum steps per episode before resetting the environment.


### PR DESCRIPTION
## Summary
- add reinforcement learning interface and policy gradient agent
- provide training helper for policy gradient
- document RL algorithm selection and packaging
- include example policy gradient project
- update streamlit module scanning logic
- add packaging configuration files

## Testing
- `pytest tests/test_reinforcement_learning.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688712f77b0883278ef7734143090cca