### PR TITLE
Add MARBLE snapshot export and CLI test

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,13 @@ activations ``ReLU``, ``Sigmoid``, ``Tanh`` and ``GELU``.
 python convert_model.py --pytorch my_model.pt --output marble_model.json
 ```
 
+To store a full MARBLE snapshot instead of JSON simply use the `.marble`
+extension:
+
+```bash
+python convert_model.py --pytorch my_model.pt --output marble_model.marble
+```
+
 Specify ``--dry-run`` to see the resulting graph statistics without writing a
 file. You can also call ``convert_model`` directly:
 

--- a/convert_model.py
+++ b/convert_model.py
@@ -1,15 +1,22 @@
 import argparse
+from pathlib import Path
+
 import torch
 from pytorch_to_marble import convert_model
+from marble_interface import MARBLE, save_marble_system
 from marble_utils import core_to_json
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Convert PyTorch model checkpoint to MARBLE JSON"
+        description="Convert PyTorch model checkpoint to MARBLE JSON or snapshot"
     )
     parser.add_argument("--pytorch", required=True, help="Path to PyTorch model")
-    parser.add_argument("--output", required=True, help="Output JSON path")
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output path (.json or .marble)",
+    )
     parser.add_argument(
         "--dry-run",
         action="store_true",
@@ -17,12 +24,25 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    model = torch.load(args.pytorch, map_location="cpu")
+    model = torch.load(args.pytorch, map_location="cpu", weights_only=False)
     core = convert_model(model, dry_run=args.dry_run)
-    if not args.dry_run:
+
+    if args.dry_run:
+        return
+
+    out_path = Path(args.output)
+    if out_path.suffix == ".json":
         js = core_to_json(core)
-        with open(args.output, "w", encoding="utf-8") as f:
+        with open(out_path, "w", encoding="utf-8") as f:
             f.write(js)
+    elif out_path.suffix == ".marble":
+        marble = MARBLE(core.params)
+        marble.core = core
+        marble.neuronenblitz.core = core
+        marble.brain.core = core
+        save_marble_system(marble, str(out_path))
+    else:
+        raise ValueError("Output extension must be .json or .marble")
 
 
 if __name__ == "__main__":

--- a/converttodo.md
+++ b/converttodo.md
@@ -17,6 +17,7 @@
 
 ### 0. Core conversion engine
 - [ ] Ensure `convert_model` handles functional operations from `torch.nn.functional`
+- [ ] Document layer mapping registry in developer docs
 - [x] Graceful fallback when `torch.fx` tracing fails
 - [x] Provide clear error when layer type is not registered
 - [x] Raise error for unsupported functional operations
@@ -51,11 +52,13 @@
 - [ ] Helper to add synapses with weights and bias
 - [ ] Parameterized wrappers for linear and convolutional layers
 - [ ] Documentation for graph builder utilities
+- [ ] Examples demonstrating dynamic message passing setup
 
 ### 3. Weight and activation handling
 - [ ] Extract weights and biases from PyTorch layers
 - [ ] Store activation type in neuron metadata
 - [ ] Support GPU and CPU weight formats
+- [ ] Verify bias neurons are created correctly
 
 ### 4. Custom layer converter support
 - [ ] Decorator-based registration for user-defined layers
@@ -73,9 +76,10 @@
   - [ ] Unit tests for small networks
   - [ ] Integration test for a custom model
   - [ ] CLI option to run validation automatically
+- [ ] Numerical tolerances for output comparison
 
 ### 7. Additional tooling
-- [ ] Support converting `.pt` files directly into `.marble` snapshots
+- [x] Support converting `.pt` files directly into `.marble` snapshots
 - [ ] Provide auto-inference mode summarizing created graph without saving
 - [ ] Command line interface for one-step conversion
 - [ ] Programmatic API returning a `Core` object
@@ -86,6 +90,7 @@
 - [ ] Programmatic `convert_model` function usable in other scripts
 - [ ] Example usage documented in README
 - [ ] Load checkpoints saved with `torch.save` automatically
+- [ ] Support `.json` or `.marble` output based on extension
 
 ### 9. Graph visualization and inspection
 - [ ] Visualize generated MARBLE graph structure
@@ -100,3 +105,4 @@
 - [ ] Map PyTorch control flow to MARBLE dynamic topology
 - [ ] Handle evolving neuron and synapse creation during inference
 - [ ] Unit tests covering dynamic model conversion paths
+- [ ] Research torch.fx support for control flow constructs

--- a/tests/test_convert_model_cli.py
+++ b/tests/test_convert_model_cli.py
@@ -1,0 +1,34 @@
+import sys
+import subprocess
+
+from pathlib import Path
+
+import torch
+from marble_interface import load_marble_system
+
+
+class SmallModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc = torch.nn.Linear(2, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc(x)
+
+
+def test_convert_model_marble(tmp_path):
+    model = SmallModel()
+    model_path = tmp_path / "model.pt"
+    torch.save(model, model_path)
+
+    out_path = tmp_path / "model.marble"
+    script = Path(__file__).resolve().parent.parent / "convert_model.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--pytorch", str(model_path), "--output", str(out_path)],
+        capture_output=True,
+    )
+    assert result.returncode == 0
+    assert out_path.exists()
+
+    marble = load_marble_system(str(out_path))
+    assert len(marble.get_core().neurons) >= 2


### PR DESCRIPTION
## Summary
- support `.marble` snapshot output in `convert_model.py`
- update README usage for snapshot option
- expand converter TODO list
- add CLI test for snapshot conversion

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_convert_model_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68889aa04e28832787d5e83a635f4036