### PR TITLE
Add layer wrappers for converter

### DIFF
--- a/converttodo.md
+++ b/converttodo.md
@@ -77,7 +77,9 @@
 ### 2. High-level graph construction API
 - [x] Helper to add neuron groups with activations
 - [x] Helper to add synapses with weights and bias
-- [ ] Parameterized wrappers for linear and convolutional layers
+- [x] Parameterized wrappers for linear and convolutional layers
+  - [x] ``linear_layer`` wrapper
+  - [x] ``conv2d_layer`` wrapper
 - [ ] Documentation for graph builder utilities
 - [ ] Examples demonstrating dynamic message passing setup
 

--- a/marble_graph_builder.py
+++ b/marble_graph_builder.py
@@ -84,3 +84,96 @@ def add_fully_connected_layer(
             core.synapses.append(syn)
 
     return out_ids
+
+
+def linear_layer(
+    core: Core,
+    in_dim: int,
+    out_dim: int,
+    *,
+    weights: Optional[Sequence[Sequence[float]]] = None,
+    bias: Optional[Sequence[float]] = None,
+    activation: Optional[str] = None,
+) -> tuple[List[int], List[int]]:
+    """Create a fully connected layer with freshly allocated neurons.
+
+    Parameters
+    ----------
+    core : Core
+        Target core to extend.
+    in_dim : int
+        Number of input neurons to create.
+    out_dim : int
+        Number of output neurons to create.
+    weights : Optional[Sequence[Sequence[float]]]
+        Optional weight matrix. ``None`` initializes weights to zero.
+    bias : Optional[Sequence[float]]
+        Optional bias vector.
+    activation : Optional[str]
+        Activation type stored in output neuron metadata.
+
+    Returns
+    -------
+    tuple[List[int], List[int]]
+        IDs of created input and output neurons.
+    """
+    inputs = add_neuron_group(core, in_dim)
+    outputs = add_fully_connected_layer(
+        core, inputs, out_dim, weights=weights, bias=bias, activation=activation
+    )
+    return inputs, outputs
+
+
+def conv2d_layer(
+    core: Core,
+    in_channels: int,
+    out_channels: int,
+    kernel_size: int | Sequence[int],
+    *,
+    stride: int | Sequence[int] = 1,
+    padding: int | Sequence[int] = 0,
+    weights: Optional[Sequence[Sequence[Sequence[Sequence[float]]]]] = None,
+    bias: Optional[Sequence[float]] = None,
+) -> tuple[List[int], List[int]]:
+    """Create a Conv2d-like layer using MARBLE primitives."""
+
+    if isinstance(kernel_size, int):
+        kernel_size = (kernel_size, kernel_size)
+    if isinstance(stride, int):
+        stride = (stride, stride)
+    if isinstance(padding, int):
+        padding = (padding, padding)
+
+    inputs = add_neuron_group(core, in_channels)
+
+    out_ids: List[int] = []
+    if weights is None:
+        weights = [
+            [[ [0.0 for _ in range(kernel_size[1])] for _ in range(kernel_size[0])] for _ in range(in_channels)]
+            for _ in range(out_channels)
+        ]
+
+    for j in range(out_channels):
+        nid = len(core.neurons)
+        neuron = Neuron(nid, value=0.0, tier="vram", neuron_type="conv2d")
+        neuron.params["kernel"] = weights[j]
+        neuron.params["stride"] = stride[0]
+        neuron.params["padding"] = padding[0]
+        core.neurons.append(neuron)
+
+        for in_id in inputs:
+            syn = Synapse(in_id, nid, weight=1.0)
+            core.neurons[in_id].synapses.append(syn)
+            core.synapses.append(syn)
+
+        if bias is not None:
+            bias_id = len(core.neurons)
+            core.neurons.append(Neuron(bias_id, value=1.0, tier="vram"))
+            b = float(bias[j])
+            bsyn = Synapse(bias_id, nid, weight=b)
+            core.neurons[bias_id].synapses.append(bsyn)
+            core.synapses.append(bsyn)
+
+        out_ids.append(nid)
+
+    return inputs, out_ids

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -4,7 +4,12 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from marble_core import Core
-from marble_graph_builder import add_neuron_group, add_fully_connected_layer
+from marble_graph_builder import (
+    add_neuron_group,
+    add_fully_connected_layer,
+    linear_layer,
+    conv2d_layer,
+)
 from tests.test_core_functions import minimal_params
 
 
@@ -29,3 +34,30 @@ def test_add_fully_connected_layer_bias_weights():
     # Bias synapses last two
     assert core.synapses[-2].weight == 0.5
     assert core.synapses[-1].weight == -0.5
+
+
+def test_linear_layer_wrapper():
+    core = Core(minimal_params(), formula="0", formula_num_neurons=0)
+    in_ids, out_ids = linear_layer(
+        core,
+        2,
+        2,
+        weights=[[1.0, -1.0], [0.5, 0.5]],
+        bias=[0.1, -0.1],
+        activation="relu",
+    )
+    assert len(in_ids) == 2
+    assert len(out_ids) == 2
+    assert any(n.params.get("activation") == "relu" for n in core.neurons)
+    # bias synapses should exist
+    assert any(s.weight == 0.1 for s in core.synapses)
+
+
+def test_conv2d_layer_wrapper():
+    core = Core(minimal_params(), formula="0", formula_num_neurons=0)
+    in_ids, out_ids = conv2d_layer(core, 1, 1, 2, bias=[0.2])
+    assert len(in_ids) == 1
+    assert len(out_ids) == 1
+    conv_neuron = core.neurons[out_ids[0]]
+    assert conv_neuron.neuron_type == "conv2d"
+    assert "kernel" in conv_neuron.params


### PR DESCRIPTION
## Summary
- implement `linear_layer` and `conv2d_layer` helpers in `marble_graph_builder`
- add unit tests for new helpers
- mark task completed in `converttodo.md`

## Testing
- `pytest tests/test_graph_builder.py tests/test_pytorch_to_marble.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888eb2b30808327897df158a93ce0d5