### PR TITLE
Organize network config section

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -263,7 +263,8 @@ Each entry is listed under its section heading.
 - symbolic_store_path
 - max_entries
 
-## remote_client
+
+## network.remote_client
 - url
 - timeout
 - max_retries
@@ -274,7 +275,7 @@ Each entry is listed under its section heading.
 - heartbeat_timeout
 - use_compression
 
-## torrent_client
+## network.torrent_client
 - client_id
 - buffer_size
 - heartbeat_interval
@@ -298,7 +299,7 @@ Each entry is listed under its section heading.
 - formula
 - formula_num_neurons
 
-## remote_server
+## network.remote_server
 - enabled
 - host
 - port

--- a/config.yaml
+++ b/config.yaml
@@ -289,20 +289,6 @@ hybrid_memory:
   vector_store_path: "vector_store.pkl"
   symbolic_store_path: "symbolic_memory.pkl"
   max_entries: 1000
-remote_client:
-  url: "http://localhost:8001"
-  timeout: 5.0
-  max_retries: 3
-  track_latency: true
-  auth_token: null
-  ssl_verify: true
-  connect_retry_interval: 5
-  heartbeat_timeout: 10
-  use_compression: true
-torrent_client:
-  client_id: "main"
-  buffer_size: 10
-  heartbeat_interval: 30
 data_compressor:
   compression_level: 6
   compression_enabled: true
@@ -315,18 +301,34 @@ experiment_tracker:
   project: "marble"
   entity: null
   run_name: null
-remote_server:
-  enabled: false
-  host: "localhost"
-  port: 8000
-  remote_url: null
-  auth_token: null
-  ssl_enabled: false
-  ssl_cert_file: "server.crt"
-  ssl_key_file: "server.key"
-  max_connections: 100
-  compression_level: 6
-  compression_enabled: true
+  
+network:
+  remote_client:
+    url: "http://localhost:8001"
+    timeout: 5.0
+    max_retries: 3
+    track_latency: true
+    auth_token: null
+    ssl_verify: true
+    connect_retry_interval: 5
+    heartbeat_timeout: 10
+    use_compression: true
+  torrent_client:
+    client_id: "main"
+    buffer_size: 10
+    heartbeat_interval: 30
+  remote_server:
+    enabled: false
+    host: "localhost"
+    port: 8000
+    remote_url: null
+    auth_token: null
+    ssl_enabled: false
+    ssl_cert_file: "server.crt"
+    ssl_key_file: "server.key"
+    max_connections: 100
+    compression_level: 6
+    compression_enabled: true
 metrics_visualizer:
   fig_width: 10
   fig_height: 6

--- a/config_loader.py
+++ b/config_loader.py
@@ -128,8 +128,9 @@ def create_marble_from_config(
         }
     )
 
+    network_cfg = cfg.get("network", {})
     remote_client = None
