### PR TITLE
Add normalization layer converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,9 +263,9 @@ The project ships with a converter that maps PyTorch models into the MARBLE
 format. Run the CLI to transform a saved ``.pt`` file into JSON:
 
 Supported layers currently include ``Linear``, ``Conv2d`` (multi-channel),
-``BatchNorm1d``, ``BatchNorm2d``, ``Dropout``, ``Flatten``, ``MaxPool2d``,
-``AvgPool2d``, ``GlobalAvgPool2d`` and the adaptive pooling variants
-``AdaptiveAvgPool2d`` and ``AdaptiveMaxPool2d`` as well as the
+``BatchNorm1d``, ``BatchNorm2d``, ``LayerNorm``, ``GroupNorm``, ``Dropout``,
+``Flatten``, ``MaxPool2d``, ``AvgPool2d``, ``GlobalAvgPool2d`` and the adaptive
+pooling variants ``AdaptiveAvgPool2d`` and ``AdaptiveMaxPool2d`` as well as the
 element-wise activations ``ReLU``, ``Sigmoid``, ``Tanh`` and ``GELU``. Functional reshaping
 operations via ``view`` or ``torch.reshape`` are also recognized. In addition,
 ``Sequential`` containers and ``ModuleList`` objects are expanded recursively

--- a/converttodo.md
+++ b/converttodo.md
@@ -62,10 +62,10 @@
   - [ ] Converter for ``LSTM``
   - [ ] Converter for ``GRU``
   - [ ] Unit tests with tiny sequences
-- [ ] Normalization layers (LayerNorm, GroupNorm)
-  - [ ] ``LayerNorm`` converter
-  - [ ] ``GroupNorm`` converter
-  - [ ] Unit tests for normalization
+- [x] Normalization layers (LayerNorm, GroupNorm)
+  - [x] ``LayerNorm`` converter
+  - [x] ``GroupNorm`` converter
+  - [x] Unit tests for normalization
 - [ ] Transformer blocks
   - [ ] Self-attention conversion
   - [ ] Feed-forward sublayers

--- a/docs/pytorch_conversion.md
+++ b/docs/pytorch_conversion.md
@@ -22,3 +22,8 @@ adding new entries using ``register_converter``.
 Pooling layers like ``MaxPool2d`` and ``AvgPool2d`` are handled by dedicated
 converters that create neurons with ``neuron_type`` set to ``"maxpool2d"`` or
 ``"avgpool2d"`` and store kernel parameters in ``neuron.params``.
+
+Normalization layers ``LayerNorm`` and ``GroupNorm`` mark their input neurons
+with ``neuron_type`` set to ``"layernorm"`` or ``"groupnorm"`` respectively.
+Important parameters such as ``normalized_shape`` or ``num_groups`` as well as
+``eps`` are stored in ``neuron.params`` for use during message passing.

--- a/pytorch_to_marble.py
+++ b/pytorch_to_marble.py
@@ -378,6 +378,37 @@ def _convert_batchnorm(
     return inputs
 
 
+@register_converter(torch.nn.LayerNorm)
+def _convert_layernorm(
+    layer: torch.nn.LayerNorm, core: Core, inputs: List[int], *args, **kwargs
+) -> List[int]:
+    """Convert a ``LayerNorm`` layer."""
+    normalized_shape = (
+        tuple(layer.normalized_shape)
+        if isinstance(layer.normalized_shape, (list, tuple))
+        else (int(layer.normalized_shape),)
+    )
+    for nid in inputs:
+        n = core.neurons[nid]
+        n.neuron_type = "layernorm"
+        n.params["normalized_shape"] = normalized_shape
+        n.params["eps"] = float(layer.eps)
+    return inputs
+
+
+@register_converter(torch.nn.GroupNorm)
+def _convert_groupnorm(
+    layer: torch.nn.GroupNorm, core: Core, inputs: List[int], *args, **kwargs
+) -> List[int]:
+    """Convert a ``GroupNorm`` layer."""
+    for nid in inputs:
+        n = core.neurons[nid]
+        n.neuron_type = "groupnorm"
+        n.params["num_groups"] = int(layer.num_groups)
+        n.params["eps"] = float(layer.eps)
+    return inputs
+
+
 @register_converter(torch.nn.Flatten)
 def _convert_flatten(
     layer: torch.nn.Flatten, core: Core, inputs: List[int], *args, **kwargs


### PR DESCRIPTION
## Summary
- support `LayerNorm` and `GroupNorm` conversion
- document new normalization converters
- list normalization layers in README
- mark normalization tasks as complete
- add tests for `LayerNorm` and `GroupNorm`

## Testing
- `pytest tests/test_pytorch_to_marble.py::test_layernorm_conversion tests/test_pytorch_to_marble.py::test_groupnorm_conversion -q`

------
https://chatgpt.com/codex/tasks/task_e_6888c4a3f27483279c23fa38932429aa