### PR TITLE
Enable Hugging Face login utilities

### DIFF
--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -18,3 +18,5 @@ Failed tests during last run of `pytest`:
 - test_wandering_anomaly.py
 - test_web_api.py
 (plus additional failures leading to 126 errors during collection)
+- test_marble_interface.py (missing yaml dependency)
+- test_huggingface_utils.py (missing dependencies)

--- a/huggingface_utils.py
+++ b/huggingface_utils.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from huggingface_hub import login as hf_login, hf_hub_download
+
+HF_TOKEN_PATH = Path.home() / ".huggingface_token"
+_logged_in = False
+
+def auto_hf_login(token_path: Optional[str | Path] = None) -> None:
+    """Login to Hugging Face if a token file exists and login hasn't happened."""
+    global _logged_in
+    if _logged_in:
+        return
+    path = Path(token_path or HF_TOKEN_PATH).expanduser()
+    if path.exists():
+        token = path.read_text().strip()
+        if token:
+            hf_login(token=token)
+            _logged_in = True
+
+def download_hf_model(repo_id: str, filename: str, *, cache_dir: str | None = None) -> str:
+    """Download ``filename`` from ``repo_id`` and return the local path."""
+    auto_hf_login()
+    return hf_hub_download(repo_id, filename, cache_dir=cache_dir)

--- a/marble_interface.py
+++ b/marble_interface.py
@@ -218,15 +218,20 @@ def convert_pytorch_model(
     )
 
 
+from huggingface_utils import auto_hf_login
+
+
 def load_hf_dataset(
     dataset_name: str,
     split: str,
     input_key: str = "input",
     target_key: str = "target",
     limit: int | None = None,
+    streaming: bool = False,
 ) -> list[tuple[Any, Any]]:
     """Load a Hugging Face dataset and return ``(input, target)`` pairs."""
-    ds = load_dataset(dataset_name, split=split)
+    auto_hf_login()
+    ds = load_dataset(dataset_name, split=split, streaming=streaming)
     examples: list[tuple[Any, Any]] = []
     for record in ds:
         examples.append((record[input_key], record[target_key]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -114,9 +114,9 @@ tensorboard-data-server==0.7.2
 threadpoolctl==3.6.0
 tokenizers==0.19.1
 toml==0.10.2
-torch==2.7.1+cpu
-torchaudio==2.7.1+cpu
-torchvision==0.22.1+cpu
+torch==2.3.0
+torchaudio==2.3.0
+torchvision==0.18.0
 tornado==6.5.1
 tqdm==4.67.1
 traitlets==5.14.3

--- a/streamlit_playground.py
+++ b/streamlit_playground.py
@@ -40,6 +40,7 @@ import torch
 import yaml
 from PIL import Image
 from transformers import AutoModel
+from huggingface_utils import auto_hf_login, download_hf_model
 
 import marble_interface
 from marble_interface import (
@@ -239,6 +240,7 @@ def search_hf_datasets(query: str, limit: int = 20) -> list[str]:
     """Return dataset IDs from the Hugging Face Hub matching ``query``."""
     from huggingface_hub import HfApi
 
+    auto_hf_login()
     api = HfApi()
     datasets = api.list_datasets(search=query, limit=limit)
     return [d.id for d in datasets]
@@ -248,6 +250,7 @@ def search_hf_models(query: str, limit: int = 20) -> list[str]:
     """Return model IDs from the Hugging Face Hub matching ``query``."""
     from huggingface_hub import HfApi
 
+    auto_hf_login()
     api = HfApi()
     models = api.list_models(search=query, limit=limit)
     return [m.id for m in models]
@@ -298,6 +301,7 @@ def select_high_attention_neurons(marble, threshold: float = 1.0) -> list[int]:
 
 def load_hf_model(model_name: str):
     """Return a pretrained model from the Hugging Face Hub."""
+    auto_hf_login()
     return AutoModel.from_pretrained(model_name, trust_remote_code=True)
 
 

--- a/tests/test_huggingface_utils.py
+++ b/tests/test_huggingface_utils.py
@@ -1,0 +1,34 @@
+import huggingface_utils as hfu
+
+
+def test_auto_hf_login(monkeypatch, tmp_path):
+    token = tmp_path / "token"
+    token.write_text("tok")
+    monkeypatch.setattr(hfu, "HF_TOKEN_PATH", token)
+    called = {}
+
+    def fake_login(token=None):
+        called["token"] = token
+
+    monkeypatch.setattr(hfu, "hf_login", fake_login)
+    hfu._logged_in = False
+    hfu.auto_hf_login()
+    assert called["token"] == "tok"
+    called["token"] = None
+    hfu.auto_hf_login()
+    assert called["token"] is None
+
+
+def test_download_hf_model(monkeypatch):
+    called = {}
+
+    def fake_download(repo_id, filename, cache_dir=None):
+        called["args"] = (repo_id, filename, cache_dir)
+        return "/tmp/x"
+
+    monkeypatch.setattr(hfu, "hf_hub_download", fake_download)
+    monkeypatch.setattr(hfu, "auto_hf_login", lambda: called.setdefault("login", True))
+    path = hfu.download_hf_model("repo", "file")
+    assert called["login"]
+    assert called["args"] == ("repo", "file", None)
+    assert path == "/tmp/x"


### PR DESCRIPTION
## Summary
- add `huggingface_utils` with automatic Hugging Face login
- use `auto_hf_login` for dataset/model operations
- add streaming parameter for `load_hf_dataset`
- update Torch packages for installation
- add unit tests for the new utilities
- record failing tests

## Testing
- `pytest tests/test_marble_interface.py -k test_load_dataset_and_dataframe_training -q`
- `pytest tests/test_huggingface_utils.py tests/test_marble_interface.py tests/test_streamlit_playground.py -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6889bf345f6c83279f57bf23e7efeab7