### PR TITLE
Add constant-time XOR and update TODO

### DIFF
--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -30,6 +30,25 @@ Full test suite run resulted in failures before adjustments:
 - tests/test_config.py::test_new_nb_parameters_configurable
 - tests/test_config.py::test_global_workspace_config
 - tests/test_episodic_simulation.py::test_simulate_returns_rewards
+- tests/test_streamlit_gui.py::test_basic_text_inference
+- tests/test_streamlit_gui.py::test_save_config_file
+- tests/test_streamlit_gui.py::test_duplicate_instance
+- tests/test_streamlit_gui.py::test_pipeline_reorder_and_remove
+- tests/test_streamlit_gui.py::test_auto_firing_start_stop
+- tests/test_streamlit_gui.py::test_save_marble
+- tests/test_streamlit_gui.py::test_attach_remote_client
+- tests/test_streamlit_gui.py::test_stats_refresh
+- tests/test_streamlit_gui.py::test_misc_gui_buttons
+- tests/test_streamlit_gui.py::test_start_background_training
+- tests/test_streamlit_gui.py::test_model_search_and_preview
+- tests/test_streamlit_gui.py::test_adaptive_control_extra
+- tests/test_streamlit_gui.py::test_hybrid_memory_forget
+- tests/test_streamlit_gui.py::test_instance_switch_and_delete
+- tests/test_streamlit_gui.py::test_autoencoder_tab_training
+- tests/test_streamlit_playground.py::test_example_project_helpers
+- tests/test_streamlit_playground.py::test_save_config_yaml_and_search
+- tests/test_streamlit_playground.py::test_find_repository_functions
+- tests/test_wandering_anomaly.py::test_detect_wandering_anomaly
 - tests/test_predictive_coding_plugin.py::test_predictive_coding_step (fixed)
 
 Latest test run:

--- a/TODO.md
+++ b/TODO.md
@@ -101,7 +101,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [x] Implement config sync service.
    - [x] Add CLI command to trigger manual sync.
    - [x] Write tests simulating multi-node environment.
-61. Enhance constant-time operations for cryptographic safety.
+61. [x] Enhance constant-time operations for cryptographic safety.
    - [x] Profile existing cryptographic operations.
    - [x] Replace variable-time functions with constant-time equivalents.
    - [x] Add unit tests verifying timing does not leak secrets.
@@ -114,7 +114,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 63. [x] Provide utilities for automatic dataset downloading and caching.
 64. [x] Integrate a simple hyperparameter search framework.
 65. [x] Add tests verifying deterministic behaviour with fixed seeds.
-66. Improve readability of configuration files with comments and sections.
+66. [x] Improve readability of configuration files with comments and sections.
    - [x] Group related config parameters into sections.
    - [x] Add descriptive comments for each parameter.
    - [x] Provide script to auto-generate sample config with comments.

--- a/crypto_utils.py
+++ b/crypto_utils.py
@@ -9,3 +9,16 @@ def constant_time_compare(val1: Union[str, bytes], val2: Union[str, bytes]) -> b
     if isinstance(val2, str):
         val2 = val2.encode()
     return hmac.compare_digest(val1, val2)
+
+
+def constant_time_xor(data1: Union[bytes, bytearray], data2: Union[bytes, bytearray]) -> bytes:
+    """Return the XOR of two byte sequences using a constant-time loop."""
+    if not isinstance(data1, (bytes, bytearray)) or not isinstance(data2, (bytes, bytearray)):
+        raise TypeError("Inputs must be bytes or bytearray")
+    if len(data1) != len(data2):
+        raise ValueError("Inputs must have the same length")
+
+    result = bytearray(len(data1))
+    for i in range(len(data1)):
+        result[i] = data1[i] ^ data2[i]
+    return bytes(result)

--- a/tests/test_crypto_utils.py
+++ b/tests/test_crypto_utils.py
@@ -1,5 +1,5 @@
 import time
-from crypto_utils import constant_time_compare
+from crypto_utils import constant_time_compare, constant_time_xor
 
 
 def test_constant_time_compare_equal():
@@ -26,3 +26,22 @@ from crypto_profile import profile_compare
 def test_profile_compare():
     diff = profile_compare(trials=1000)
     assert diff < 1000  # ns
+
+
+def test_constant_time_xor():
+    a = bytes([0x0F, 0xAA, 0x55])
+    b = bytes([0xF0, 0x55, 0xAA])
+    result = constant_time_xor(a, b)
+    assert result == bytes([0xFF, 0xFF, 0xFF])
+
+
+def test_constant_time_xor_timing():
+    a = b"a" * 32
+    b = b"b" * 32
+    start = time.perf_counter_ns()
+    constant_time_xor(a, b)
+    xor_time1 = time.perf_counter_ns() - start
+    start = time.perf_counter_ns()
+    constant_time_xor(a, a)
+    xor_time2 = time.perf_counter_ns() - start
+    assert abs(xor_time1 - xor_time2) < 5_000_000  # 5 ms


### PR DESCRIPTION
## Summary
- implement `constant_time_xor` for cryptographic utilities
- expand crypto tests with XOR timing checks
- record new failing tests
- mark TODO items 61 and 66 as complete

## Testing
- `pytest -q tests/test_crypto_utils.py`
- `pytest -q` *(fails: 66 failed, 449 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6887b07b9a34832793f7ce4714c95ec5