### PR TITLE
Add summary mode to PyTorch converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,10 @@ python convert_model.py --pytorch my_model.pt --output marble_model.marble
 Specify ``--dry-run`` to see the resulting graph statistics without writing a
 file. You can also call ``convert_model`` directly:
 
+For a quick overview without producing an output file you can use ``--summary``
+to print the neuron and synapse counts. ``--summary-output`` writes the same
+information to a JSON file.
+
 ```python
 from pytorch_to_marble import convert_model
 marble_brain = convert_model(torch_model)

--- a/converttodo.md
+++ b/converttodo.md
@@ -98,8 +98,8 @@
 - [x] Per-layer mapping information
 - [ ] Visualize neuron and synapse counts
 
-- [ ] Add `--summary` CLI flag to print dry-run stats
-- [ ] Support saving summary to JSON via `--summary-output`
+- [x] Add `--summary` CLI flag to print dry-run stats
+- [x] Support saving summary to JSON via `--summary-output`
 ### 6. Validation utilities
 - [ ] Validate converted models by comparing PyTorch and MARBLE outputs
   - [ ] Unit tests for small networks
@@ -109,7 +109,7 @@
 
 ### 7. Additional tooling
 - [x] Support converting `.pt` files directly into `.marble` snapshots
-- [ ] Provide auto-inference mode summarizing created graph without saving
+- [x] Provide auto-inference mode summarizing created graph without saving
 - [ ] Command line interface for one-step conversion
 - [ ] Programmatic API returning a `Core` object
 - [ ] YAML configuration for converter options

--- a/pytorch_to_marble.py
+++ b/pytorch_to_marble.py
@@ -572,8 +572,11 @@ def _print_dry_run_summary(core: Core, node_outputs: Dict[str, List[int]]) -> No
 
 
 def convert_model(
-    model: torch.nn.Module, core_params: Dict | None = None, dry_run: bool = False
-) -> Core:
+    model: torch.nn.Module,
+    core_params: Dict | None = None,
+    dry_run: bool = False,
+    return_summary: bool = False,
+) -> Core | tuple[Core, Dict[str, Dict]]:
     """Convert ``model`` into a MARBLE ``Core``."""
     if core_params is None:
         core_params = {
@@ -650,9 +653,15 @@ def convert_model(
             raise UnsupportedLayerError(
                 f"Operation {node.op} is not supported for conversion"
             )
-    if dry_run:
+    summary = {
+        "neurons": len(core.neurons),
+        "synapses": len(core.synapses),
+        "layers": {name: len(ids) for name, ids in node_outputs.items() if name != "output"},
+    }
+    if dry_run or return_summary:
         _print_dry_run_summary(core, node_outputs)
-        return core
+    if return_summary:
+        return core, summary
     return core
 
 

--- a/tests/test_convert_model_cli.py
+++ b/tests/test_convert_model_cli.py
@@ -32,3 +32,40 @@ def test_convert_model_marble(tmp_path):
 
     marble = load_marble_system(str(out_path))
     assert len(marble.get_core().neurons) >= 2
+
+
+def test_convert_model_summary(tmp_path):
+    model = SmallModel()
+    model_path = tmp_path / "model.pt"
+    torch.save(model, model_path)
+
+    script = Path(__file__).resolve().parent.parent / "convert_model.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--pytorch", str(model_path), "--summary"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "[DRY RUN]" in result.stdout
+
+
+def test_convert_model_summary_output(tmp_path):
+    model = SmallModel()
+    model_path = tmp_path / "model.pt"
+    torch.save(model, model_path)
+
+    summary_path = tmp_path / "summary.json"
+    script = Path(__file__).resolve().parent.parent / "convert_model.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--pytorch",
+            str(model_path),
+            "--summary-output",
+            str(summary_path),
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 0
+    assert summary_path.exists()


### PR DESCRIPTION
## Summary
- add optional `--summary` and `--summary-output` flags for the conversion CLI
- support returning summary information from `convert_model`
- document the new flags in README
- mark tasks as completed in `converttodo.md`
- test CLI summary options

## Testing
- `pytest tests/test_pytorch_to_marble.py::test_basic_conversion -q`
- `pytest tests/test_convert_model_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6888ce2ab3a8832795c911ed2902fe3d