### PR TITLE
Implement huggingface login and streaming dataset support

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1355,6 +1355,8 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
        "mnist", "train[:100]", input_key="image", target_key="label"
    )
    ```
+   If the dataset requires authentication place your Hugging Face token in
+   `~/.cache/marble/hf_token`. The helper will log in automatically.
 2. **Load a CSV dataset from a URL** using the `dataset_loader` utility:
    ```python
    from dataset_loader import load_dataset

--- a/huggingface_utils.py
+++ b/huggingface_utils.py
@@ -1,0 +1,72 @@
+import os
+from typing import Any, Iterable
+
+from datasets import load_dataset
+from huggingface_hub import HfApi, login
+from transformers import AutoModel
+
+HF_TOKEN_FILE = os.path.expanduser("~/.cache/marble/hf_token")
+
+
+def hf_login(token: str | None = None, token_file: str = HF_TOKEN_FILE) -> str | None:
+    """Login to the Hugging Face Hub using ``token``.
+
+    If ``token`` is ``None`` and ``token_file`` exists, the token is read from the
+    file. After a successful login the token is saved back to ``token_file``. The
+    token is returned so callers can pass it to API functions that expect it.
+    """
+    if token is None:
+        token_path = os.path.expanduser(token_file)
+        if os.path.exists(token_path):
+            with open(token_path, "r", encoding="utf-8") as f:
+                token = f.read().strip()
+            if token:
+                login(token=token)
+                return token
+        return None
+
+    login(token=token)
+    token_path = os.path.expanduser(token_file)
+    os.makedirs(os.path.dirname(token_path), exist_ok=True)
+    with open(token_path, "w", encoding="utf-8") as f:
+        f.write(token.strip())
+    return token
+
+
+def hf_load_dataset(
+    dataset_name: str,
+    split: str,
+    input_key: str = "input",
+    target_key: str = "target",
+    limit: int | None = None,
+    streaming: bool = False,
+) -> list[tuple[Any, Any]]:
+    """Return ``(input, target)`` pairs from a Hugging Face dataset."""
+    token = hf_login()
+    ds = load_dataset(dataset_name, split=split, token=token, streaming=streaming)
+    examples: list[tuple[Any, Any]] = []
+    for record in ds:
+        examples.append((record[input_key], record[target_key]))
+        if limit is not None and len(examples) >= limit:
+            break
+    return examples
+
+
+def hf_load_model(model_name: str):
+    """Return a pretrained model from the Hugging Face Hub."""
+    hf_login()
+    return AutoModel.from_pretrained(model_name, trust_remote_code=True)
+
+
+def search_hf_datasets(query: str, limit: int = 20) -> list[str]:
+    """Return dataset IDs from the Hugging Face Hub matching ``query``."""
+    hf_login()
+    datasets = HfApi().list_datasets(search=query, limit=limit)
+    return [d.id for d in datasets]
+
+
+def search_hf_models(query: str, limit: int = 20) -> list[str]:
+    """Return model IDs from the Hugging Face Hub matching ``query``."""
+    hf_login()
+    models = HfApi().list_models(search=query, limit=limit)
+    return [m.id for m in models]

--- a/marble_interface.py
+++ b/marble_interface.py
@@ -9,6 +9,8 @@ import pandas as pd
 import torch
 from datasets import load_dataset
 
+from huggingface_utils import hf_login
+
 from autoencoder_learning import AutoencoderLearner
 from config_loader import create_marble_from_config, load_config
 from curriculum_learning import curriculum_train
@@ -224,9 +226,11 @@ def load_hf_dataset(
     input_key: str = "input",
     target_key: str = "target",
     limit: int | None = None,
+    streaming: bool = False,
 ) -> list[tuple[Any, Any]]:
     """Load a Hugging Face dataset and return ``(input, target)`` pairs."""
-    ds = load_dataset(dataset_name, split=split)
+    token = hf_login()
+    ds = load_dataset(dataset_name, split=split, token=token, streaming=streaming)
     examples: list[tuple[Any, Any]] = []
     for record in ds:
         examples.append((record[input_key], record[target_key]))

--- a/streamlit_playground.py
+++ b/streamlit_playground.py
@@ -39,7 +39,13 @@ import streamlit.components.v1 as components
 import torch
 import yaml
 from PIL import Image
