### PR TITLE
Add pooling converters and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,9 @@ The project ships with a converter that maps PyTorch models into the MARBLE
 format. Run the CLI to transform a saved ``.pt`` file into JSON:
 
 Supported layers currently include ``Linear``, ``Conv2d`` (single-channel),
-``BatchNorm1d``, ``BatchNorm2d``, ``Dropout``, ``Flatten`` and the element-wise
-activations ``ReLU``, ``Sigmoid``, ``Tanh`` and ``GELU``. Functional reshaping
+``BatchNorm1d``, ``BatchNorm2d``, ``Dropout``, ``Flatten``, ``MaxPool2d`` and
+``AvgPool2d`` as well as the element-wise activations ``ReLU``, ``Sigmoid``,
+``Tanh`` and ``GELU``. Functional reshaping
 operations via ``view`` or ``torch.reshape`` are also recognized.
 
 ```bash

--- a/converttodo.md
+++ b/converttodo.md
@@ -17,7 +17,7 @@
 
 ### 0. Core conversion engine
 - [x] Ensure `convert_model` handles functional operations from `torch.nn.functional`
-- [ ] Document layer mapping registry in developer docs
+- [x] Document layer mapping registry in developer docs
 - [x] Graceful fallback when `torch.fx` tracing fails
 - [x] Provide clear error when layer type is not registered
 - [x] Raise error for unsupported functional operations
@@ -39,8 +39,9 @@
 - [x] Additional activations (Sigmoid, Tanh, GELU)
 - [ ] Multi-channel Conv2d
 - [ ] Pooling layers
-  - [ ] MaxPool2d and AvgPool2d
+  - [x] MaxPool2d and AvgPool2d
   - [ ] GlobalAvgPool2d and adaptive pooling
+  - [x] Update docs for pooling support
 - [ ] Sequential and ModuleList containers
 - [ ] Embedding layers
 - [ ] Recurrent layers (RNN, LSTM, GRU)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,3 +13,8 @@ Compatibility
 -------------
 
 .. include:: python_compatibility.md
+
+PyTorch Conversion
+------------------
+
+.. include:: pytorch_conversion.md

--- a/docs/pytorch_conversion.md
+++ b/docs/pytorch_conversion.md
@@ -1,0 +1,24 @@
+# PyTorch Conversion Registry
+
+MARBLE's model converter relies on a registry that maps PyTorch layers and
+operations to conversion functions. Each converter receives the layer instance,
+the active :class:`marble_core.Core` and the input neuron IDs. It returns the
+IDs of the output neurons created in the MARBLE graph.
+
+Converters are registered with decorators:
+
+```python
+from pytorch_to_marble import register_converter
+
+@register_converter(torch.nn.Linear)
+def convert_linear(layer, core, inputs):
+    ...
+```
+
+The registry dictionaries ``LAYER_CONVERTERS``, ``FUNCTION_CONVERTERS`` and
+``METHOD_CONVERTERS`` hold these mappings. Custom layers can be supported by
+adding new entries using ``register_converter``.
+
+Pooling layers like ``MaxPool2d`` and ``AvgPool2d`` are handled by dedicated
+converters that create neurons with ``neuron_type`` set to ``"maxpool2d"`` or
+``"avgpool2d"`` and store kernel parameters in ``neuron.params``.


### PR DESCRIPTION
## Summary
- implement MaxPool2d and AvgPool2d conversion
- document layer mapping registry and pooling support
- update README with pooling support info
- mark completed tasks in `converttodo.md`
- test pooling layer conversions

## Testing
- `pre-commit run --files pytorch_to_marble.py tests/test_pytorch_to_marble.py README.md converttodo.md docs/pytorch_conversion.md docs/index.rst`
- `pytest tests/test_pytorch_to_marble.py::test_maxpool2d_conversion tests/test_pytorch_to_marble.py::test_avgpool2d_conversion tests/test_pytorch_to_marble.py::test_unsupported_layer -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ae8d26148327b433a394280499de