### PR TITLE
Add versatile PyTorch model IO utilities

### DIFF
--- a/convert_model.py
+++ b/convert_model.py
@@ -1,7 +1,6 @@
 import argparse
 from pathlib import Path
 
-import torch
 from pytorch_to_marble import convert_model
 from marble_interface import MARBLE, save_marble_system
 from marble_utils import core_to_json
@@ -37,7 +36,8 @@ def main() -> None:
     ):
         parser.error("--output is required unless running in dry-run or summary mode")
 
-    model = torch.load(args.pytorch, map_location="cpu", weights_only=False)
+    from torch_model_io import load_model_auto
+    model = load_model_auto(args.pytorch)
 
     if args.summary or args.summary_output:
         core, summary = convert_model(

--- a/marble.py
+++ b/marble.py
@@ -1,20 +1,14 @@
 import os
-import sys
 import torch
-from typing import Iterable, Any
 import numpy as np
-import json
 import tarfile
-import tempfile
 import requests
 import time
 from pathlib import Path
 from tqdm.notebook import tqdm  # For Jupyter-optimized progress bars
 from PIL import Image
-from io import BytesIO
 import matplotlib.pyplot as plt
 import pickle
-import zlib
 from data_compressor import DataCompressor
 import random
 import math
@@ -96,7 +90,7 @@ def download_and_process_tar(url: str, temp_dir: str | os.PathLike[str]) -> list
         print("Detected LFS pointer file. Downloading actual tar file...")
         lfs_info = content.decode("utf-8").strip().splitlines()
         oid_line = next(line for line in lfs_info if line.startswith("oid sha256:"))
-        oid = oid_line.split(":")[1].strip()
+        _ = oid_line.split(":")[1].strip()
         lfs_url = f"https://huggingface.co/datasets/jackyhate/text-to-image-2M/resolve/main/data_512_2M/data_{url.split('data_')[-1]}"
         response = requests.get(lfs_url, stream=True, headers=headers, allow_redirects=True)
         response.raise_for_status()
@@ -189,7 +183,7 @@ class MetricsVisualizer:
 # -----------------------------------------------------
 
 # 4.1 Neuron and Synapse
-class Neuron:
+class Neuron:  # noqa: F811
     def __init__(self, nid, value=0.0, tier='vram'):
         self.id = nid
         self.value = value
@@ -197,7 +191,7 @@ class Neuron:
         self.synapses = []
         self.formula = None
 
-class Synapse:
+class Synapse:  # noqa: F811
     def __init__(self, source, target, weight=1.0):
         self.source = source
         self.target = target
@@ -237,7 +231,7 @@ def compute_mandelbrot(
     return mandelbrot
 
 # 4.3 Core  Build the neural core (supports multiple worlds: VRAM, RAM, disk)
-class Core:
+class Core:  # noqa: F811
     def __init__(self, params, formula=None, formula_num_neurons=100):
         print("Initializing MARBLE Core...")
         self.params = params
@@ -792,8 +786,9 @@ class MarbleConverter:
                 'max_iter': 50
             }
         if isinstance(model, str):
+            from torch_model_io import load_model_auto
             try:
-                model = torch.load(model, map_location='cpu')
+                model = load_model_auto(model)
             except Exception as e:
                 raise ValueError(f"Error loading model: {e}")
         if init_from_weights:

--- a/marble_interface.py
+++ b/marble_interface.py
@@ -15,6 +15,7 @@ from curriculum_learning import curriculum_train
 from distillation_trainer import DistillationTrainer
 from marble_autograd import MarbleAutogradLayer, TransparentMarbleLayer
 from marble_main import MARBLE
+from marble_brain import Brain
 from marble_utils import core_from_json, core_to_json
 
 warnings.filterwarnings(
@@ -474,10 +475,8 @@ def attach_marble_layer(
     """Return ``model`` with an attached transparent Marble layer."""
 
     if isinstance(model_or_path, str):
-        from torch.serialization import add_safe_globals
-
-        add_safe_globals([torch.nn.modules.container.Sequential])
-        model = torch.load(model_or_path, weights_only=False)
+        from torch_model_io import load_model_auto
+        model = load_model_auto(model_or_path)
     else:
         model = model_or_path
 
@@ -523,4 +522,5 @@ def attach_marble_layer(
 
 def save_attached_model(model: torch.nn.Module, path: str) -> None:
     """Persist ``model`` with attached MARBLE to ``path``."""
-    torch.save(model, path)
+    from torch_model_io import save_entire_model
+    save_entire_model(model, path)

--- a/pytorch_to_marble.py
+++ b/pytorch_to_marble.py
@@ -675,7 +675,8 @@ def main() -> None:
     parser.add_argument("--output", required=True, help="Output JSON path")
     args = parser.parse_args()
 
-    model = torch.load(args.pytorch, map_location="cpu")
+    from torch_model_io import load_model_auto
+    model = load_model_auto(args.pytorch)
     core = convert_model(model)
     js = core_to_json(core)
     with open(args.output, "w", encoding="utf-8") as f:

--- a/tests/test_torch_model_io.py
+++ b/tests/test_torch_model_io.py
@@ -1,0 +1,42 @@
+import torch
+from torch_model_io import (
+    save_state_dict,
+    load_state_dict,
+    save_entire_model,
+    load_entire_model,
+    save_safetensors,
+    load_safetensors,
+)
+
+
+class SmallModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc = torch.nn.Linear(2, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - not needed
+        return self.fc(x)
+
+
+def test_save_and_load_state_dict(tmp_path):
+    model = SmallModel()
+    path = tmp_path / "model_sd.pt"
+    save_state_dict(model, path)
+    loaded = load_state_dict(SmallModel, path)
+    assert isinstance(loaded, SmallModel)
+
+
+def test_save_and_load_entire_model(tmp_path):
+    model = SmallModel()
+    path = tmp_path / "model_entire.pt"
+    save_entire_model(model, path)
+    loaded = load_entire_model(path)
+    assert isinstance(loaded, SmallModel)
+
+
+def test_save_and_load_safetensors(tmp_path):
+    model = SmallModel()
+    path = tmp_path / "model.safetensors"
+    save_safetensors(model, path)
+    loaded = load_safetensors(SmallModel, path)
+    assert isinstance(loaded, SmallModel)

--- a/torch_model_io.py
+++ b/torch_model_io.py
@@ -1,0 +1,144 @@
+import torch
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+try:
+    from safetensors.torch import save_file as st_save_file, load_file as st_load_file
+except Exception:  # pragma: no cover - safetensors optional
+    st_save_file = None
+    st_load_file = None
+
+
+def save_state_dict(model: torch.nn.Module, path: str) -> None:
+    """Save model parameters to ``path`` using :func:`torch.save`."""
+    torch.save(model.state_dict(), path)
+
+
+def load_state_dict(
+    model_class: type,
+    path: str,
+    device: Optional[str | torch.device] = None,
+    strict: bool = True,
+    **init_kwargs: Any,
+) -> torch.nn.Module:
+    """Return a model of ``model_class`` loaded from a saved ``state_dict``."""
+    device = torch.device(device or "cpu")
+    sd = torch.load(path, map_location=device, weights_only=True)
+    model = model_class(**init_kwargs)
+    model.load_state_dict(sd, strict=strict)
+    model.to(device)
+    model.eval()
+    return model
+
+
+def save_entire_model(model: torch.nn.Module, path: str) -> None:
+    """Serialize ``model`` to ``path``."""
+    torch.save(model, path)
+
+
+def load_entire_model(path: str, device: Optional[str | torch.device] = None) -> torch.nn.Module:
+    """Load a model saved with :func:`save_entire_model`."""
+    device = torch.device(device or "cpu")
+    model = torch.load(path, map_location=device, weights_only=False)
+    model.to(device)
+    model.eval()
+    return model
+
+
+def save_exported_program(ep: torch.export.ExportedProgram, path: str) -> None:
+    """Save ``ExportedProgram`` to ``path`` using :func:`torch.export.save`."""
+    torch.export.save(ep, path)
+
+
+def load_exported_program(path: str) -> torch.export.ExportedProgram:
+    """Load ``ExportedProgram`` from ``path``."""
+    return torch.export.load(path)
+
+
+def save_checkpoint(state: Dict[str, Any], path: str) -> None:
+    """Persist checkpoint ``state`` to ``path``."""
+    torch.save(state, path)
+
+
+def load_checkpoint(path: str, device: Optional[str | torch.device] = None) -> Dict[str, Any]:
+    """Return checkpoint dictionary stored at ``path``."""
+    device = torch.device(device or "cpu")
+    return torch.load(path, map_location=device, weights_only=True)
+
+
+def save_multi_model(states: Dict[str, Any], path: str) -> None:
+    """Save multiple model and optimizer states in one file."""
+    torch.save(states, path)
+
+
+def load_multi_model(path: str, device: Optional[str | torch.device] = None) -> Dict[str, Any]:
+    """Load dictionary produced by :func:`save_multi_model`."""
+    device = torch.device(device or "cpu")
+    return torch.load(path, map_location=device, weights_only=True)
+
+
+def warmstart_model(
+    model: torch.nn.Module,
+    state_dict_path: str,
+    device: Optional[str | torch.device] = None,
+    strict: bool = False,
+) -> torch.nn.Module:
+    """Load parameters from ``state_dict_path`` into ``model`` with ``strict=False``."""
+    device = torch.device(device or "cpu")
+    sd = torch.load(state_dict_path, map_location=device, weights_only=True)
+    model.load_state_dict(sd, strict=strict)
+    model.to(device)
+    return model
+
+
+# ===== safetensors helpers =====
+
+def save_safetensors(model: torch.nn.Module, path: str) -> None:
+    """Save model ``state_dict`` using ``safetensors`` if available."""
+    if st_save_file is None:
+        raise RuntimeError("safetensors not installed")
+    st_save_file(model.state_dict(), path)
+
+
+def load_safetensors(
+    model_class: type,
+    path: str,
+    device: Optional[str | torch.device] = None,
+    strict: bool = True,
+    **init_kwargs: Any,
+) -> torch.nn.Module:
+    """Load a model from a safetensors ``state_dict`` file."""
+    if st_load_file is None:
+        raise RuntimeError("safetensors not installed")
+    device = torch.device(device or "cpu")
+    sd = st_load_file(path, device=str(device))
+    model = model_class(**init_kwargs)
+    model.load_state_dict(sd, strict=strict)
+    model.to(device)
+    model.eval()
+    return model
+
+
+# ===== convenience autodetection =====
+
+def load_model_auto(
+    path: str,
+    model_class: Optional[type] = None,
+    device: Optional[str | torch.device] = None,
+    **kwargs: Any,
+) -> torch.nn.Module:
+    """Load a model from ``path`` inferring the correct format from the extension."""
+    ext = Path(path).suffix
+    if ext == ".pt2":
+        return load_exported_program(path)
+    if ext == ".safetensors":
+        if model_class is None:
+            raise ValueError("model_class required for safetensors files")
+        return load_safetensors(model_class, path, device=device, **kwargs)
+    try:
+        if model_class is None:
+            return load_entire_model(path, device=device)
+        return load_state_dict(model_class, path, device=device, **kwargs)
+    except Exception:
+        return load_entire_model(path, device=device)
+


### PR DESCRIPTION
## Summary
- add `torch_model_io` helper for saving/loading PyTorch models
- integrate new IO helpers in `marble_interface`, `convert_model`, `pytorch_to_marble`, and `marble`
- tests covering new model IO helpers
- cleanup unused imports and apply ruff

## Testing
- `pytest tests/test_torch_model_io.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889b7ec1b0c8327ba1682ed0776bff4