### PR TITLE
Enhance DiffusionCore capabilities

### DIFF
--- a/diffusion_core.py
+++ b/diffusion_core.py
@@ -12,6 +12,10 @@ from marble_core import Core, DataLoader, perform_message_passing
 from marble_base import MetricsVisualizer
 from marble_neuronenblitz import Neuronenblitz
 from hybrid_memory import HybridMemory
+from plugin_system import load_plugins
+from neural_schema_induction import NeuralSchemaInductionLearner
+import predictive_coding
+import torch
 
 
 class DiffusionCore(Core):
@@ -29,6 +33,9 @@ class DiffusionCore(Core):
         neuromodulatory_system: NeuromodulatorySystem | None = None,
         remote_client: Any | None = None,
         metrics_visualizer: "MetricsVisualizer | None" = None,
+        predictive_coding_params: dict | None = None,
+        schema_induction_params: dict | None = None,
+        plugin_dirs: list[str] | None = None,
     ) -> None:
         params = params.copy() if params is not None else {}
         if diffusion_steps is not None:
@@ -64,6 +71,24 @@ class DiffusionCore(Core):
                 symbolic_path=hm.get("symbolic_store_path", "symbolic_memory.pkl"),
                 max_entries=hm.get("max_entries", 1000),
             )
+        self.schema_learner: NeuralSchemaInductionLearner | None = None
+        if schema_induction_params:
+            self.schema_learner = NeuralSchemaInductionLearner(
+                self,
+                self.neuronenblitz,
+                support_threshold=schema_induction_params.get("support_threshold", 2),
+                max_schema_size=schema_induction_params.get("max_schema_size", 3),
+            )
+        self.predictive_coding = None
+        if predictive_coding_params is not None:
+            self.predictive_coding = predictive_coding.activate(
+                self.neuronenblitz,
+                num_layers=predictive_coding_params.get("num_layers", 2),
+                latent_dim=predictive_coding_params.get("latent_dim", self.rep_size),
+                learning_rate=predictive_coding_params.get("learning_rate", 0.001),
+            )
+        if plugin_dirs:
+            load_plugins(plugin_dirs)
 
     def _noise_level(self, step: int) -> float:
         if self.noise_schedule == "linear":
@@ -82,12 +107,23 @@ class DiffusionCore(Core):
         else:
             value = float(tensor)
         current = value
+        if self.hybrid_memory is not None:
+            retrieved = self.hybrid_memory.retrieve(current, top_k=1)
+            if retrieved:
+                current = float(retrieved[0][1])
         for step in range(self.diffusion_steps):
             noise = random.gauss(0.0, self._noise_level(step))
             if self.neuromodulatory_system is not None:
                 ctx = self.neuromodulatory_system.get_context()
                 noise *= 1.0 + ctx.get("stress", 0.0) - ctx.get("reward", 0.0)
+            if self.predictive_coding is not None:
+                _ = self.predictive_coding.step(
+                    torch.tensor([current + noise], dtype=torch.float32)
+                )
             out, path = self.neuronenblitz.dynamic_wander(current + noise)
+            if self.schema_learner is not None:
+                self.schema_learner._record_sequence(path)
+                self.schema_learner._induce_schemas()
             self.neuronenblitz.apply_weight_updates_and_attention(path, 0.0)
             perform_message_passing(self)
             if self.hybrid_memory is not None:

--- a/tests/test_diffusion_core_extra_features.py
+++ b/tests/test_diffusion_core_extra_features.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from tests.test_core_functions import minimal_params
+from diffusion_core import DiffusionCore
+from marble_core import NEURON_TYPES
+
+
+def test_diffusion_core_predictive_and_schema(tmp_path):
+    params = minimal_params()
+    params["diffusion_steps"] = 1
+    plugin_file = tmp_path / "myplugin.py"
+    plugin_file.write_text("def register(reg_neuron, reg_synapse):\n    reg_neuron('schema_neuron')\n")
+
+    core = DiffusionCore(
+        params,
+        predictive_coding_params={"num_layers": 1, "latent_dim": 4, "learning_rate": 0.001},
+        schema_induction_params={"support_threshold": 1, "max_schema_size": 2},
+        plugin_dirs=[str(tmp_path)],
+    )
+
+    initial = len(core.neurons)
+    out = core.diffuse(0.2)
+    assert isinstance(out, float)
+    assert "schema_neuron" in NEURON_TYPES
+    assert len(core.neurons) > initial
+    assert core.predictive_coding is not None
+


### PR DESCRIPTION
## Summary
- expand DiffusionCore with predictive coding, schema induction, plugin loading and hybrid memory retrieval
- exercise new features in tests

## Testing
- `pytest tests/test_diffusion_core.py -q`
- `pytest tests/test_diffusion_core_features.py -q`
- `pytest tests/test_diffusion_core_extra_features.py -q`
- `pytest tests/test_predictive_coding_plugin.py -q`
- `pytest tests/test_neural_schema_induction.py -q`
- `pytest tests/test_plugin_system.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6889dfe8fecc83278005e040b02982c0