### PR TITLE
Add function/method conversion support

### DIFF
--- a/converttodo.md
+++ b/converttodo.md
@@ -20,6 +20,13 @@
 - [ ] Graceful fallback when `torch.fx` tracing fails
 - [ ] Provide clear error when layer type is not registered
 
+### Functional layer converters
+- [ ] Registry for functional operations
+- [ ] Converter for `F.relu`
+- [ ] Converter for `F.sigmoid`
+- [ ] Converter for `F.tanh`
+- [ ] Unit tests covering functional converters
+
 ### 1. Expand registry with more PyTorch layers
 - [x] BatchNorm and Dropout
 - [ ] Flatten and Reshape operations
@@ -67,3 +74,9 @@
 - [ ] Command line interface for one-step conversion
 - [ ] Programmatic API returning a `Core` object
 - [ ] YAML configuration for converter options
+
+### 8. Model loader interface
+- [ ] CLI supports `--pytorch`, `--output` and `--dry-run`
+- [ ] Programmatic `convert_model` function usable in other scripts
+- [ ] Example usage documented in README
+- [ ] Load checkpoints saved with `torch.save` automatically

--- a/tests/test_pytorch_to_marble.py
+++ b/tests/test_pytorch_to_marble.py
@@ -88,6 +88,36 @@ class TanhModel(torch.nn.Module):
         return self.seq(x)
 
 
+class FuncReluModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc = torch.nn.Linear(2, 2)
+        self.input_size = 2
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.relu(self.fc(x))
+
+
+class FuncSigmoidModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc = torch.nn.Linear(2, 2)
+        self.input_size = 2
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.sigmoid(self.fc(x))
+
+
+class FuncTanhModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc = torch.nn.Linear(2, 2)
+        self.input_size = 2
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.tanh(self.fc(x))
+
+
 class FlattenModel(torch.nn.Module):
     def __init__(self) -> None:
         super().__init__()
@@ -198,6 +228,27 @@ def test_dry_run_summary(capsys):
     out = capsys.readouterr().out
     assert "created" in out
     assert "seq_0" in out
+
+
+def test_functional_relu_conversion():
+    model = FuncReluModel()
+    params = minimal_params()
+    core = convert_model(model, core_params=params)
+    assert any(n.params.get("activation") == "relu" for n in core.neurons)
+
+
+def test_functional_sigmoid_conversion():
+    model = FuncSigmoidModel()
+    params = minimal_params()
+    core = convert_model(model, core_params=params)
+    assert any(n.neuron_type == "sigmoid" for n in core.neurons)
+
+
+def test_functional_tanh_conversion():
+    model = FuncTanhModel()
+    params = minimal_params()
+    core = convert_model(model, core_params=params)
+    assert any(n.neuron_type == "tanh" for n in core.neurons)
 
 
 


### PR DESCRIPTION
## Summary
- extend TODO with functional converter tasks and model loader interface section
- add conversion registry for functional and method ops
- support functional and method nodes in `convert_model`
- implement converters for relu/sigmoid/tanh functions and methods
- test new converters

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_pytorch_to_marble.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688891a0d8a48327a9549d7f038057f4