### PR TITLE
Extend diffusion core features

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -61,6 +61,7 @@ Each entry is listed under its section heading.
 - noise_start
 - noise_end
 - noise_schedule
+- workspace_broadcast
 - cross_tier_migration
 - synapse_echo_length
 - synapse_echo_decay

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ database so long conversations can be recalled accurately and hallucinations are
 reduced.
 DiffusionCore leverages Neuronenblitz wandering for iterative denoising so
 diffusion models can be trained and sampled entirely within MARBLE.
+When ``workspace_broadcast`` is enabled the final sample of each diffusion run
+is published through the Global Workspace so other modules can react in real
+time.
 
 MARBLE can train on datasets provided as lists of ``(input, target)`` pairs or using PyTorch-style ``Dataset``/``DataLoader`` objects. Each sample must expose an ``input`` and ``target`` field. After training and saving a model, ``Brain.infer`` generates outputs when given only an input value.
 For quick experiments without external files you can generate synthetic regression pairs using ``synthetic_dataset.generate_sine_wave_dataset``.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1614,6 +1614,9 @@ plugins and components.
 4. **Offload** the core automatically when VRAM usage exceeds
    ``offload_threshold`` by passing a ``RemoteBrainClient`` to
    ``DiffusionCore``.
+5. **Broadcast results** by setting ``workspace_broadcast: true`` under
+   ``core``. Each call to ``diffuse`` then publishes the final sample through the
+   Global Workspace so plugins can react.
 
 Running this project demonstrates the new ``DiffusionCore`` which integrates
 Neuronenblitz wandering, hybrid memory and remote offloading to support

--- a/config.yaml
+++ b/config.yaml
@@ -75,6 +75,7 @@ core:
   noise_start: 1.0
   noise_end: 0.1
   noise_schedule: "linear"
+  workspace_broadcast: false
 # Neuronenblitz learning system parameters
 
   synapse_echo_length: 5

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,6 +30,7 @@ def test_load_config_defaults():
     assert cfg["core"]["tier_autotune_enabled"] is True
     assert cfg["core"]["memory_cleanup_interval"] == 60
     assert cfg["core"]["representation_noise_std"] == 0.0
+    assert cfg["core"]["workspace_broadcast"] is False
     assert cfg["core"]["gradient_clip_value"] == 1.0
     assert cfg["core"]["synapse_weight_decay"] == 0.0
     assert cfg["core"]["message_passing_iterations"] == 1
@@ -148,6 +149,7 @@ def test_create_marble_from_config():
     assert marble.dataloader.compressor.level == 6
     assert marble.core.rep_size == 4
     assert marble.core.params["message_passing_alpha"] == 0.5
+    assert marble.core.params["workspace_broadcast"] is False
     assert marble.core.synapse_weight_decay == 0.0
     assert marble.brain.loss_growth_threshold == 0.1
     assert marble.brain.dream_cycle_sleep == 0.1

--- a/tests/test_diffusion_core_features.py
+++ b/tests/test_diffusion_core_features.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import global_workspace
+from neuromodulatory_system import NeuromodulatorySystem
+from diffusion_core import DiffusionCore
+from tests.test_core_functions import minimal_params
+
+
+def test_diffusion_core_workspace_broadcast():
+    params = minimal_params()
+    params["diffusion_steps"] = 1
+    params["workspace_broadcast"] = True
+    gw = global_workspace.activate(capacity=1)
+    ns = NeuromodulatorySystem()
+    core = DiffusionCore(params, neuromodulatory_system=ns)
+    out = core.diffuse(0.0)
+    assert isinstance(out, float)
+    assert gw.queue and gw.queue[-1].content == out
+

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -178,6 +178,9 @@ core:
     to ``0.0`` for crisp outputs.
   noise_schedule: Schedule controlling how the noise decreases across
     ``diffusion_steps``. Valid options are ``"linear"`` or ``"cosine"``.
+  workspace_broadcast: Set to ``true`` to publish each diffusion result to the
+    Global Workspace. Components subscribed to the workspace can then react to
+    new samples in real time.
   cross_tier_migration: When ``true`` neurons may move between tiers even if
     their age thresholds have not been reached.
   synapse_echo_length: Number of past activations each synapse stores in its


### PR DESCRIPTION
## Summary
- integrate neuromodulatory adjustments and Global Workspace broadcast
- add `workspace_broadcast` parameter with docs and defaults
- document the new option in YAML manual and tutorial
- update config and README references
- test broadcasting behaviour and config loading

## Testing
- `pytest tests/test_diffusion_core.py -q`
- `pytest tests/test_diffusion_core_features.py -q`
- `pytest tests/test_config.py::test_load_config_defaults tests/test_config.py::test_create_marble_from_config -q`

------
https://chatgpt.com/codex/tasks/task_e_6889da1a8c808327ba99272da291ad52