### PR TITLE
Address documentation TODOs

### DIFF
--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -1,0 +1,24 @@
+name: Publish to TestPyPI
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Build
+        run: |
+          pip install build
+          python -m build
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@v1.8.11
+        with:
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ to automatically format and lint changes before each commit.
 \nMARBLE can be extended via a simple plugin system. Specify directories in the `plugins` list of the configuration and each module's `register` function will be invoked to add custom neuron or synapse types.
 Neuronenblitz exposes a runtime plugin API. After creating a `Neuronenblitz` instance you may activate modules via `n_plugin.activate("my_plugin")`. The plugin\x27s `activate(nb)` function receives the instance and can freely read or modify any attributes or methods.
 The repository now also provides a `global_workspace` plugin which broadcasts small messages to all registered listeners. Enable it by adding a `global_workspace` section to `config.yaml` and activating the plugin with `n_plugin.activate("global_workspace")`.
+An additional `attention_codelets` plugin can broadcast the output of custom
+codelets through the workspace. Register your own codelets via
+`attention_codelets.register_codelet` and invoke
+`attention_codelets.run_cycle()` during training.
 
 ## Release Process
 To publish a new release to PyPI:

--- a/TODO.md
+++ b/TODO.md
@@ -16,13 +16,13 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [x] Add tests verifying GPU and CPU parity.
 6. [x] Provide a command line interface for common training tasks.
 7. Refactor `marble_neuronenblitz.py` into logical submodules.
-   - [ ] Identify separate functionalities (learning algorithms, memory, etc.).
-   - [ ] Split file into modules under new package `marble_neuronenblitz/`.
-   - [ ] Update imports across the project.
-   - [ ] Add tests ensuring modules operate as before.
+   - [x] Identify separate functionalities (learning algorithms, memory, etc.).
+   - [x] Split file into modules under new package `marble_neuronenblitz/`.
+   - [x] Update imports across the project.
+   - [x] Add tests ensuring modules operate as before.
 8. Document all public APIs with docstrings and examples.
-   - [ ] Audit modules to list all public functions and classes.
-   - [ ] Add comprehensive docstrings using Google style.
+   - [x] Audit modules to list all public functions and classes.
+   - [x] Add comprehensive docstrings using Google style.
    - [x] Provide minimal working examples in docs directory.
    - [x] Generate API reference via Sphinx.
 9. [x] Create tutorials that walk through real-world datasets.
@@ -133,7 +133,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 74. [x] Implement offline mode with pre-packaged datasets.
 75. Add automated packaging to publish releases on PyPI.
    - [x] Create setup.py and pyproject.toml for packaging.
-   - [ ] Setup CI workflow for building and uploading to TestPyPI.
+   - [x] Setup CI workflow for building and uploading to TestPyPI.
    - [x] Add versioning scheme.
    - [x] Document release process.
 76. [x] Improve data compression for network transfers.
@@ -237,8 +237,8 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 113. [x] Add YAML configuration options for all new plugins and document them thoroughly.
 114. [x] Create unit and integration tests ensuring each plugin works on CPU and GPU.
 115. Update tutorials and manuals with instructions on using the consciousness plugins.
-   - [ ] Write step-by-step tutorial for each new plugin.
-   - [ ] Update yaml-manual with plugin parameters.
-   - [ ] Add troubleshooting section.
-   - [ ] Provide example configuration files.
+   - [x] Write step-by-step tutorial for each new plugin.
+   - [x] Update yaml-manual with plugin parameters.
+   - [x] Add troubleshooting section.
+   - [x] Provide example configuration files.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -24,3 +24,7 @@ For further help open an issue on the project repository with your configuration
 
 ## Python 3.8/3.9 Support
 MARBLE uses modern type hint syntax. Run `scripts/convert_to_py38.py` on the source tree when using Python 3.8 or 3.9. Some optional features may be unavailable.
+
+## Plugin Troubleshooting
+* **Global workspace messages not appearing** – Ensure `global_workspace.enabled` is `true` in your configuration and that the plugin is activated before other plugins.
+* **Attention codelets have no effect** – Verify that `attention_codelets.enabled` is `true` and that at least one codelet has been registered. Call `attention_codelets.run_cycle()` during training to broadcast proposals.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1530,6 +1530,35 @@ The new *Global Workspace* plugin is loaded in the same way. Add
 `n_plugin.activate("global_workspace")` to share broadcast messages between
 plugins and components.
 
+### Using Attention Codelets
+
+1. Define a codelet that returns an ``AttentionProposal``:
+   ```python
+   from attention_codelets import AttentionProposal, register_codelet
+
+   def my_codelet():
+       # score can be any float; higher values are more salient
+       return AttentionProposal(score=1.0, content="Hello World")
+
+   register_codelet(my_codelet)
+   ```
+2. Enable the plugin in ``config.yaml``:
+   ```yaml
+   attention_codelets:
+     enabled: true
+     coalition_size: 1
+   ```
+3. Activate both plugins before training:
+   ```python
+   import global_workspace
+   import attention_codelets
+
+   gw = global_workspace.activate(marble.brain, capacity=10)
+   attention_codelets.activate(coalition_size=1)
+   ```
+4. Call ``attention_codelets.run_cycle()`` periodically to broadcast proposals
+   through the workspace. Subscribers can listen via ``gw.subscribe``.
+
 
 ## Organising Multiple Experiments
 

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -9,5 +9,10 @@ This document lists the main classes and functions intended for external use.
 - `marble_neuronenblitz.learning.rl_select_action`
 - `marble_neuronenblitz.learning.rl_update`
 - `marble_neuronenblitz.memory.decay_memory_gates`
