### PR TITLE
Implement Sequential container support

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,9 @@ Supported layers currently include ``Linear``, ``Conv2d`` (multi-channel),
 ``AvgPool2d``, ``GlobalAvgPool2d`` and the adaptive pooling variants
 ``AdaptiveAvgPool2d`` and ``AdaptiveMaxPool2d`` as well as the
 element-wise activations ``ReLU``, ``Sigmoid``, ``Tanh`` and ``GELU``. Functional reshaping
-operations via ``view`` or ``torch.reshape`` are also recognized.
+operations via ``view`` or ``torch.reshape`` are also recognized. In addition,
+``Sequential`` containers and ``ModuleList`` objects are expanded recursively
+during conversion.
 
 ```bash
 python convert_model.py --pytorch my_model.pt --output marble_model.json

--- a/converttodo.md
+++ b/converttodo.md
@@ -47,14 +47,28 @@
   - [x] Adaptive pooling layers
   - [x] Unit tests for global/adaptive pooling
   - [x] Update docs for pooling support
-- [ ] Sequential and ModuleList containers
-  - [ ] Handle torch.nn.Sequential recursion
-  - [ ] Support ModuleList iteration
-  - [ ] Unit tests for container handling
+- [x] Sequential and ModuleList containers
+  - [x] Handle torch.nn.Sequential recursion
+  - [x] Support ModuleList iteration
+  - [x] Unit tests for container handling
 - [ ] Embedding layers
+  - [ ] Basic ``Embedding`` converter
+  - [ ] ``EmbeddingBag`` support
+  - [ ] Unit tests for embeddings
 - [ ] Recurrent layers (RNN, LSTM, GRU)
+  - [ ] Converter for ``RNN``
+  - [ ] Converter for ``LSTM``
+  - [ ] Converter for ``GRU``
+  - [ ] Unit tests with tiny sequences
 - [ ] Normalization layers (LayerNorm, GroupNorm)
+  - [ ] ``LayerNorm`` converter
+  - [ ] ``GroupNorm`` converter
+  - [ ] Unit tests for normalization
 - [ ] Transformer blocks
+  - [ ] Self-attention conversion
+  - [ ] Feed-forward sublayers
+  - [ ] Positional encoding handling
+  - [ ] Integration tests on a small transformer
 
 ### 2. High-level graph construction API
 - [ ] Helper to add neuron groups with activations

--- a/pytorch_to_marble.py
+++ b/pytorch_to_marble.py
@@ -364,6 +364,30 @@ def _convert_unflatten(
     return inputs
 
 
+@register_converter(torch.nn.Sequential)
+def _convert_sequential(
+    layer: torch.nn.Sequential, core: Core, inputs: List[int], *args, **kwargs
+) -> List[int]:
+    """Recursively convert all submodules of a ``Sequential`` container."""
+    out = inputs
+    for sub in layer:
+        converter = _get_converter(sub)
+        out = converter(sub, core, out)
+    return out
+
+
+@register_converter(torch.nn.ModuleList)
+def _convert_modulelist(
+    layer: torch.nn.ModuleList, core: Core, inputs: List[int], *args, **kwargs
+) -> List[int]:
+    """Iterate over a ``ModuleList`` converting each module in order."""
+    out = inputs
+    for sub in layer:
+        converter = _get_converter(sub)
+        out = converter(sub, core, out)
+    return out
+
+
 @register_function_converter(torch.reshape)
 def _convert_reshape(
     func: Callable, core: Core, inputs: List[int], *shape, **kwargs


### PR DESCRIPTION
## Summary
- add converters for `Sequential` and `ModuleList`
- document container handling in README
- update converter TODO list
- handle sequential container in dry-run output test
- test `Sequential` and `ModuleList` conversion

## Testing
- `pre-commit run --files pytorch_to_marble.py tests/test_pytorch_to_marble.py README.md converttodo.md`
- `pytest tests/test_pytorch_to_marble.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888bc19c5a88327b42d4a40ca26397a