### PR TITLE
Implement constant-time auth token and scheduler fix

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -301,6 +301,7 @@ Each entry is listed under its section heading.
 - host
 - port
 - remote_url
+- auth_token
 - ssl_enabled
 - ssl_cert_file
 - ssl_key_file

--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -1,3 +1,4 @@
 Failed tests after latest changes:
 - tests/test_remote_offloading.py::test_bandwidth_and_route
 - tests/test_streamlit_gui.py::test_function_search_count_synapses (timeout)
+tests/test_streamlit_gui.py::test_function_search_count_synapses

--- a/config.yaml
+++ b/config.yaml
@@ -318,6 +318,7 @@ remote_server:
   host: "localhost"
   port: 8000
   remote_url: null
+  auth_token: null
   ssl_enabled: false
   ssl_cert_file: "server.crt"
   ssl_key_file: "server.key"

--- a/config_loader.py
+++ b/config_loader.py
@@ -134,6 +134,7 @@ def create_marble_from_config(
             remote_cfg["url"],
             timeout=remote_cfg.get("timeout", 5.0),
             max_retries=remote_cfg.get("max_retries", 3),
+            auth_token=remote_cfg.get("auth_token"),
         )
 
     remote_server = None
@@ -143,6 +144,7 @@ def create_marble_from_config(
             host=server_cfg.get("host", "localhost"),
             port=server_cfg.get("port", 8000),
             remote_url=server_cfg.get("remote_url"),
+            auth_token=server_cfg.get("auth_token"),
         )
         remote_server.start()
 

--- a/config_schema.py
+++ b/config_schema.py
@@ -64,6 +64,12 @@ CONFIG_SCHEMA = {
             "type": ["array", "string"],
             "items": {"type": "string"},
         },
