### PR TITLE
Extend DiffusionCore features

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -62,6 +62,11 @@ Each entry is listed under its section heading.
 - noise_end
 - noise_schedule
 - workspace_broadcast
+- activation_output_dir
+- memory_system
+- cwfl
+- harmonic
+- fractal
 - cross_tier_migration
 - synapse_echo_length
 - synapse_echo_decay

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1620,6 +1620,12 @@ plugins and components.
 5. **Broadcast results** by setting ``workspace_broadcast: true`` under
    ``core``. Each call to ``diffuse`` then publishes the final sample through the
    Global Workspace so plugins can react.
+6. **Enable advanced features** by adding ``activation_output_dir``, ``memory_system``,
+   ``cwfl``, ``harmonic`` and ``fractal`` sections under ``core``. With these set
+   the diffusion engine stores each step in hierarchical memory, trains the
+   continuous weight field, adapts representations via harmonic resonance and
+   fractal learning and finally writes an activation heatmap to the configured
+   directory.
 
 Running this project demonstrates the new ``DiffusionCore`` which integrates
 Neuronenblitz wandering, hybrid memory and remote offloading to support

--- a/config.yaml
+++ b/config.yaml
@@ -76,6 +76,21 @@ core:
   noise_end: 0.1
   noise_schedule: "linear"
   workspace_broadcast: false
+  activation_output_dir: "activations"
+  memory_system:
+    long_term_path: "diffusion_memory.pkl"
+    threshold: 0.5
+    consolidation_interval: 10
+  cwfl:
+    num_basis: 10
+    bandwidth: 1.0
+    reg_lambda: 0.01
+    learning_rate: 0.01
+  harmonic:
+    base_frequency: 1.0
+    decay: 0.99
+  fractal:
+    target_dimension: 4.0
 # Neuronenblitz learning system parameters
 
   synapse_echo_length: 5

--- a/tests/test_diffusion_core_additional_features.py
+++ b/tests/test_diffusion_core_additional_features.py
@@ -1,0 +1,43 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from tests.test_core_functions import minimal_params
+from diffusion_core import DiffusionCore
+from marble_core import MemorySystem
+
+
+def test_diffusion_core_additional_features(tmp_path):
+    params = minimal_params()
+    params["diffusion_steps"] = 1
+    params["activation_output_dir"] = str(tmp_path)
+    params["memory_system"] = {
+        "long_term_path": str(tmp_path / "lt.pkl"),
+        "threshold": 0.5,
+        "consolidation_interval": 1,
+    }
+    params["cwfl"] = {"num_basis": 2}
+    params["harmonic"] = {"base_frequency": 1.0, "decay": 0.9}
+    params["fractal"] = {"target_dimension": 2.0}
+
+    ms = MemorySystem(long_term_path=params["memory_system"]["long_term_path"],
+                      threshold=0.5, consolidation_interval=1)
+
+    core = DiffusionCore(
+        params,
+        memory_system=ms,
+        cwfl_params=params["cwfl"],
+        harmonic_params=params["harmonic"],
+        fractal_params=params["fractal"],
+        activation_output_dir=params["activation_output_dir"],
+    )
+    out = core.diffuse(0.1)
+    assert isinstance(out, float)
+    assert (tmp_path / "diffusion_1.png").exists()
+    assert ms.retrieve("diffusion_output") == out
+    if core.cwfl is not None:
+        assert core.cwfl.history
+    if core.harmonic is not None:
+        assert core.harmonic.history
+    if core.fractal is not None:
+        assert core.fractal.history

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -185,6 +185,33 @@ core:
   workspace_broadcast: Set to ``true`` to publish each diffusion result to the
     Global Workspace. Components subscribed to the workspace can then react to
     new samples in real time.
+  activation_output_dir: Directory where a heatmap of neuron activations is
+    written after every diffusion run. Useful for visualising internal state
+    evolution. The directory is created automatically if it does not exist.
+  memory_system:
+    long_term_path: File used for persistent storage of diffusion outputs. Both
+      short- and long-term layers are utilised so recent results can be cached
+      in RAM while important entries are kept on disk.
+    threshold: Neuromodulatory value above which entries bypass short-term
+      storage. Typical values fall between ``0.3`` and ``0.7``.
+    consolidation_interval: Number of stored items between automatic disk
+      consolidation.
+  cwfl:
+    num_basis: Number of radial basis functions forming the smooth weight
+      field. More bases allow finer detail but require additional computation.
+    bandwidth: Spread of each basis function controlling the locality of weight
+      influence.
+    reg_lambda: L2 penalty applied to basis weights to prevent divergence.
+    learning_rate: Step size used when updating the weight field each step.
+  harmonic:
+    base_frequency: Starting frequency for the harmonic encoder that converts
+      scalar inputs into oscillatory representations.
+    decay: Multiplicative factor applied after each update so the active
+      frequency gradually decreases and stabilises.
+  fractal:
+    target_dimension: Desired fractal dimension of the representation space.
+      When the measured dimension exceeds this threshold the core expands its
+      representation size to capture additional structure.
   cross_tier_migration: When ``true`` neurons may move between tiers even if
     their age thresholds have not been reached.
   synapse_echo_length: Number of past activations each synapse stores in its


### PR DESCRIPTION
## Summary
- integrate additional Marble capabilities into `DiffusionCore`
- expose new configuration options for the advanced features
- document parameters in the YAML manual and parameter list
- mention the new options in the tutorial
- test the new DiffusionCore functionality

## Testing
- `pytest tests/test_diffusion_core.py -q`
- `pytest tests/test_diffusion_core_features.py -q`
- `pytest tests/test_diffusion_core_extra_features.py -q`
- `pytest tests/test_diffusion_core_additional_features.py -q`
- `pytest tests/test_continuous_weight_field_learning.py -q`
- `pytest tests/test_harmonic_resonance_learning.py -q`
- `pytest tests/test_fractal_dimension_learning.py -q`
- `pytest tests/test_hierarchical_memory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6889e3adea8c8327bc4bb9550ccc55c5