-    remote_cfg = cfg.get("remote_client", {})
+    remote_cfg = network_cfg.get("remote_client", {})
     if isinstance(remote_cfg, dict) and remote_cfg.get("url"):
         remote_client = RemoteBrainClient(
             remote_cfg["url"],
@@ -139,7 +140,7 @@ def create_marble_from_config(
         )
 
     remote_server = None
-    server_cfg = cfg.get("remote_server", {})
+    server_cfg = network_cfg.get("remote_server", {})
     if isinstance(server_cfg, dict) and server_cfg.get("enabled", False):
         remote_server = RemoteBrainServer(
             host=server_cfg.get("host", "localhost"),
@@ -150,7 +151,7 @@ def create_marble_from_config(
         remote_server.start()
 
     torrent_client = None
-    torrent_cfg = cfg.get("torrent_client", {})
+    torrent_cfg = network_cfg.get("torrent_client", {})
     if isinstance(torrent_cfg, dict) and torrent_cfg.get("client_id"):
         tracker = BrainTorrentTracker()
         torrent_client = BrainTorrentClient(

--- a/config_schema.py
+++ b/config_schema.py
@@ -64,10 +64,17 @@ CONFIG_SCHEMA = {
             "type": ["array", "string"],
             "items": {"type": "string"},
         },
-        "remote_server": {
+        "network": {
             "type": "object",
             "properties": {
-                "auth_token": {"type": ["string", "null"]},
+                "remote_server": {
+                    "type": "object",
+                    "properties": {
+                        "auth_token": {"type": ["string", "null"]},
+                    },
+                },
+                "remote_client": {"type": "object"},
+                "torrent_client": {"type": "object"},
             },
         },
         "autograd": {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,11 +37,11 @@ def test_load_config_defaults():
     assert cfg["brain"]["save_threshold"] == 0.05
     assert cfg["meta_controller"]["history_length"] == 5
     assert cfg["neuromodulatory_system"]["initial"]["emotion"] == "neutral"
-    assert cfg["remote_client"]["url"] == "http://localhost:8001"
-    assert cfg["remote_client"]["timeout"] == 5.0
-    assert cfg["remote_client"]["max_retries"] == 3
-    assert cfg["torrent_client"]["client_id"] == "main"
-    assert cfg["torrent_client"]["buffer_size"] == 10
+    assert cfg["network"]["remote_client"]["url"] == "http://localhost:8001"
+    assert cfg["network"]["remote_client"]["timeout"] == 5.0
+    assert cfg["network"]["remote_client"]["max_retries"] == 3
+    assert cfg["network"]["torrent_client"]["client_id"] == "main"
+    assert cfg["network"]["torrent_client"]["buffer_size"] == 10
     assert cfg["brain"]["initial_neurogenesis_factor"] == 1.0
     assert cfg["brain"]["offload_enabled"] is False
     assert cfg["brain"]["torrent_offload_enabled"] is False
@@ -95,7 +95,7 @@ def test_load_config_defaults():
     assert cfg["brain"]["dream_cycle_sleep"] == 0.1
     assert cfg["lobe_manager"]["attention_increase_factor"] == 1.05
     assert cfg["lobe_manager"]["attention_decrease_factor"] == 0.95
-    assert cfg["remote_server"]["enabled"] is False
+    assert cfg["network"]["remote_server"]["enabled"] is False
     assert cfg["metrics_visualizer"]["fig_width"] == 10
     assert cfg["metrics_visualizer"]["fig_height"] == 6
     assert cfg["metrics_visualizer"]["track_cpu_usage"] is False
@@ -161,7 +161,7 @@ def test_create_marble_from_config():
 def test_remote_server_start(tmp_path):
     cfg_path = tmp_path / "cfg.yaml"
     cfg = load_config()
-    cfg["remote_server"] = {
+    cfg.setdefault("network", {})["remote_server"] = {
         "enabled": True,
         "host": "localhost",
         "port": 8123,

--- a/tests/test_config_additional.py
+++ b/tests/test_config_additional.py
@@ -8,8 +8,8 @@ def test_extended_config_parameters():
     assert cfg["core"]["random_seed"] == 42
     assert cfg["neuronenblitz"]["plasticity_modulation"] == 1.0
     assert cfg["brain"]["model_name"] == "marble_default"
-    assert cfg["remote_client"]["auth_token"] is None
-    assert cfg["remote_server"]["ssl_enabled"] is False
-    assert cfg["remote_server"]["auth_token"] is None
+    assert cfg["network"]["remote_client"]["auth_token"] is None
+    assert cfg["network"]["remote_server"]["ssl_enabled"] is False
+    assert cfg["network"]["remote_server"]["auth_token"] is None
     assert cfg["metrics_visualizer"]["refresh_rate"] == 1
     assert cfg["brain"]["super_evolution_mode"] is False

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -655,34 +655,35 @@ hybrid_memory:
     stores. When the count exceeds this limit the oldest entries are removed
     to keep memory usage bounded.
 
-remote_client:
-  # Configuration for forwarding parts of the brain to a remote server. When
-  # ``offload_enabled`` is true the brain serializes a subcore and sends it to
-  # this endpoint for processing.
-  url: Base URL for the remote HTTP brain server.
-  timeout: Seconds to wait for remote requests before they are aborted. Values
-    between 5 and 30 are typical depending on network latency.
-  max_retries: Number of times a remote operation is retried upon failure.
-  track_latency: When true the client records the time taken for each
-    request so average latency can be inspected through the API.
-  auth_token: Optional token sent as an ``Authorization`` header on each
-    request.
-  ssl_verify: Whether HTTPS certificates should be verified. Set to ``false``
-    when using self-signed certificates.
-  connect_retry_interval: Seconds to wait between connection retry attempts.
-  heartbeat_timeout: Maximum time to wait for a heartbeat response when
-    maintaining persistent connections.
-  use_compression: If ``true`` payloads are compressed before transmission.
+network:
+  remote_client:
+    # Configuration for forwarding parts of the brain to a remote server. When
+    # ``offload_enabled`` is true the brain serializes a subcore and sends it to
+    # this endpoint for processing.
+    url: Base URL for the remote HTTP brain server.
+    timeout: Seconds to wait for remote requests before they are aborted. Values
+      between 5 and 30 are typical depending on network latency.
+    max_retries: Number of times a remote operation is retried upon failure.
+    track_latency: When true the client records the time taken for each
+      request so average latency can be inspected through the API.
+    auth_token: Optional token sent as an ``Authorization`` header on each
+      request.
+    ssl_verify: Whether HTTPS certificates should be verified. Set to ``false``
+      when using self-signed certificates.
+    connect_retry_interval: Seconds to wait between connection retry attempts.
+    heartbeat_timeout: Maximum time to wait for a heartbeat response when
+      maintaining persistent connections.
+    use_compression: If ``true`` payloads are compressed before transmission.
 
-torrent_client:
-  # Enables distribution of brain parts through the tracker network. Each client
-  # processes assigned subcores asynchronously.
-  client_id: Identifier used when registering with the torrent tracker. Must be
-    unique across participating clients.
-  buffer_size: Maximum number of asynchronous tasks queued for a torrent
-    client. Larger values allow more parallel requests but use more memory.
-  heartbeat_interval: Seconds between status pings sent to the tracker. Has no
-    effect in the current simplified implementation but reserved for future use.
+  torrent_client:
+    # Enables distribution of brain parts through the tracker network. Each client
+    # processes assigned subcores asynchronously.
+    client_id: Identifier used when registering with the torrent tracker. Must be
+      unique across participating clients.
+    buffer_size: Maximum number of asynchronous tasks queued for a torrent
+      client. Larger values allow more parallel requests but use more memory.
+    heartbeat_interval: Seconds between status pings sent to the tracker. Has no
+      effect in the current simplified implementation but reserved for future use.
 
 data_compressor:
   # Controls how strongly the DataCompressor reduces data size before it is
@@ -720,30 +721,30 @@ experiment_tracker:
   entity: Optional account or team under which the run is recorded.
   run_name: Custom name assigned to the run. If ``null`` Wandb generates one.
 
-remote_server:
-  # Launches an optional local ``RemoteBrainServer`` so this MARBLE instance can
-  # forward computation to another machine. When ``enabled`` is ``true`` the
-  # server starts automatically using the provided ``host`` and ``port``. If
-  # ``remote_url`` is specified the server itself forwards heavy requests to that
-  # address, creating a chain of offload targets.
-  enabled: Whether to start the server alongside the main process.
-  host: Interface address to bind the HTTP server to. Usually ``"localhost"``
-    for local testing.
-  port: TCP port used by the server.
-  remote_url: Optional URL of another remote brain server to which this server
-    offloads work.
-  auth_token: Optional shared secret required in the ``Authorization`` header of
-    every request. When set, clients must supply ``"Bearer <token>"`` and the
-    server compares it using constant-time logic to avoid timing attacks.
-  ssl_enabled: Enables HTTPS with the provided certificate and key files.
-  ssl_cert_file: Path to the SSL certificate used when ``ssl_enabled`` is true.
-  ssl_key_file: Path to the private key for the certificate.
-  max_connections: Maximum concurrent connections the server will accept.
-  compression_level: Compression strength used when exchanging data with
-    clients. The value is passed to ``zlib.compress`` and ranges from 0
-    (no compression) to 9 (maximum compression).
-  compression_enabled: Set to ``false`` to disable compression entirely. When
-    disabled the server expects plain JSON payloads.
+  remote_server:
+    # Launches an optional local ``RemoteBrainServer`` so this MARBLE instance can
+    # forward computation to another machine. When ``enabled`` is ``true`` the
+    # server starts automatically using the provided ``host`` and ``port``. If
+    # ``remote_url`` is specified the server itself forwards heavy requests to that
+    # address, creating a chain of offload targets.
+    enabled: Whether to start the server alongside the main process.
+    host: Interface address to bind the HTTP server to. Usually ``"localhost"``
+      for local testing.
+    port: TCP port used by the server.
+    remote_url: Optional URL of another remote brain server to which this server
+      offloads work.
+    auth_token: Optional shared secret required in the ``Authorization`` header of
+      every request. When set, clients must supply ``"Bearer <token>"`` and the
+      server compares it using constant-time logic to avoid timing attacks.
+    ssl_enabled: Enables HTTPS with the provided certificate and key files.
+    ssl_cert_file: Path to the SSL certificate used when ``ssl_enabled`` is true.
+    ssl_key_file: Path to the private key for the certificate.
+    max_connections: Maximum concurrent connections the server will accept.
+    compression_level: Compression strength used when exchanging data with
+      clients. The value is passed to ``zlib.compress`` and ranges from 0
+      (no compression) to 9 (maximum compression).
+    compression_enabled: Set to ``false`` to disable compression entirely. When
+      disabled the server expects plain JSON payloads.
 
 metrics_visualizer:
   # Configure the live metrics plot size. These values are passed directly to


### PR DESCRIPTION
## Summary
- group remote_client, remote_server and torrent_client under a new `network` section in config
- reflect the new `network` structure in schema and loader
- update YAML manual and configurable parameters docs
- fix unit tests for new config layout

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_config.py::test_load_config_defaults tests/test_config_additional.py::test_extended_config_parameters -q`

------
https://chatgpt.com/codex/tasks/task_e_68874b9eb8d88327b6e9455d25d71455