+- `global_workspace.activate`
+- `global_workspace.GlobalWorkspace.publish`
+- `global_workspace.GlobalWorkspace.subscribe`
+- `attention_codelets.register_codelet`
+- `attention_codelets.run_cycle`
 
 These APIs are kept stable across minor versions. Internal helpers not listed here may change without notice.

--- a/examples/configs/consciousness_plugins.yaml
+++ b/examples/configs/consciousness_plugins.yaml
@@ -1,0 +1,11 @@
+# Example config for consciousness plugins
+plugins:
+  - ./plugins
+
+global_workspace:
+  enabled: true
+  capacity: 20
+
+attention_codelets:
+  enabled: true
+  coalition_size: 2

--- a/global_workspace.py
+++ b/global_workspace.py
@@ -1,3 +1,5 @@
+"""Global Workspace plugin used by consciousness modules."""
+
 from __future__ import annotations
 
 from collections import deque
@@ -23,14 +25,23 @@ class GlobalWorkspace:
         self.subscribers: List[Callable[[BroadcastMessage], None]] = []
 
     def publish(self, source: str, content: Any) -> None:
-        """Add a message and notify all subscribers."""
+        """Add a message and notify all subscribers.
+
+        Args:
+            source: Identifier of the sender.
+            content: Arbitrary payload to deliver.
+        """
         msg = BroadcastMessage(source, content)
         self.queue.append(msg)
         for cb in list(self.subscribers):
             cb(msg)
 
     def subscribe(self, callback: Callable[[BroadcastMessage], None]) -> None:
-        """Register ``callback`` to receive future messages."""
+        """Register ``callback`` to receive future messages.
+
+        Args:
+            callback: Function invoked with each :class:`BroadcastMessage`.
+        """
         self.subscribers.append(callback)
 
 
@@ -39,7 +50,16 @@ workspace: GlobalWorkspace | None = None
 
 
 def activate(nb: object | None = None, capacity: int = 100) -> GlobalWorkspace:
-    """Initialise the global workspace and attach to ``nb`` if given."""
+    """Initialise the global workspace and optionally attach it to ``nb``.
+
+    Args:
+        nb: Object to attach the workspace to. If ``None`` the workspace is
+            created but not assigned.
+        capacity: Maximum number of messages stored.
+
+    Returns:
+        The shared :class:`GlobalWorkspace` instance.
+    """
     global workspace
     if workspace is None or workspace.queue.maxlen != capacity:
         workspace = GlobalWorkspace(capacity)
@@ -49,5 +69,9 @@ def activate(nb: object | None = None, capacity: int = 100) -> GlobalWorkspace:
 
 
 def register(*_: Callable[[str], None]) -> None:
-    """No neuron or synapse types are registered by this plugin."""
+    """Required plugin entry point.
+
+    The global workspace does not register custom neuron or synapse types,
+    but this function is provided for consistency with the plugin interface.
+    """
     return

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -814,6 +814,8 @@ global_workspace:
   capacity: Maximum number of messages kept in the queue. When the queue
     exceeds this length older entries are discarded. Typical values range from
     ``10`` to ``100`` depending on how much history you wish to retain.
+  # The workspace is automatically attached to a ``Neuronenblitz`` instance
+  # when :func:`global_workspace.activate` is called with ``nb``.
 attention_codelets:
   # Attention codelets are lightweight plugins that each propose a piece of
   # information along with a salience ``score``. During every cycle the
@@ -827,6 +829,9 @@ attention_codelets:
     ``5`` depending on how much information you want to expose at once.
   # See ``examples/configs/attention_codelets.yaml`` for a minimal
   # configuration demonstrating these settings.
+  # To create your own codelet define a callable that returns an
+  # :class:`AttentionProposal` and register it with
+  # :func:`attention_codelets.register_codelet`.
 pytorch_challenge:
   enabled: If true the training loop compares MARBLE with a pretrained PyTorch model after every training example. When MARBLE's validation loss, inference speed or model size exceed the PyTorch model, neuromodulatory stress is increased which lowers plasticity on subsequent updates.
   loss_penalty: Amount of stress added when MARBLE's loss is worse than the PyTorch baseline. Values around 0.1 provide noticeable pressure without overwhelming the system.


### PR DESCRIPTION
## Summary
- check off completed TODOs for docs and packaging
- add plugin docs in README and tutorial
- provide TestPyPI workflow
- extend YAML manual
- add example plugin configuration
- update troubleshooting tips
- add Google style docstrings and update public API docs

## Testing
- `pre-commit run --files README.md TODO.md TROUBLESHOOTING.md TUTORIAL.md attention_codelets.py docs/public_api.md global_workspace.py yaml-manual.txt .github/workflows/testpypi.yml examples/configs/consciousness_plugins.yaml`
- `pre-commit run --files attention_codelets.py`
- `pytest -q` *(fails: test_streamlit_all_buttons.py::test_click_all_buttons, test_streamlit_gui.py::test_function_search_count_synapses)*

------
https://chatgpt.com/codex/tasks/task_e_688778f65a6c83279cc6334100638119