### PR TITLE
Enhance converter support and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,22 @@ codelets through the workspace. Register your own codelets via
 `attention_codelets.register_codelet` and invoke
 `attention_codelets.run_cycle()` during training.
 
+## PyTorch to MARBLE Conversion
+The project ships with a converter that maps PyTorch models into the MARBLE
+format. Run the CLI to transform a saved ``.pt`` file into JSON:
+
+```bash
+python convert_model.py --pytorch my_model.pt --output marble_model.json
+```
+
+Specify ``--dry-run`` to see the resulting graph statistics without writing a
+file. You can also call ``convert_model`` directly:
+
+```python
+from pytorch_to_marble import convert_model
+marble_brain = convert_model(torch_model)
+```
+
 ## Release Process
 To publish a new release to PyPI:
 1. Update the version number in `pyproject.toml` and `setup.py`.

--- a/converttodo.md
+++ b/converttodo.md
@@ -9,15 +9,17 @@
 - [x] Raise explicit errors for unsupported layers.
 - [x] Provide CLI script `convert_model.py`.
 - [x] Write unit tests covering simple model conversion.
-- [ ] Add converter for Conv2d layers (single-channel only).
-  - [ ] Unit test conv2d conversion.
-- [ ] Document CLI usage in README.
+- [x] Add converter for Conv2d layers (single-channel only).
+  - [x] Unit test conv2d conversion.
+- [x] Document CLI usage in README.
 
 ## Upcoming Features
 - [ ] Expand registry with more PyTorch layers
   - [ ] BatchNorm and Dropout
   - [ ] Flatten and Reshape operations
   - [ ] Additional activations (Sigmoid, Tanh, GELU)
+  - [ ] Multi-channel Conv2d
+  - [ ] MaxPool2d and AvgPool2d
 - [ ] Create high-level graph construction API
   - [ ] Helper to add neuron groups with activations
   - [ ] Helper to add synapses with weights and bias
@@ -25,6 +27,7 @@
 - [ ] Support custom layer converters via decorator registration
   - [ ] Example converter for a user-defined PyTorch layer
   - [ ] Unit tests for custom converter workflow
+  - [ ] Conversion of Sequential and ModuleList containers
 - [ ] Enhance `dry_run` mode to output summary statistics
   - [ ] Number of neurons and synapses created
   - [ ] Per-layer mapping information

--- a/pytorch_to_marble.py
+++ b/pytorch_to_marble.py
@@ -139,7 +139,11 @@ def convert_model(
             if input_tensor is not None:
                 in_dim = input_tensor.shape[1]
             else:
-                in_dim = model.input_size if hasattr(model, "input_size") else 1
+                if hasattr(model, "input_size"):
+                    size = model.input_size
+                    in_dim = size[0] if isinstance(size, tuple) else size
+                else:
+                    in_dim = 1
             ids = []
             for _ in range(in_dim):
                 nid = len(core.neurons)


### PR DESCRIPTION
## Summary
- handle tuple input sizes in `convert_model`
- mark conv2d tasks as done and expand TODOs
- add user guide for the conversion CLI

## Testing
- `pytest -k pytorch_to_marble -q`

------
https://chatgpt.com/codex/tasks/task_e_688879147d348327b92adb3d045d81c7