### PR TITLE
Expand converter roadmap

### DIFF
--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -1,1 +1,20 @@
-All tests passing.
+Failed tests during last run of `pytest`:
+- test_remote_offloading.py
+- test_self_monitoring_plugin.py
+- test_semi_supervised_learning.py
+- test_streamlit_all_buttons.py
+- test_streamlit_gui.py
+- test_streamlit_playground.py
+- test_super_evolution.py
+- test_synapse_dropout_batchnorm.py
+- test_synapse_types.py
+- test_synaptic_echo_learning.py
+- test_torch_interop.py
+- test_torrent_offload.py
+- test_transfer_learning.py
+- test_unified_learning.py
+- test_usage_profiler.py
+- test_utils.py
+- test_wandering_anomaly.py
+- test_web_api.py
+(plus additional failures leading to 126 errors during collection)

--- a/converttodo.md
+++ b/converttodo.md
@@ -14,31 +14,43 @@
 - [x] Document CLI usage in README.
 
 ## Upcoming Features
-- [ ] Expand registry with more PyTorch layers
-  - [x] BatchNorm and Dropout
-  - [ ] Flatten and Reshape operations
-    - [x] Flatten
-    - [x] Reshape (Unflatten)
-    - [ ] View/reshape functional
-  - [x] Additional activations (Sigmoid, Tanh, GELU)
-  - [ ] Multi-channel Conv2d
+
+### 1. Expand registry with more PyTorch layers
+- [x] BatchNorm and Dropout
+- [ ] Flatten and Reshape operations
+  - [x] Flatten
+  - [x] Reshape (Unflatten)
+  - [ ] View/reshape functional
+- [x] Additional activations (Sigmoid, Tanh, GELU)
+- [ ] Multi-channel Conv2d
+- [ ] Pooling layers
   - [ ] MaxPool2d and AvgPool2d
-  - [ ] GlobalAvgPool2d and Adaptive pooling layers
-  - [ ] Sequential and ModuleList containers
-- [ ] Create high-level graph construction API
-  - [ ] Helper to add neuron groups with activations
-  - [ ] Helper to add synapses with weights and bias
-  - [ ] Parameterized wrappers for linear and convolutional layers
-  - [ ] Documentation for graph builder utilities
-- [ ] Support custom layer converters via decorator registration
-  - [ ] Example converter for a user-defined PyTorch layer
-  - [ ] Unit tests for custom converter workflow
-  - [ ] Document registration mechanism in README
-- [x] Enhance `dry_run` mode to output summary statistics
-  - [x] Number of neurons and synapses created
-  - [x] Per-layer mapping information
-  - [ ] Visualize neuron and synapse counts
+  - [ ] GlobalAvgPool2d and adaptive pooling
+- [ ] Sequential and ModuleList containers
+
+### 2. High-level graph construction API
+- [ ] Helper to add neuron groups with activations
+- [ ] Helper to add synapses with weights and bias
+- [ ] Parameterized wrappers for linear and convolutional layers
+- [ ] Documentation for graph builder utilities
+
+### 3. Custom layer converter support
+- [ ] Decorator-based registration for user-defined layers
+- [ ] Example converter for a custom layer
+- [ ] Unit tests validating custom converter workflow
+- [ ] Document registration mechanism in README
+
+### 4. Dry-run improvements
+- [x] Number of neurons and synapses created
+- [x] Per-layer mapping information
+- [ ] Visualize neuron and synapse counts
+
+### 5. Validation utilities
 - [ ] Validate converted models by comparing PyTorch and MARBLE outputs
   - [ ] Unit tests for small networks
-  - [ ] Integration test for custom model
+  - [ ] Integration test for a custom model
   - [ ] CLI option to run validation automatically
+
+### 6. Additional tooling
+- [ ] Support converting `.pt` files directly into `.marble` snapshots
+- [ ] Provide auto-inference mode summarizing created graph without saving


### PR DESCRIPTION
## Summary
- expand roadmap for PyTorch to MARBLE converter features
- record failing tests

## Testing
- `pytest -q` *(fails: 126 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68888d336b8c8327954a77fbd1e4d97c