### PR TITLE
Update converter roadmap

### DIFF
--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -1,1 +1,2 @@
-All tests passed.
+Failed tests during conversion update:
+- tests/test_pytorch_to_marble.py::test_conv2d_conversion

--- a/converttodo.md
+++ b/converttodo.md
@@ -12,3 +12,22 @@
 - [ ] Add converter for Conv2d layers (single-channel only).
   - [ ] Unit test conv2d conversion.
 - [ ] Document CLI usage in README.
+
+## Upcoming Features
+- [ ] Expand registry with more PyTorch layers
+  - [ ] BatchNorm and Dropout
+  - [ ] Flatten and Reshape operations
+  - [ ] Additional activations (Sigmoid, Tanh, GELU)
+- [ ] Create high-level graph construction API
+  - [ ] Helper to add neuron groups with activations
+  - [ ] Helper to add synapses with weights and bias
+  - [ ] Parameterized wrappers for linear and convolutional layers
+- [ ] Support custom layer converters via decorator registration
+  - [ ] Example converter for a user-defined PyTorch layer
+  - [ ] Unit tests for custom converter workflow
+- [ ] Enhance `dry_run` mode to output summary statistics
+  - [ ] Number of neurons and synapses created
+  - [ ] Per-layer mapping information
+- [ ] Validate converted models by comparing PyTorch and MARBLE outputs
+  - [ ] Unit tests for small networks
+  - [ ] Integration test for custom model


### PR DESCRIPTION
## Summary
- update PyTorch-to-MARBLE converter roadmap in `converttodo.md`
- record failing conv2d conversion test in `FAILEDTESTS.md`

## Testing
- `pytest tests/test_pytorch_to_marble.py::test_unsupported_layer -q`
- `pytest tests/test_pytorch_to_marble.py::test_basic_conversion -q`
- `pytest tests/test_pytorch_to_marble.py::test_conv2d_conversion -q` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_6888758e4b1c8327bb13ba0b96760480