### PR TITLE
Add diffusion core with docs and tests

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -57,6 +57,10 @@ Each entry is listed under its section heading.
 - early_cleanup_enabled
 - pretraining_epochs
 - min_cluster_k
+- diffusion_steps
+- noise_start
+- noise_end
+- noise_schedule
 - cross_tier_migration
 - synapse_echo_length
 - synapse_echo_decay

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ abstract ideas not present in the training data.
 The Hybrid Memory Architecture augments MARBLE with a vector store and symbolic
 database so long conversations can be recalled accurately and hallucinations are
 reduced.
+DiffusionCore leverages Neuronenblitz wandering for iterative denoising so
+diffusion models can be trained and sampled entirely within MARBLE.
 
 MARBLE can train on datasets provided as lists of ``(input, target)`` pairs or using PyTorch-style ``Dataset``/``DataLoader`` objects. Each sample must expose an ``input`` and ``target`` field. After training and saving a model, ``Brain.infer`` generates outputs when given only an input value.
 For quick experiments without external files you can generate synthetic regression pairs using ``synthetic_dataset.generate_sine_wave_dataset``.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1587,9 +1587,37 @@ plugins and components.
    import episodic_simulation
 
    mem = episodic_memory.EpisodicMemory()
-   rewards = episodic_simulation.simulate(nb, mem, length=5)
+  rewards = episodic_simulation.simulate(nb, mem, length=5)
+  ```
+  The list ``rewards`` contains predicted outcomes for the top episodes.
+
+## Project 31 – Diffusion Core (Advanced)
+
+**Goal:** Generate samples using MARBLE's dedicated diffusion engine.
+
+1. **Enable diffusion settings** by adding the parameters ``diffusion_steps``,
+   ``noise_start``, ``noise_end`` and ``noise_schedule`` under ``core`` in
+   ``config.yaml``. The defaults perform ten linear denoising steps.
+2. **Create the DiffusionCore** directly:
+   ```python
+   from config_loader import load_config
+   from diffusion_core import DiffusionCore
+
+   cfg = load_config()
+   dcore = DiffusionCore(cfg["core"])
+   output = dcore.diffuse(0.0)
+   print("Final value", output)
    ```
-   The list ``rewards`` contains predicted outcomes for the top episodes.
+3. **Store intermediate results** by enabling the ``hybrid_memory`` section in
+   the configuration. Each diffusion step is embedded and saved so similar
+   samples can be retrieved later.
+4. **Offload** the core automatically when VRAM usage exceeds
+   ``offload_threshold`` by passing a ``RemoteBrainClient`` to
+   ``DiffusionCore``.
+
+Running this project demonstrates the new ``DiffusionCore`` which integrates
+Neuronenblitz wandering, hybrid memory and remote offloading to support
+diffusion-based models in a fully data type agnostic way.
 
 
 ## Organising Multiple Experiments

--- a/config.yaml
+++ b/config.yaml
@@ -71,6 +71,10 @@ core:
   early_cleanup_enabled: false
   pretraining_epochs: 0
   min_cluster_k: 2
+  diffusion_steps: 10
+  noise_start: 1.0
+  noise_end: 0.1
+  noise_schedule: "linear"
 # Neuronenblitz learning system parameters
 
   synapse_echo_length: 5

--- a/diffusion_core.py
+++ b/diffusion_core.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import Any
+
+from marble_imports import *  # noqa: F401,F403
+from marble_core import Core, DataLoader, perform_message_passing
+from marble_neuronenblitz import Neuronenblitz
+from hybrid_memory import HybridMemory
+
+
+class DiffusionCore(Core):
+    """MARBLE core extension for diffusion-based generation."""
+
+    def __init__(
+        self,
+        params: dict | None = None,
+        *,
+        diffusion_steps: int | None = None,
+        noise_start: float | None = None,
+        noise_end: float | None = None,
+        noise_schedule: str | None = None,
+        remote_client: Any | None = None,
+        metrics_visualizer: "MetricsVisualizer | None" = None,
+    ) -> None:
+        params = params.copy() if params is not None else {}
+        if diffusion_steps is not None:
+            params.setdefault("diffusion_steps", diffusion_steps)
+        if noise_start is not None:
+            params.setdefault("noise_start", noise_start)
+        if noise_end is not None:
+            params.setdefault("noise_end", noise_end)
+        if noise_schedule is not None:
+            params.setdefault("noise_schedule", noise_schedule)
+        super().__init__(params, metrics_visualizer=metrics_visualizer)
+        self.diffusion_steps = int(self.params.get("diffusion_steps", 10))
+        self.noise_start = float(self.params.get("noise_start", 1.0))
+        self.noise_end = float(self.params.get("noise_end", 0.1))
+        self.noise_schedule = self.params.get("noise_schedule", "linear")
+        self.neuronenblitz = Neuronenblitz(self)
+        self.loader = DataLoader()
+        self.remote_client = remote_client
+        self.history: deque[float] = deque(maxlen=100)
+        self.hybrid_memory: HybridMemory | None = None
+        if "hybrid_memory" in self.params:
+            hm = self.params["hybrid_memory"]
+            self.hybrid_memory = HybridMemory(
+                self,
+                self.neuronenblitz,
+                vector_path=hm.get("vector_store_path", "vector_store.pkl"),
+                symbolic_path=hm.get("symbolic_store_path", "symbolic_memory.pkl"),
+                max_entries=hm.get("max_entries", 1000),
+            )
+
+    def _noise_level(self, step: int) -> float:
+        if self.noise_schedule == "linear":
+            ratio = step / max(1, self.diffusion_steps - 1)
+            return self.noise_start * (1 - ratio) + self.noise_end * ratio
+        if self.noise_schedule == "cosine":
+            ratio = (math.cos(math.pi * step / self.diffusion_steps) + 1) / 2
+            return self.noise_end + (self.noise_start - self.noise_end) * ratio
+        raise ValueError(f"Unknown noise_schedule: {self.noise_schedule}")
+
+    def diffuse(self, data: Any) -> float:
+        """Generate a value by iteratively denoising ``data``."""
+        tensor = self.loader.encode(data)
+        if hasattr(tensor, "mean"):
+            value = float(cp.asnumpy(tensor).astype(float).mean())
+        else:
+            value = float(tensor)
+        current = value
+        for step in range(self.diffusion_steps):
+            noise = random.gauss(0.0, self._noise_level(step))
+            out, path = self.neuronenblitz.dynamic_wander(current + noise)
+            self.neuronenblitz.apply_weight_updates_and_attention(path, 0.0)
+            perform_message_passing(self)
+            if self.hybrid_memory is not None:
+                self.hybrid_memory.store(f"step_{step}", out)
+            current = out
+        self.history.append(current)
+        if (
+            self.remote_client is not None
+            and self.get_usage_by_tier("vram")
+            > self.params.get("offload_threshold", 1.0)
+        ):
+            try:
+                self.remote_client.offload(self)
+            except Exception:
+                pass
+        return current

--- a/tests/test_diffusion_core.py
+++ b/tests/test_diffusion_core.py
@@ -1,0 +1,14 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from tests.test_core_functions import minimal_params
+from diffusion_core import DiffusionCore
+
+
+def test_diffusion_core_runs():
+    params = minimal_params()
+    params["diffusion_steps"] = 3
+    core = DiffusionCore(params)
+    out = core.diffuse(0.0)
+    assert isinstance(out, float)
+    assert core.history

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -169,6 +169,15 @@ core:
     training begins.
   min_cluster_k: Smallest number of clusters allowed when ``cluster_neurons``
     is invoked automatically.
+  diffusion_steps: Number of denoising iterations performed during diffusion
+    sampling. Values above ``1`` produce smoother results but increase
+    computation time.
+  noise_start: Standard deviation of the Gaussian noise applied at the first
+    diffusion step. Higher values start the process from a noisier state.
+  noise_end: Noise level used for the final diffusion step. Typically set close
+    to ``0.0`` for crisp outputs.
+  noise_schedule: Schedule controlling how the noise decreases across
+    ``diffusion_steps``. Valid options are ``"linear"`` or ``"cosine"``.
   cross_tier_migration: When ``true`` neurons may move between tiers even if
     their age thresholds have not been reached.
   synapse_echo_length: Number of past activations each synapse stores in its


### PR DESCRIPTION
## Summary
- implement `DiffusionCore` for iterative denoising
- document new diffusion parameters and project
- extend default `config.yaml`
- update configurable parameter list and YAML manual
- add basic unit test for diffusion core

## Testing
- `pytest -q tests/test_diffusion_core.py`
- `pytest -q tests/test_config.py`

------
https://chatgpt.com/codex/tasks/task_e_6889d79f6ac4832781e1a650e863abf3