### PR TITLE
Add reshape converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,8 @@ format. Run the CLI to transform a saved ``.pt`` file into JSON:
 
 Supported layers currently include ``Linear``, ``Conv2d`` (single-channel),
 ``BatchNorm1d``, ``BatchNorm2d``, ``Dropout``, ``Flatten`` and the element-wise
-activations ``ReLU``, ``Sigmoid``, ``Tanh`` and ``GELU``.
+activations ``ReLU``, ``Sigmoid``, ``Tanh`` and ``GELU``. Functional reshaping
+operations via ``view`` or ``torch.reshape`` are also recognized.
 
 ```bash
 python convert_model.py --pytorch my_model.pt --output marble_model.json

--- a/converttodo.md
+++ b/converttodo.md
@@ -16,18 +16,18 @@
 ## Upcoming Features
 
 ### 0. Core conversion engine
-- [ ] Ensure `convert_model` handles functional operations from `torch.nn.functional`
+- [x] Ensure `convert_model` handles functional operations from `torch.nn.functional`
 - [ ] Document layer mapping registry in developer docs
 - [x] Graceful fallback when `torch.fx` tracing fails
 - [x] Provide clear error when layer type is not registered
 - [x] Raise error for unsupported functional operations
 
 ### Functional layer converters
-- [ ] Registry for functional operations
-- [ ] Converter for `F.relu`
-- [ ] Converter for `F.sigmoid`
-- [ ] Converter for `F.tanh`
-- [ ] Unit tests covering functional converters
+- [x] Registry for functional operations
+- [x] Converter for `F.relu`
+- [x] Converter for `F.sigmoid`
+- [x] Converter for `F.tanh`
+- [x] Unit tests covering functional converters
   - [x] Unsupported functional op error test
 
 ### 1. Expand registry with more PyTorch layers
@@ -35,7 +35,7 @@
 - [ ] Flatten and Reshape operations
   - [x] Flatten
   - [x] Reshape (Unflatten)
-  - [ ] View/reshape functional
+  - [x] View/reshape functional
 - [x] Additional activations (Sigmoid, Tanh, GELU)
 - [ ] Multi-channel Conv2d
 - [ ] Pooling layers
@@ -86,11 +86,11 @@
 - [ ] YAML configuration for converter options
 
 ### 8. Model loader interface
-- [ ] CLI supports `--pytorch`, `--output` and `--dry-run`
-- [ ] Programmatic `convert_model` function usable in other scripts
-- [ ] Example usage documented in README
-- [ ] Load checkpoints saved with `torch.save` automatically
-- [ ] Support `.json` or `.marble` output based on extension
+- [x] CLI supports `--pytorch`, `--output` and `--dry-run`
+- [x] Programmatic `convert_model` function usable in other scripts
+- [x] Example usage documented in README
+- [x] Load checkpoints saved with `torch.save` automatically
+- [x] Support `.json` or `.marble` output based on extension
 
 ### 9. Graph visualization and inspection
 - [ ] Visualize generated MARBLE graph structure

--- a/tests/test_pytorch_to_marble.py
+++ b/tests/test_pytorch_to_marble.py
@@ -126,6 +126,28 @@ class FuncTanhModel(torch.nn.Module):
         return torch.nn.functional.tanh(self.fc(x))
 
 
+class FuncReshapeModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc = torch.nn.Linear(4, 4)
+        self.input_size = 4
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.fc(x)
+        return torch.reshape(x, (2, 2))
+
+
+class ViewModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc = torch.nn.Linear(4, 4)
+        self.input_size = 4
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.fc(x)
+        return x.view(2, 2)
+
+
 class FlattenModel(torch.nn.Module):
     def __init__(self) -> None:
         super().__init__()
@@ -257,6 +279,21 @@ def test_functional_tanh_conversion():
     params = minimal_params()
     core = convert_model(model, core_params=params)
     assert any(n.neuron_type == "tanh" for n in core.neurons)
+
+
+def test_functional_reshape_conversion():
+    model = FuncReshapeModel()
+    params = minimal_params()
+    core = convert_model(model, core_params=params)
+    reshape_neuron = next(n for n in core.neurons if n.neuron_type == "reshape")
+    assert tuple(reshape_neuron.params["shape"]) == (2, 2)
+
+
+def test_view_method_conversion():
+    model = ViewModel()
+    params = minimal_params()
+    core = convert_model(model, core_params=params)
+    assert any(n.neuron_type == "reshape" for n in core.neurons)
 
 
 class FuncUnsupportedModel(torch.nn.Module):


### PR DESCRIPTION
## Summary
- support `torch.reshape` and `.view()` calls in PyTorch to MARBLE converter
- allow extra arguments to functional and method converters
- test reshape and view conversion
- document new support in README
- update converter TODO list

## Testing
- `pytest tests/test_pytorch_to_marble.py tests/test_convert_model_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888aaab817883279e862f01515d8517