+        "remote_server": {
+            "type": "object",
+            "properties": {
+                "auth_token": {"type": ["string", "null"]},
+            },
+        },
         "autograd": {
             "type": "object",
             "properties": {

--- a/crypto_utils.py
+++ b/crypto_utils.py
@@ -1,0 +1,11 @@
+import hmac
+from typing import Union
+
+
+def constant_time_compare(val1: Union[str, bytes], val2: Union[str, bytes]) -> bool:
+    """Return ``True`` if ``val1`` and ``val2`` are equal using constant-time comparison."""
+    if isinstance(val1, str):
+        val1 = val1.encode()
+    if isinstance(val2, str):
+        val2 = val2.encode()
+    return hmac.compare_digest(val1, val2)

--- a/marble_neuronenblitz/core.py
+++ b/marble_neuronenblitz/core.py
@@ -1257,6 +1257,8 @@ class Neuronenblitz:
                     syn.weight *= 1.0 - self.weight_decay
             self._accum_updates.clear()
             self._accum_step = 0
+            self.step_lr_scheduler()
+            self.step_epsilon_scheduler()
         if path:
             last_neuron = self.core.neurons[path[-1].target]
             last_neuron.attention_score += abs(error)
@@ -1368,8 +1370,6 @@ class Neuronenblitz:
             self.last_message_passing_change = change
             self.decide_synapse_action()
             self.adjust_learning_rate()
-            self.step_lr_scheduler()
-            self.step_epsilon_scheduler()
             if (
                 self.use_experience_replay
                 and len(self.replay_buffer) >= self.replay_batch_size

--- a/streamlit_playground.py
+++ b/streamlit_playground.py
@@ -951,6 +951,7 @@ def start_remote_server(
     remote_url: str | None = None,
     compression_level: int = 6,
     compression_enabled: bool = True,
+    auth_token: str | None = None,
 ) -> object:
     """Start and return a ``RemoteBrainServer`` instance."""
     from remote_offload import RemoteBrainServer
@@ -961,6 +962,7 @@ def start_remote_server(
         remote_url=remote_url,
         compression_level=compression_level,
         compression_enabled=compression_enabled,
+        auth_token=auth_token,
     )
     server.start()
     return server
@@ -972,6 +974,7 @@ def create_remote_client(
     max_retries: int = 3,
     compression_level: int = 6,
     compression_enabled: bool = True,
+    auth_token: str | None = None,
 ) -> object:
     """Return a configured ``RemoteBrainClient``."""
     from remote_offload import RemoteBrainClient
@@ -982,6 +985,7 @@ def create_remote_client(
         max_retries=max_retries,
         compression_level=compression_level,
         compression_enabled=compression_enabled,
+        auth_token=auth_token,
     )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -166,6 +166,7 @@ def test_remote_server_start(tmp_path):
         "host": "localhost",
         "port": 8123,
         "remote_url": None,
+        "auth_token": "abc",
     }
     with open(cfg_path, "w", encoding="utf-8") as f:
         yaml.safe_dump(cfg, f)

--- a/tests/test_config_additional.py
+++ b/tests/test_config_additional.py
@@ -10,5 +10,6 @@ def test_extended_config_parameters():
     assert cfg["brain"]["model_name"] == "marble_default"
     assert cfg["remote_client"]["auth_token"] is None
     assert cfg["remote_server"]["ssl_enabled"] is False
+    assert cfg["remote_server"]["auth_token"] is None
     assert cfg["metrics_visualizer"]["refresh_rate"] == 1
     assert cfg["brain"]["super_evolution_mode"] is False

--- a/tests/test_crypto_utils.py
+++ b/tests/test_crypto_utils.py
@@ -1,0 +1,23 @@
+import time
+from crypto_utils import constant_time_compare
+
+
+def test_constant_time_compare_equal():
+    assert constant_time_compare("abc", "abc")
+
+
+def test_constant_time_compare_not_equal():
+    assert not constant_time_compare("abc", "abd")
+
+
+def test_constant_time_compare_timing():
+    a = "a" * 32
+    b = "b" * 32
+    start = time.perf_counter_ns()
+    constant_time_compare(a, a)
+    equal_time = time.perf_counter_ns() - start
+    start = time.perf_counter_ns()
+    constant_time_compare(a, b)
+    diff_time = time.perf_counter_ns() - start
+    assert abs(equal_time - diff_time) < 5_000_000  # 5 ms
+

--- a/tests/test_remote_latency.py
+++ b/tests/test_remote_latency.py
@@ -4,9 +4,10 @@ from remote_offload import RemoteBrainClient
 
 
 def test_remote_client_latency_tracking(monkeypatch):
-    def fake_post(url, json=None, timeout=0):
+    def fake_post(url, json=None, timeout=0, **kwargs):
         time.sleep(0.01)
         class Res:
+            status_code = 200
             def json(self):
                 return {"output": 1.0}
         return Res()

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -725,6 +725,9 @@ remote_server:
   port: TCP port used by the server.
   remote_url: Optional URL of another remote brain server to which this server
     offloads work.
+  auth_token: Optional shared secret required in the ``Authorization`` header of
+    every request. When set, clients must supply ``"Bearer <token>"`` and the
+    server compares it using constant-time logic to avoid timing attacks.
   ssl_enabled: Enables HTTPS with the provided certificate and key files.
   ssl_cert_file: Path to the SSL certificate used when ``ssl_enabled`` is true.
   ssl_key_file: Path to the private key for the certificate.


### PR DESCRIPTION
## Summary
- implement constant_time_compare utility
- add auth token support for remote server/client using constant-time compare
- update scheduler to step after gradient accumulation
- document new auth_token parameter and update configuration
- adjust unit tests for new auth logic and fix mocks
- log failing test

## Testing
- `pytest tests/test_remote_offloading.py tests/test_remote_latency.py -q`
- `pytest -q` *(fails: tests/test_streamlit_gui.py::test_function_search_count_synapses)*

------
https://chatgpt.com/codex/tasks/task_e_688722aee3788327bbfb6482711e82d5