### PR TITLE
Add PyTorch model converter

### DIFF
--- a/converttodo.md
+++ b/converttodo.md
@@ -1,0 +1,11 @@
+# PyTorch to MARBLE Converter TODO
+
+1. Implement converter registry and decorator.
+2. Create graph builder helpers for neurons and synapses.
+   - Fully connected layers
+   - Activation handling
+3. Add default converters for Linear and ReLU layers.
+4. Build convert_model using torch.fx symbolic tracing.
+5. Raise explicit errors for unsupported layers.
+6. Provide CLI script `convert_model.py`.
+7. Write unit tests covering simple model conversion.

--- a/pytorch_to_marble.py
+++ b/pytorch_to_marble.py
@@ -1,0 +1,144 @@
+import argparse
+from typing import Callable, Dict, List, Type
+
+import torch
+from torch.fx import symbolic_trace
+
+from marble_core import Core, Neuron, Synapse
+from marble_utils import core_to_json
+
+
+class UnsupportedLayerError(Exception):
+    """Raised when a layer type is not supported for conversion."""
+
+
+LayerConverter = Callable[[torch.nn.Module, Core, List[int]], List[int]]
+
+
+LAYER_CONVERTERS: Dict[Type[torch.nn.Module], LayerConverter] = {}
+
+
+def register_converter(
+    layer_type: Type[torch.nn.Module],
+) -> Callable[[LayerConverter], LayerConverter]:
+    """Decorator to register a layer conversion function."""
+
+    def decorator(func: LayerConverter) -> LayerConverter:
+        LAYER_CONVERTERS[layer_type] = func
+        return func
+
+    return decorator
+
+
+def _add_fully_connected_layer(
+    core: Core, input_ids: List[int], layer: torch.nn.Linear
+) -> List[int]:
+    out_ids = []
+    for _ in range(layer.out_features):
+        nid = len(core.neurons)
+        core.neurons.append(Neuron(nid, value=0.0, tier="vram"))
+        out_ids.append(nid)
+    weight = layer.weight.detach().cpu().numpy()
+    for j, out_id in enumerate(out_ids):
+        for i, in_id in enumerate(input_ids):
+            w = float(weight[j, i])
+            syn = Synapse(in_id, out_id, weight=w)
+            core.neurons[in_id].synapses.append(syn)
+            core.synapses.append(syn)
+    if layer.bias is not None:
+        bias_id = len(core.neurons)
+        core.neurons.append(Neuron(bias_id, value=1.0, tier="vram"))
+        bias = layer.bias.detach().cpu().numpy()
+        for j, out_id in enumerate(out_ids):
+            syn = Synapse(bias_id, out_id, weight=float(bias[j]))
+            core.neurons[bias_id].synapses.append(syn)
+            core.synapses.append(syn)
+    return out_ids
+
+
+@register_converter(torch.nn.Linear)
+def _convert_linear(layer: torch.nn.Linear, core: Core, inputs: List[int]) -> List[int]:
+    return _add_fully_connected_layer(core, inputs, layer)
+
+
+@register_converter(torch.nn.ReLU)
+def _convert_relu(layer: torch.nn.ReLU, core: Core, inputs: List[int]) -> List[int]:
+    for nid in inputs:
+        core.neurons[nid].params["activation"] = "relu"
+    return inputs
+
+
+def _get_converter(layer: torch.nn.Module) -> LayerConverter:
+    for cls in LAYER_CONVERTERS:
+        if isinstance(layer, cls):
+            return LAYER_CONVERTERS[cls]
+    raise UnsupportedLayerError(
+        f"{layer.__class__.__name__} is not supported for conversion"
+    )
+
+
+def convert_model(
+    model: torch.nn.Module, core_params: Dict | None = None, dry_run: bool = False
+) -> Core:
+    """Convert ``model`` into a MARBLE ``Core``."""
+    if core_params is None:
+        core_params = {
+            "xmin": -2.0,
+            "xmax": 1.0,
+            "ymin": -1.5,
+            "ymax": 1.5,
+            "width": 1,
+            "height": 1,
+            "max_iter": 1,
+            "vram_limit_mb": 0.1,
+            "ram_limit_mb": 0.1,
+            "disk_limit_mb": 0.1,
+        }
+    traced = symbolic_trace(model)
+    core = Core(core_params, formula="0", formula_num_neurons=0)
+    node_outputs: Dict[str, List[int]] = {}
+    for node in traced.graph.nodes:
+        if node.op == "placeholder":
+            input_tensor = node.meta.get("tensor_meta")
+            if input_tensor is not None:
+                in_dim = input_tensor.shape[1]
+            else:
+                in_dim = model.input_size if hasattr(model, "input_size") else 1
+            ids = []
+            for _ in range(in_dim):
+                nid = len(core.neurons)
+                core.neurons.append(Neuron(nid, value=0.0, tier="vram"))
+                ids.append(nid)
+            node_outputs[node.name] = ids
+        elif node.op == "call_module":
+            layer = dict(model.named_modules())[node.target]
+            converter = _get_converter(layer)
+            inp = node_outputs[node.args[0].name]
+            out = converter(layer, core, inp)
+            node_outputs[node.name] = out
+        elif node.op == "output":
+            pass
+        else:
+            raise UnsupportedLayerError(
+                f"Operation {node.op} is not supported for conversion"
+            )
+    if dry_run:
+        return core
+    return core
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert PyTorch model to MARBLE JSON")
+    parser.add_argument("--pytorch", required=True, help="Path to PyTorch model")
+    parser.add_argument("--output", required=True, help="Output JSON path")
+    args = parser.parse_args()
+
+    model = torch.load(args.pytorch, map_location="cpu")
+    core = convert_model(model)
+    js = core_to_json(core)
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write(js)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pytorch_to_marble.py
+++ b/tests/test_pytorch_to_marble.py
@@ -1,0 +1,51 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import torch
+import pytest
+
+from pytorch_to_marble import convert_model, UnsupportedLayerError
+from marble_core import Core
+from tests.test_core_functions import minimal_params
+
+
+class SimpleModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.seq = torch.nn.Sequential(
+            torch.nn.Linear(4, 3),
+            torch.nn.ReLU(),
+            torch.nn.Linear(3, 2),
+        )
+        self.input_size = 4
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.seq(x)
+
+
+def test_basic_conversion():
+    model = SimpleModel()
+    params = minimal_params()
+    core = convert_model(model, core_params=params)
+    assert isinstance(core, Core)
+    # expect number of neurons equals input+hidden+output+biases
+    expected_neurons = 4 + 3 + 1 + 2 + 1
+    assert len(core.neurons) == expected_neurons
+    # verify a synapse weight from first layer
+    w = model.seq[0].weight.detach().cpu().numpy()[0, 0]
+    syn = core.synapses[0]
+    assert syn.weight == float(w)
+
+
+def test_unsupported_layer():
+    class Unsupported(torch.nn.Module):
+        def forward(self, x):
+            return torch.sigmoid(x)
+
+    model = torch.nn.Sequential(Unsupported())
+    params = minimal_params()
+    with pytest.raises(UnsupportedLayerError) as exc:
+        convert_model(model, core_params=params)
+    assert "not supported" in str(exc.value)


### PR DESCRIPTION
## Summary
- implement universal PyTorch-to-MARBLE converter with registry and FX tracing
- add simple CLI entry point
- create TODO list for converter
- test conversion on a small model

## Testing
- `ruff format pytorch_to_marble.py tests/test_pytorch_to_marble.py`
- `ruff check pytorch_to_marble.py tests/test_pytorch_to_marble.py`
- `pytest tests/test_pytorch_to_marble.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68886ad47af48327b0c1f2d07226c8e7