### PR TITLE
Add recurrent layer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,10 +266,11 @@ Supported layers currently include ``Linear``, ``Conv2d`` (multi-channel),
 ``BatchNorm1d``, ``BatchNorm2d``, ``LayerNorm``, ``GroupNorm``, ``Dropout``,
 ``Flatten``, ``MaxPool2d``, ``AvgPool2d``, ``GlobalAvgPool2d`` and the adaptive
 pooling variants ``AdaptiveAvgPool2d`` and ``AdaptiveMaxPool2d`` as well as the
-element-wise activations ``ReLU``, ``Sigmoid``, ``Tanh`` and ``GELU``. Functional reshaping
-operations via ``view`` or ``torch.reshape`` are also recognized. In addition,
-``Sequential`` containers and ``ModuleList`` objects are expanded recursively
-during conversion.
+element-wise activations ``ReLU``, ``Sigmoid``, ``Tanh`` and ``GELU``. ``Embedding`` and
+``EmbeddingBag`` layers are supported, together with recurrent modules ``RNN``, ``LSTM`` and
+``GRU``. Functional reshaping operations via ``view`` or ``torch.reshape`` are also
+recognized. In addition, ``Sequential`` containers and ``ModuleList`` objects are expanded
+recursively during conversion.
 
 ```bash
 python convert_model.py --pytorch my_model.pt --output marble_model.json

--- a/converttodo.md
+++ b/converttodo.md
@@ -57,11 +57,13 @@
   - [x] Unit tests for embeddings
   - [ ] Support ``padding_idx`` and ``max_norm`` options
   - [ ] Test embeddings on GPU and CPU
-- [ ] Recurrent layers (RNN, LSTM, GRU)
-  - [ ] Converter for ``RNN``
-  - [ ] Converter for ``LSTM``
-  - [ ] Converter for ``GRU``
-  - [ ] Unit tests with tiny sequences
+- [x] Recurrent layers (RNN, LSTM, GRU)
+  - [x] Converter for ``RNN``
+  - [x] Converter for ``LSTM``
+  - [x] Converter for ``GRU``
+  - [x] Unit tests with tiny sequences
+  - [ ] Bidirectional and multi-layer support
+  - [ ] Persistent hidden state mapping
 - [x] Normalization layers (LayerNorm, GroupNorm)
   - [x] ``LayerNorm`` converter
   - [x] ``GroupNorm`` converter

--- a/tests/test_pytorch_to_marble.py
+++ b/tests/test_pytorch_to_marble.py
@@ -599,6 +599,57 @@ def test_embedding_conversion():
     assert emb_neuron.params["embedding_dim"] == 3
 
 
+class RNNModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.rnn = torch.nn.RNN(3, 2, batch_first=True)
+        self.input_size = (1, 1, 3)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.rnn(x)[0]
+
+
+class LSTMModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.rnn = torch.nn.LSTM(3, 2, batch_first=True)
+        self.input_size = (1, 1, 3)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.rnn(x)[0]
+
+
+class GRUModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.rnn = torch.nn.GRU(3, 2, batch_first=True)
+        self.input_size = (1, 1, 3)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.rnn(x)[0]
+
+
+def test_rnn_conversion():
+    model = RNNModel()
+    params = minimal_params()
+    core = convert_model(model, core_params=params)
+    assert any(n.neuron_type == "rnn" for n in core.neurons)
+
+
+def test_lstm_conversion():
+    model = LSTMModel()
+    params = minimal_params()
+    core = convert_model(model, core_params=params)
+    assert any(n.neuron_type == "lstm" for n in core.neurons)
+
+
+def test_gru_conversion():
+    model = GRUModel()
+    params = minimal_params()
+    core = convert_model(model, core_params=params)
+    assert any(n.neuron_type == "gru" for n in core.neurons)
+
+
 def test_embeddingbag_conversion():
     model = EmbeddingBagModel()
     params = minimal_params()


### PR DESCRIPTION
## Summary
- support RNN/LSTM/GRU layers in pytorch_to_marble
- allow tuple indexing by converting ``operator.getitem``
- test recurrent layer conversion
- document new layer support in README
- update converter roadmap

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_pytorch_to_marble.py -k "test_rnn_conversion or test_lstm_conversion or test_gru_conversion" -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ca1b05c08327a8716b2a9b3b32fb