### PR TITLE
Add transparent Marble layer injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ You can now download the currently active configuration or save it to a custom
 path directly from the sidebar. Advanced mode also features search boxes for
 quickly locating functions by name within ``marble_interface`` or any module.
 The Model Conversion tab now supports searching the Hub for pretrained models so
-they can be converted with a single click.
+they can be converted with a single click. You can also inject MARBLE as a
+transparent layer inside any loaded PyTorch model to monitor or train it in
+parallel without affecting the network's predictions.
 An additional **Visualization** tab renders an interactive graph of the core so
 you can inspect neuron connectivity in real time. You may select a *spring* or
 *circular* layout for this graph. The new **Weight Heatmap** tab displays

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -277,6 +277,8 @@ a minimal web API.
    # before applying them, enabling larger effective batch sizes.
    out = layer(torch.tensor(1.0, requires_grad=True))
    ```
+5. **Inject MARBLE into any PyTorch model** with `attach_marble_layer` to run
+   MARBLE side by side without altering the model output.
 
 **Complete Example**
 ```python

--- a/tests/test_transparent_layer.py
+++ b/tests/test_transparent_layer.py
@@ -1,0 +1,40 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import torch
+from marble_core import Core, DataLoader
+from marble_neuronenblitz import Neuronenblitz
+from marble_brain import Brain
+from marble_interface import attach_marble_layer
+from tests.test_core_functions import minimal_params
+
+
+def test_attach_layer_keeps_output_and_runs_marble():
+    torch.manual_seed(0)
+    base = torch.nn.Sequential(torch.nn.Linear(1, 1), torch.nn.ReLU(), torch.nn.Linear(1, 1))
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader())
+    hooked = attach_marble_layer(base, brain, after=0)
+    inp = torch.tensor([[0.5]])
+    expected = base(inp)
+    brain.neuronenblitz.global_activation_count = 0
+    out = hooked(inp)
+    assert torch.allclose(expected, out)
+    assert brain.neuronenblitz.global_activation_count > 0
+
+
+def test_attach_layer_from_file(tmp_path):
+    model = torch.nn.Sequential(torch.nn.Linear(1, 1))
+    path = tmp_path / "model.pt"
+    torch.save(model, path)
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader())
+    hooked = attach_marble_layer(str(path), brain)
+    inp = torch.tensor([[0.2]])
+    assert torch.allclose(model(inp), hooked(inp))
+    save_path = tmp_path / "hooked.pt"
+    torch.save(hooked, save_path)
+    assert save_path.exists()


### PR DESCRIPTION
## Summary
- implement `TransparentMarbleLayer` for hooking Marble into PyTorch
- provide `attach_marble_layer` and `save_attached_model` helpers
- document PyTorch layer injection in README and tutorial
- test attaching Marble as transparent layer

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_autograd_layer.py tests/test_marble_interface.py tests/test_transparent_layer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6889af5186848327aed24aad11796d4e