### PR TITLE
Improve PyTorch conversion errors

### DIFF
--- a/converttodo.md
+++ b/converttodo.md
@@ -14,23 +14,26 @@
 - [x] Document CLI usage in README.
 
 ## Upcoming Features
-- [ ] Expand registry with more PyTorch layers
+- **Auto-inference mode for dry runs**
+  - [ ] Print neuron and synapse statistics
+  - [ ] Visualize MARBLE graph structure
+- **Expand registry with more PyTorch layers**
   - [ ] BatchNorm and Dropout
   - [ ] Flatten and Reshape operations
   - [ ] Additional activations (Sigmoid, Tanh, GELU)
   - [ ] Multi-channel Conv2d
   - [ ] MaxPool2d and AvgPool2d
-- [ ] Create high-level graph construction API
+- **Create high-level graph construction API**
   - [ ] Helper to add neuron groups with activations
   - [ ] Helper to add synapses with weights and bias
   - [ ] Parameterized wrappers for linear and convolutional layers
-- [ ] Support custom layer converters via decorator registration
+- **Support custom layer converters via decorator registration**
   - [ ] Example converter for a user-defined PyTorch layer
   - [ ] Unit tests for custom converter workflow
   - [ ] Conversion of Sequential and ModuleList containers
-- [ ] Enhance `dry_run` mode to output summary statistics
+- **Enhance `dry_run` mode to output summary statistics**
   - [ ] Number of neurons and synapses created
   - [ ] Per-layer mapping information
-- [ ] Validate converted models by comparing PyTorch and MARBLE outputs
+- **Validate converted models by comparing PyTorch and MARBLE outputs**
   - [ ] Unit tests for small networks
   - [ ] Integration test for custom model

--- a/pytorch_to_marble.py
+++ b/pytorch_to_marble.py
@@ -60,7 +60,9 @@ def _add_conv2d_layer(
     core: Core, input_ids: List[int], layer: torch.nn.Conv2d
 ) -> List[int]:
     if layer.in_channels != 1 or len(input_ids) != 1 or layer.groups != 1:
-        raise UnsupportedLayerError("Conv2d with in_channels!=1 is not supported for conversion")
+        raise UnsupportedLayerError(
+            f"{layer.__class__.__name__} with in_channels!=1 is not supported for conversion"
+        )
     out_ids = []
     weight = layer.weight.detach().cpu().numpy()
     stride = layer.stride[0] if isinstance(layer.stride, tuple) else layer.stride

--- a/tests/test_pytorch_to_marble.py
+++ b/tests/test_pytorch_to_marble.py
@@ -3,11 +3,11 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-import torch
 import pytest
+import torch
 
-from pytorch_to_marble import convert_model, UnsupportedLayerError
 from marble_core import Core
+from pytorch_to_marble import UnsupportedLayerError, convert_model
 from tests.test_core_functions import minimal_params
 
 
@@ -50,15 +50,11 @@ def test_basic_conversion():
 
 
 def test_unsupported_layer():
-    class Unsupported(torch.nn.Module):
-        def forward(self, x):
-            return torch.sigmoid(x)
-
-    model = torch.nn.Sequential(Unsupported())
+    model = torch.nn.Sequential(torch.nn.Sigmoid())
     params = minimal_params()
     with pytest.raises(UnsupportedLayerError) as exc:
         convert_model(model, core_params=params)
-    assert "not supported" in str(exc.value)
+    assert "Sigmoid is not supported for conversion" in str(exc.value)
 
 
 def test_conv2d_conversion():
@@ -66,4 +62,3 @@ def test_conv2d_conversion():
     params = minimal_params()
     core = convert_model(model, core_params=params)
     assert any(n.neuron_type == "conv2d" for n in core.neurons)
-


### PR DESCRIPTION
## Summary
- raise consistent UnsupportedLayerError when Conv2d settings are invalid
- expect exact error message in converter tests
- expand TODO list with subtasks for auto-inference mode and other features

## Testing
- `pre-commit run --files pytorch_to_marble.py tests/test_pytorch_to_marble.py converttodo.md`
- `pytest tests/test_pytorch_to_marble.py::test_basic_conversion tests/test_pytorch_to_marble.py::test_unsupported_layer tests/test_pytorch_to_marble.py::test_conv2d_conversion -q`

------
https://chatgpt.com/codex/tasks/task_e_68887bbc23a48327b5f622d1580ac18d