### PR TITLE
Add Conv2d error message test

### DIFF
--- a/converttodo.md
+++ b/converttodo.md
@@ -38,6 +38,9 @@
   - [x] View/reshape functional
 - [x] Additional activations (Sigmoid, Tanh, GELU)
 - [ ] Multi-channel Conv2d
+  - [ ] Support arbitrary input/output channels
+  - [ ] Unit test multi-channel conversion
+  - [x] Error message for unsupported configuration
 - [ ] Pooling layers
   - [x] MaxPool2d and AvgPool2d
   - [ ] GlobalAvgPool2d and adaptive pooling
@@ -101,6 +104,7 @@
 ### 10. Error handling and logging
 - [x] Unsupported layers raise `"[layer type name] is not supported for conversion"`
 - [x] Logging statements for each conversion step
+  - [x] Consistent error message for invalid Conv2d parameters
 
 ### 11. Dynamic graph support
 - [ ] Map PyTorch control flow to MARBLE dynamic topology

--- a/pytorch_to_marble.py
+++ b/pytorch_to_marble.py
@@ -103,7 +103,7 @@ def _add_conv2d_layer(
 ) -> List[int]:
     if layer.in_channels != 1 or len(input_ids) != 1 or layer.groups != 1:
         raise UnsupportedLayerError(
-            "Conv2d with in_channels!=1 is not supported for conversion"
+            f"{layer.__class__.__name__} is not supported for conversion"
         )
     out_ids = []
     weight = layer.weight.detach().cpu().numpy()

--- a/tests/test_pytorch_to_marble.py
+++ b/tests/test_pytorch_to_marble.py
@@ -224,6 +224,24 @@ def test_conv2d_conversion():
     assert any(n.neuron_type == "conv2d" for n in core.neurons)
 
 
+class MultiChannelConv(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv2d(3, 1, kernel_size=2)
+        self.input_size = (3, 3, 3)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x)
+
+
+def test_multichannel_conv2d_error():
+    model = MultiChannelConv()
+    params = minimal_params()
+    with pytest.raises(UnsupportedLayerError) as exc:
+        convert_model(model, core_params=params)
+    assert str(exc.value) == "Conv2d is not supported for conversion"
+
+
 def test_batchnorm_conversion():
     model = BNModel()
     params = minimal_params()


### PR DESCRIPTION
## Summary
- improve conv2d unsupported configuration error message
- test conv2d error for unsupported channels
- update conversion TODOs

## Testing
- `pytest tests/test_pytorch_to_marble.py tests/test_convert_model_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b1dad72c83278884489e800598ef