### PR TITLE
Implement adversarial dataset wrapper

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -109,7 +109,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 62. Add more comprehensive adversarial training examples.
    - [ ] Implement adversarial example generators.
    - [ ] Add training loops demonstrating adversarial robustness.
-   - [ ] Provide dataset wrappers for adversarial data.
+   - [x] Provide dataset wrappers for adversarial data.
    - [ ] Document new examples in TUTORIAL.
 63. [x] Provide utilities for automatic dataset downloading and caching.
 64. [x] Integrate a simple hyperparameter search framework.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -502,10 +502,16 @@ Execute this file to observe Hebbian updates on your data.
    ```python
    from datasets import load_dataset
    ds = load_dataset('mnist', split='train')
-   real_values = [x['image'].reshape(-1).numpy() / 255.0 for x in ds]
    ```
-4. **Construct an `AdversarialLearner`** and call `learner.train(real_values)` to alternate generator and discriminator updates.
-5. **Sample new data** after training by passing random noise vectors to the generator's `dynamic_wander` method.
+4. **Wrap the dataset** with `FGSMDataset` to generate adversarial variants on the fly:
+   ```python
+   from adversarial_dataset import FGSMDataset
+   model = ToyModel()
+   adv_ds = FGSMDataset(ds, model, epsilon=0.05)
+   real_values = [x[0] for x in adv_ds]
+   ```
+5. **Construct an `AdversarialLearner`** and call `learner.train(real_values)` to alternate generator and discriminator updates.
+6. **Sample new data** after training by passing random noise vectors to the generator's `dynamic_wander` method.
 
 **Complete Example**
 ```python

--- a/adversarial_dataset.py
+++ b/adversarial_dataset.py
@@ -1,0 +1,66 @@
+"""Dataset wrappers for generating adversarial examples on the fly."""
+
+from __future__ import annotations
+
+import torch
+from torch.utils.data import Dataset
+
+
+class FGSMDataset(Dataset):
+    """Wrap another dataset to generate FGSM adversarial samples.
+
+    Parameters
+    ----------
+    dataset:
+        The underlying dataset providing ``(input, target)`` pairs.
+    model:
+        A PyTorch model used to compute input gradients.
+    epsilon:
+        Magnitude of the adversarial perturbation.
+    device:
+        Device to run computations on. Defaults to CUDA when available.
+    loss_fn:
+        Loss function to use for computing gradients. Defaults to
+        ``torch.nn.MSELoss``.
+    """
+
+    def __init__(
+        self,
+        dataset: Dataset,
+        model: torch.nn.Module,
+        *,
+        epsilon: float = 0.01,
+        device: str | torch.device | None = None,
+        loss_fn: torch.nn.Module | None = None,
+    ) -> None:
+        self.dataset = dataset
+        self.model = model
+        self.epsilon = float(epsilon)
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.loss_fn = loss_fn or torch.nn.MSELoss()
+        self.model.to(self.device)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.dataset)
+
+    def _to_tensor(self, value: torch.Tensor | float | int | list | tuple) -> torch.Tensor:
+        t = torch.as_tensor(value, dtype=torch.float32, device=self.device)
+        if t.ndim == 0:
+            t = t.unsqueeze(0)
+        return t
+
+    def __getitem__(self, idx: int):
+        x, y = self.dataset[idx]
+        x_t = self._to_tensor(x).clone().detach().requires_grad_(True)
+        y_t = self._to_tensor(y)
+
+        output = self.model(x_t.unsqueeze(0))
+        loss = self.loss_fn(output.squeeze(), y_t.squeeze())
+        loss.backward()
+        grad = x_t.grad.detach()
+        adv_x = (x_t + self.epsilon * grad.sign()).detach()
+
+        x_out = adv_x.squeeze().cpu().numpy()
+        if x_out.shape == ():
+            x_out = float(x_out)
+        return x_out, y

--- a/tests/test_adversarial_dataset.py
+++ b/tests/test_adversarial_dataset.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import torch
+from torch.utils.data import Dataset
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from adversarial_dataset import FGSMDataset
+
+
+class ToyDataset(Dataset):
+    def __init__(self):
+        self.data = [(0.1, 0.2), (0.2, 0.4)]
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        return self.data[idx]
+
+
+class ToyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(1, 1)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+def test_fgsm_dataset_produces_different_inputs():
+    dataset = ToyDataset()
+    model = ToyModel()
+    wrapped = FGSMDataset(dataset, model, epsilon=0.5)
+    x0, y0 = dataset[0]
+    adv_x0, adv_y0 = wrapped[0]
+    assert adv_y0 == y0
+    assert adv_x0 != x0


### PR DESCRIPTION
## Summary
- implement FGSMDataset for generating adversarial examples
- test FGSM adversarial dataset wrapper
- mention new wrapper in tutorial
- check off TODO item for dataset wrappers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68877ee715808327a7c1998a771ca1b4