-from transformers import AutoModel
+
+from huggingface_utils import (
+    hf_load_dataset,
+    hf_load_model,
+    search_hf_datasets as hf_search_datasets_fn,
+    search_hf_models as hf_search_models_fn,
+)
 
 import marble_interface
 from marble_interface import (
@@ -52,7 +58,6 @@ from marble_interface import (
     import_core_from_json,
     increase_marble_representation,
     infer_marble_system,
-    load_hf_dataset,
     load_marble_system,
     new_marble_system,
     randomize_core_representations,
@@ -232,25 +237,19 @@ def load_hf_examples(
     limit: int | None = None,
 ) -> list[tuple]:
     """Load ``(input, target)`` pairs from a Hugging Face dataset."""
-    return load_hf_dataset(dataset_name, split, input_key, target_key, limit)
+    return hf_load_dataset(
+        dataset_name, split, input_key, target_key, limit, streaming=False
+    )
 
 
 def search_hf_datasets(query: str, limit: int = 20) -> list[str]:
     """Return dataset IDs from the Hugging Face Hub matching ``query``."""
-    from huggingface_hub import HfApi
-
-    api = HfApi()
-    datasets = api.list_datasets(search=query, limit=limit)
-    return [d.id for d in datasets]
+    return hf_search_datasets_fn(query, limit)
 
 
 def search_hf_models(query: str, limit: int = 20) -> list[str]:
     """Return model IDs from the Hugging Face Hub matching ``query``."""
-    from huggingface_hub import HfApi
-
-    api = HfApi()
-    models = api.list_models(search=query, limit=limit)
-    return [m.id for m in models]
+    return hf_search_models_fn(query, limit)
 
 
 def lobe_info(marble) -> list[dict]:
@@ -298,7 +297,7 @@ def select_high_attention_neurons(marble, threshold: float = 1.0) -> list[int]:
 
 def load_hf_model(model_name: str):
     """Return a pretrained model from the Hugging Face Hub."""
-    return AutoModel.from_pretrained(model_name, trust_remote_code=True)
+    return hf_load_model(model_name)
 
 
 def model_summary(model: torch.nn.Module) -> str:

--- a/tests/test_huggingface_utils.py
+++ b/tests/test_huggingface_utils.py
@@ -1,0 +1,42 @@
+import os
+from unittest import mock
+
+from huggingface_utils import hf_login, hf_load_dataset, hf_load_model
+
+
+def test_hf_login_reads_and_writes(tmp_path):
+    token_file = tmp_path / "token"
+    token_file.write_text("abc")
+    with mock.patch("huggingface_utils.login") as login_mock:
+        tok = hf_login(token_file=str(token_file))
+        login_mock.assert_called_once_with(token="abc")
+        assert tok == "abc"
+
+    with mock.patch("huggingface_utils.login") as login_mock:
+        tok = hf_login(token="xyz", token_file=str(token_file))
+        login_mock.assert_called_once_with(token="xyz")
+        assert token_file.read_text() == "xyz"
+        assert tok == "xyz"
+
+
+def test_hf_load_dataset_streaming():
+    dummy = [{"input": 1, "target": 2}, {"input": 3, "target": 4}]
+    with mock.patch(
+        "huggingface_utils.hf_login", return_value=None
+    ) as login_mock, mock.patch(
+        "huggingface_utils.load_dataset", return_value=dummy
+    ) as ld:
+        pairs = hf_load_dataset("dummy", "train", streaming=True)
+    login_mock.assert_called_once()
+    ld.assert_called_once_with("dummy", split="train", token=None, streaming=True)
+    assert pairs == [(1, 2), (3, 4)]
+
+
+def test_hf_load_model():
+    with mock.patch("huggingface_utils.hf_login") as login_mock, mock.patch(
+        "huggingface_utils.AutoModel.from_pretrained", return_value="m"
+    ) as fm:
+        model = hf_load_model("bert")
+    login_mock.assert_called_once()
+    fm.assert_called_once_with("bert", trust_remote_code=True)
+    assert model == "m"

--- a/tests/test_marble_interface.py
+++ b/tests/test_marble_interface.py
@@ -81,8 +81,16 @@ def test_load_dataset_and_dataframe_training(tmp_path):
     marble_main.MetricsVisualizer = MetricsVisualizer
 
     dummy = [{"input": 0.1, "target": 0.2}, {"input": 0.2, "target": 0.4}]
-    with patch("marble_interface.load_dataset", return_value=dummy):
-        pairs = load_hf_dataset("dummy", "train")
+    with patch(
+        "marble_interface.hf_login", return_value=None
+    ) as login_mock, patch(
+        "marble_interface.load_dataset", return_value=dummy
+    ) as ld:
+        pairs = load_hf_dataset("dummy", "train", streaming=True)
+    login_mock.assert_called_once()
+    ld.assert_called_once_with(
+        "dummy", split="train", token=None, streaming=True
+    )
     assert pairs == [(0.1, 0.2), (0.2, 0.4)]
 
     cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -13,6 +13,9 @@ dataset:
   offline: When ``true`` no network access is attempted. Remote datasets must
     already exist in ``cache_dir`` or a ``FileNotFoundError`` is raised. Use
     this to run experiments on machines without internet connectivity.
+  hf_token: Path to a file containing your Hugging Face API token. When the
+    file exists Marble automatically logs in before downloading datasets or
+    models. The default location is ``~/.cache/marble/hf_token``.
 logging:
   structured: When true, all logs are emitted as JSON objects. This simplifies parsing in tools like Logstash or Splunk.
   log_file: File path where structured logs are written. If set to ``null`` the logs go to stderr.


### PR DESCRIPTION
## Summary
- support automatic Hugging Face login and model/dataset download helpers
- use the new helpers in `marble_interface` and Streamlit GUI
- document token usage in `yaml-manual.txt` and tutorial
- add regression tests for the new utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889bf345f6c83279f57bf23e7efeab7