### PR TITLE
Allow partial config merge, enhance diffusion metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ python cli.py --config config.yaml --train data.csv --epochs 5 \
 
 See ``python cli.py --help`` for the full list of options.
 
+Configuration files passed via ``--config`` may contain only the parameters you
+want to override.  Any missing options fall back to the defaults defined in
+``config.yaml``.
+
 Any Python object can serve as an ``input`` or ``target`` because the built-in
 ``DataLoader`` serializes data through ``DataCompressor``. This makes it
 possible to train on multimodal pairs such as text-to-image, image-to-text or

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -57,6 +57,9 @@ This tutorial demonstrates every major component of MARBLE through a series of p
 4. **Edit configuration**. Open `config.yaml` and modify the values under `core` to adjust the representation size and other parameters. Save the file after your edits.
    To experiment with sparser communication set `attention_dropout` to a value between `0.0` and `1.0`. Higher values randomly ignore more incoming messages during attention-based updates.
    You can also introduce oscillatory gating of synaptic weights by setting `global_phase_rate` to a value above `0.0`. Each call to `run_message_passing` then advances the internal `global_phase`, modulating every synapse via a cosine of its individual `phase`.
+   You may also provide a *partial* YAML file containing only the settings you
+   wish to override. `load_config` merges it with the defaults from
+   `config.yaml` automatically.
 5. **Create a MARBLE instance** from the configuration:
    ```python
    from marble_main import MARBLE

--- a/config_loader.py
+++ b/config_loader.py
@@ -15,15 +15,6 @@ from torrent_offload import BrainTorrentClient, BrainTorrentTracker
 DEFAULT_CONFIG_FILE = Path(__file__).resolve().parent / "config.yaml"
 
 
-def load_config(path: str | None = None) -> dict:
-    """Load configuration from a YAML file."""
-    cfg_path = Path(path) if path is not None else DEFAULT_CONFIG_FILE
-    with open(cfg_path, "r", encoding="utf-8") as f:
-        data = yaml.safe_load(f) or {}
-    validate_config_schema(data)
-    return data
-
-
 def _deep_update(base: dict, updates: dict) -> None:
     """Recursively update ``base`` with values from ``updates``."""
     for key, val in updates.items():
@@ -31,6 +22,20 @@ def _deep_update(base: dict, updates: dict) -> None:
             _deep_update(base[key], val)
         else:
             base[key] = val
+
+
+def load_config(path: str | None = None) -> dict:
+    """Load configuration from a YAML file and merge with defaults."""
+    with open(DEFAULT_CONFIG_FILE, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    if path is not None:
+        cfg_path = Path(path)
+        if cfg_path.is_file():
+            with open(cfg_path, "r", encoding="utf-8") as f:
+                overrides = yaml.safe_load(f) or {}
+            _deep_update(data, overrides)
+    validate_config_schema(data)
+    return data
 
 
 def create_marble_from_config(

--- a/diffusion_core.py
+++ b/diffusion_core.py
@@ -93,9 +93,18 @@ class DiffusionCore(Core):
             if self.hybrid_memory is not None:
                 self.hybrid_memory.store(f"step_{step}", out)
             if self.metrics_visualizer is not None:
-                self.metrics_visualizer.update({"diffusion_noise": abs(noise)})
+                rep_matrix = cp.stack([n.representation for n in self.neurons])
+                variance = float(cp.var(rep_matrix))
+                self.metrics_visualizer.update(
+                    {
+                        "diffusion_noise": abs(noise),
+                        "representation_variance": variance,
+                    }
+                )
             current = out
         self.history.append(current)
+        if self.metrics_visualizer is not None:
+            self.metrics_visualizer.update({"diffusion_output": current})
         if (
             self.remote_client is not None
             and self.get_usage_by_tier("vram")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -225,3 +225,14 @@ def test_invalid_config_raises(tmp_path):
         yaml.safe_dump(cfg, f)
     with pytest.raises(jsonschema.ValidationError):
         load_config(str(cfg_path))
+
+
+def test_partial_config_merges_defaults(tmp_path):
+    partial = {"core": {"width": 5}}
+    cfg_path = tmp_path / "partial.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(partial, f)
+    cfg = load_config(str(cfg_path))
+    default = load_config()
+    assert cfg["core"]["width"] == 5
+    assert cfg["core"]["height"] == default["core"]["height"]

--- a/tests/test_diffusion_core_features.py
+++ b/tests/test_diffusion_core_features.py
@@ -6,6 +6,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import global_workspace
 from neuromodulatory_system import NeuromodulatorySystem
 from diffusion_core import DiffusionCore
+from marble_base import MetricsVisualizer
 from tests.test_core_functions import minimal_params
 
 
@@ -19,4 +20,14 @@ def test_diffusion_core_workspace_broadcast():
     out = core.diffuse(0.0)
     assert isinstance(out, float)
     assert gw.queue and gw.queue[-1].content == out
+
+
+def test_diffusion_core_metrics_logged():
+    params = minimal_params()
+    params["diffusion_steps"] = 1
+    mv = MetricsVisualizer()
+    core = DiffusionCore(params, metrics_visualizer=mv)
+    out = core.diffuse(0.0)
+    assert mv.metrics["diffusion_output"][-1] == out
+    assert mv.metrics["representation_variance"], "variance metric missing"
 

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -5,6 +5,10 @@ internal JSON schema to catch missing sections or invalid values early.
 A sample configuration with inline comments can be generated using the
 `config_generator.py` script. Run `python config_generator.py` to create `sample_config_with_comments.yaml` which mirrors `config.yaml` but includes descriptions for each parameter.
 
+Any configuration file may specify only a subset of parameters. Missing values
+are automatically filled with the defaults from `config.yaml`, allowing small
+YAML snippets to override just the options you need.
+
 dataset:
   num_shards: Number of shards the training dataset is split into. When greater
     than ``1`` each training worker should set ``shard_index`` to a unique value


### PR DESCRIPTION
## Summary
- support partial configuration files by merging with defaults
- log variance and final output metrics in `DiffusionCore`
- document partial YAML behaviour in README, tutorial and manual
- test configuration merging and new diffusion metrics

## Testing
- `pytest tests/test_config.py`
- `pytest tests/test_config_additional.py`
- `pytest tests/test_diffusion_core.py`
- `pytest tests/test_diffusion_core_features.py`


------
https://chatgpt.com/codex/tasks/task_e_6889dd61c3d883278f41db61e771636d