### PR TITLE
Implement dry run summary for PyTorch converter

### DIFF
--- a/converttodo.md
+++ b/converttodo.md
@@ -29,12 +29,16 @@
   - [ ] Helper to add neuron groups with activations
   - [ ] Helper to add synapses with weights and bias
   - [ ] Parameterized wrappers for linear and convolutional layers
+  - [ ] Documentation for graph builder utilities
 - [ ] Support custom layer converters via decorator registration
   - [ ] Example converter for a user-defined PyTorch layer
   - [ ] Unit tests for custom converter workflow
-- [ ] Enhance `dry_run` mode to output summary statistics
-  - [ ] Number of neurons and synapses created
-  - [ ] Per-layer mapping information
+  - [ ] Document registration mechanism in README
+- [x] Enhance `dry_run` mode to output summary statistics
+  - [x] Number of neurons and synapses created
+  - [x] Per-layer mapping information
+  - [ ] Visualize neuron and synapse counts
 - [ ] Validate converted models by comparing PyTorch and MARBLE outputs
   - [ ] Unit tests for small networks
   - [ ] Integration test for custom model
+  - [ ] CLI option to run validation automatically

--- a/pytorch_to_marble.py
+++ b/pytorch_to_marble.py
@@ -172,6 +172,16 @@ def _get_converter(layer: torch.nn.Module) -> LayerConverter:
     )
 
 
+def _print_dry_run_summary(core: Core, node_outputs: Dict[str, List[int]]) -> None:
+    """Print summary statistics for a dry-run conversion."""
+    print(
+        f"[DRY RUN] created {len(core.neurons)} neurons and {len(core.synapses)} synapses"
+    )
+    for name, ids in node_outputs.items():
+        if name != "output":
+            print(f"[DRY RUN] {name}: {len(ids)} neurons")
+
+
 def convert_model(
     model: torch.nn.Module, core_params: Dict | None = None, dry_run: bool = False
 ) -> Core:
@@ -225,6 +235,7 @@ def convert_model(
                 f"Operation {node.op} is not supported for conversion"
             )
     if dry_run:
+        _print_dry_run_summary(core, node_outputs)
         return core
     return core
 

--- a/tests/test_pytorch_to_marble.py
+++ b/tests/test_pytorch_to_marble.py
@@ -191,4 +191,13 @@ def test_unflatten_conversion():
     assert tuple(n.params["unflattened_size"]) == (2, 2)
 
 
+def test_dry_run_summary(capsys):
+    model = SimpleModel()
+    params = minimal_params()
+    convert_model(model, core_params=params, dry_run=True)
+    out = capsys.readouterr().out
+    assert "created" in out
+    assert "seq_0" in out
+
+
 


### PR DESCRIPTION
## Summary
- add summary printing when converting with `dry_run` to list created neurons and synapses
- test that dry run prints summary information
- expand converter TODOs

## Testing
- `pytest -q tests/test_pytorch_to_marble.py::test_dry_run_summary`

------
https://chatgpt.com/codex/tasks/task_e_68888b14bb4883279ac8385a7aea9699