### PR TITLE
Improve PyTorch converter logging and custom layer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,33 @@ from pytorch_to_marble import convert_model
 marble_brain = convert_model(torch_model)
 ```
 
+### Registering Custom Layer Converters
+The converter can handle user-defined layers by registering a conversion
+function. Decorate your converter with `@register_converter` and provide the
+layer class:
+
+```python
+from pytorch_to_marble import register_converter
+
+class MyCustomLayer(torch.nn.Module):
+    def __init__(self, size):
+        super().__init__()
+        self.linear = torch.nn.Linear(size, size)
+
+    def forward(self, x):
+        return self.linear(x) * 2
+
+@register_converter(MyCustomLayer)
+def convert_my_layer(layer, core, inputs):
+    out = _add_fully_connected_layer(core, inputs, layer.linear)
+    for nid in out:
+        core.neurons[nid].params["scale"] = 2.0
+    return out
+```
+
+Any occurrence of `MyCustomLayer` in the PyTorch model will be converted using
+the provided function.
+
 ## Release Process
 To publish a new release to PyPI:
 1. Update the version number in `pyproject.toml` and `setup.py`.

--- a/converttodo.md
+++ b/converttodo.md
@@ -61,10 +61,10 @@
 - [ ] Verify bias neurons are created correctly
 
 ### 4. Custom layer converter support
-- [ ] Decorator-based registration for user-defined layers
-- [ ] Example converter for a custom layer
-- [ ] Unit tests validating custom converter workflow
-- [ ] Document registration mechanism in README
+- [x] Decorator-based registration for user-defined layers
+- [x] Example converter for a custom layer
+- [x] Unit tests validating custom converter workflow
+- [x] Document registration mechanism in README
 
 ### 5. Dry-run improvements
 - [x] Number of neurons and synapses created
@@ -99,7 +99,7 @@
 
 ### 10. Error handling and logging
 - [x] Unsupported layers raise `"[layer type name] is not supported for conversion"`
-- [ ] Logging statements for each conversion step
+- [x] Logging statements for each conversion step
 
 ### 11. Dynamic graph support
 - [ ] Map PyTorch control flow to MARBLE dynamic topology


### PR DESCRIPTION
## Summary
- document how to register custom converters
- mark completed tasks in `converttodo.md`
- add logging of conversion steps
- support tracing custom layers as leaf modules
- add tests for custom converter and logging

## Testing
- `pytest tests/test_pytorch_to_marble.py::test_custom_layer_converter tests/test_pytorch_to_marble.py::test_logging_messages tests/test_pytorch_to_marble.py::test_tracing_failed_error tests/test_pytorch_to_marble.py::test_basic_conversion tests/test_convert_model_cli.py::test_convert_model_marble`

------
https://chatgpt.com/codex/tasks/task_e_6888a4df4e1c832789f940aaf2ba3519