### PR TITLE
Enhance playground dataset loading

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -133,3 +133,4 @@ widgetsnbextension==4.0.14
 xxhash==3.5.0
 yarl==1.20.1
 zipp==3.23.0
+openpyxl==3.1.2

--- a/streamlit_playground.py
+++ b/streamlit_playground.py
@@ -143,6 +143,9 @@ def load_examples(file) -> list[tuple]:
     if ext == ".csv" or not ext:
         df = pd.read_csv(file)
         return _pairs_from_df(df)
+    if ext in {".xlsx", ".xls"}:
+        df = pd.read_excel(file)
+        return _pairs_from_df(df)
     if ext == ".json" or ext == ".jsonl":
         js = json.load(file)
         df = pd.DataFrame(js)
@@ -152,6 +155,13 @@ def load_examples(file) -> list[tuple]:
             if "dataset.csv" in zf.namelist():
                 with zf.open("dataset.csv") as f:
                     df = pd.read_csv(f)
+                return _pairs_from_df(df, zf)
+            if "dataset.xlsx" in zf.namelist() or "dataset.xls" in zf.namelist():
+                fname = (
+                    "dataset.xlsx" if "dataset.xlsx" in zf.namelist() else "dataset.xls"
+                )
+                with zf.open(fname) as f:
+                    df = pd.read_excel(f)
                 return _pairs_from_df(df, zf)
             if "dataset.json" in zf.namelist():
                 with zf.open("dataset.json") as f:
@@ -175,6 +185,10 @@ def load_value_list(file) -> list[float]:
         df = pd.read_csv(file)
         col = "value" if "value" in df.columns else df.columns[0]
         return df[col].astype(float).tolist()
+    if ext in {".xlsx", ".xls"}:
+        df = pd.read_excel(file)
+        col = "value" if "value" in df.columns else df.columns[0]
+        return df[col].astype(float).tolist()
     if ext in {".json", ".jsonl"}:
         js = json.load(file)
         if isinstance(js, list):
@@ -190,6 +204,14 @@ def load_value_list(file) -> list[float]:
             if "values.csv" in zf.namelist():
                 with zf.open("values.csv") as f:
                     df = pd.read_csv(f)
+                col = "value" if "value" in df.columns else df.columns[0]
+                return df[col].astype(float).tolist()
+            if "values.xlsx" in zf.namelist() or "values.xls" in zf.namelist():
+                fname = (
+                    "values.xlsx" if "values.xlsx" in zf.namelist() else "values.xls"
+                )
+                with zf.open(fname) as f:
+                    df = pd.read_excel(f)
                 col = "value" if "value" in df.columns else df.columns[0]
                 return df[col].astype(float).tolist()
             if "values.json" in zf.namelist():


### PR DESCRIPTION
## Summary
- support Excel datasets in `streamlit_playground`
- handle Excel data inside zip archives
- update requirements with `openpyxl`
- add unit tests for Excel loading

## Testing
- `ruff check tests/test_streamlit_playground.py streamlit_playground.py`
- `black tests/test_streamlit_playground.py streamlit_playground.py`
- `pytest tests/test_streamlit_playground.py::test_load_examples_excel tests/test_streamlit_playground.py::test_load_value_list_excel tests/test_streamlit_playground.py::test_load_examples_csv_and_json tests/test_streamlit_playground.py::test_load_examples_zip tests/test_streamlit_gui.py tests/test_streamlit_all_buttons.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d575665c8327b7325567da667290