### PR TITLE
Update conversion todo and tests

### DIFF
--- a/converttodo.md
+++ b/converttodo.md
@@ -20,6 +20,8 @@
   - [ ] Additional activations (Sigmoid, Tanh, GELU)
   - [ ] Multi-channel Conv2d
   - [ ] MaxPool2d and AvgPool2d
+  - [ ] GlobalAvgPool2d and Adaptive pooling layers
+  - [ ] Sequential and ModuleList containers
 - [ ] Create high-level graph construction API
   - [ ] Helper to add neuron groups with activations
   - [ ] Helper to add synapses with weights and bias
@@ -27,7 +29,6 @@
 - [ ] Support custom layer converters via decorator registration
   - [ ] Example converter for a user-defined PyTorch layer
   - [ ] Unit tests for custom converter workflow
-  - [ ] Conversion of Sequential and ModuleList containers
 - [ ] Enhance `dry_run` mode to output summary statistics
   - [ ] Number of neurons and synapses created
   - [ ] Per-layer mapping information

--- a/tests/test_pytorch_to_marble.py
+++ b/tests/test_pytorch_to_marble.py
@@ -50,15 +50,11 @@ def test_basic_conversion():
 
 
 def test_unsupported_layer():
-    class Unsupported(torch.nn.Module):
-        def forward(self, x):
-            return torch.sigmoid(x)
-
-    model = torch.nn.Sequential(Unsupported())
+    model = torch.nn.Sequential(torch.nn.MaxPool2d(2))
     params = minimal_params()
     with pytest.raises(UnsupportedLayerError) as exc:
         convert_model(model, core_params=params)
-    assert "not supported" in str(exc.value)
+    assert str(exc.value) == "MaxPool2d is not supported for conversion"
 
 
 def test_conv2d_conversion():


### PR DESCRIPTION
## Summary
- expand `converttodo.md` with granular tasks for the universal PyTorch to MARBLE converter
- adjust unsupported layer test to check message for an unsupported built-in layer

## Testing
- `pytest tests/test_pytorch_to_marble.py::test_unsupported_layer -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68887bbc23a48327b5f622d1580ac18d