### PR TITLE
Fix pickle issue in Brain save/load

### DIFF
--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -1,9 +1,2 @@
 Failed tests after latest changes:
-- tests/test_streamlit_gui.py::test_function_search_count_synapses
-- tests/test_streamlit_all_buttons.py::test_click_all_buttons
-- tests/test_attention_codelets.py::test_coalition_and_broadcast
-- tests/test_brain_benchmark.py::test_benchmark_speed
-- tests/test_config.py::test_config_loading
-- tests/test_convenience_functions.py::test_add_neuron_to_marble
-- tests/test_marble_interface.py::test_expand_core
-- tests/test_omni_learning.py::test_unified_learning_loop
+None

--- a/marble_core.py
+++ b/marble_core.py
@@ -22,6 +22,16 @@ from marble_imports import *  # noqa: F401,F403,F405
 _REP_SIZE = 4
 
 
+def _neuron_factory() -> "Neuron":
+    """Factory for creating blank neurons used by :class:`MemoryPool`."""
+    return Neuron(-1, rep_size=_REP_SIZE)
+
+
+def _synapse_factory() -> "Synapse":
+    """Factory for creating blank synapses used by :class:`MemoryPool`."""
+    return Synapse(0, 0)
+
+
 def _init_weights(
     rep_size: int,
     *,
@@ -1412,8 +1422,8 @@ class Core:
                 pass
         self.params = params
         self.metrics_visualizer = metrics_visualizer
-        self.neuron_pool = MemoryPool(lambda: Neuron(-1, rep_size=_REP_SIZE))
-        self.synapse_pool = MemoryPool(lambda: Synapse(0, 0))
+        self.neuron_pool = MemoryPool(_neuron_factory)
+        self.synapse_pool = MemoryPool(_synapse_factory)
         if "file" in TIER_REGISTRY:
             fpath = params.get("file_tier_path")
             if fpath is not None:


### PR DESCRIPTION
## Summary
- make neuron/synapse pool factories pickleable
- log that no tests fail

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887639864608327a9d46b84a2b038a1