### PR TITLE
Add pipeline class and CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ Pipelines can be imported or exported as JSON and a **Custom Code** tab lets you
 run arbitrary Python snippets with the active MARBLE instance.
 Pipeline steps may also be reordered or removed directly from the UI so complex
 workflows can be iterated on quickly.
+You can run the same JSON pipelines from the command line using ``--pipeline``
+with ``cli.py`` or execute them programmatically through the ``Pipeline``
+class for full automation.
 Multiple MARBLE systems can be created in one session. Use the *Active Instance*
 selector in the sidebar to switch between them, duplicate a system for
 comparison or delete instances you no longer need.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1448,6 +1448,9 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
    ``marble_interface`` or any repository module, then press **Run Pipeline** to
    execute them sequentially. This lets you combine training, evaluation and
    analysis commands without leaving the UI.
+    The same pipelines can be saved as JSON and executed from the command line
+    using ``python cli.py --pipeline mypipe.json`` or through the ``Pipeline``
+    class in your own scripts.
 12. **View the core graph** on the *Visualization* tab. Press **Generate Graph**
    to see an interactive display of neurons and synapses.
 13. **Inspect synaptic weights** on the *Weight Heatmap* tab. Set a maximum

--- a/cli.py
+++ b/cli.py
@@ -36,6 +36,10 @@ def main() -> None:
     parser.add_argument("--min-lr", type=float, help="Minimum learning rate")
     parser.add_argument("--max-lr", type=float, help="Maximum learning rate")
     parser.add_argument(
+        "--pipeline",
+        help="Path to a pipeline JSON file to execute after initialization",
+    )
+    parser.add_argument(
         "--early-stopping-patience",
         type=int,
         help="Patience for early stopping",
@@ -115,6 +119,13 @@ def main() -> None:
         eval_data = load_dataset(args.evaluate)
         mse = evaluate_marble_system(marble, eval_data)
         print(f"Evaluation MSE: {mse:.6f}")
+    if args.pipeline:
+        from pipeline import Pipeline
+
+        with open(args.pipeline, "r", encoding="utf-8") as f:
+            pipe = Pipeline.load_json(f)
+        results = pipe.execute(marble)
+        print(results)
     if args.save:
         save_marble_system(marble, args.save)
     if args.export_core:

--- a/examples/interactive_llm_pipeline.py
+++ b/examples/interactive_llm_pipeline.py
@@ -1,0 +1,75 @@
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from marble_main import insert_into_torch_model, MARBLE
+from config_loader import load_config
+from pipeline import Pipeline
+
+
+model = None
+tokenizer = None
+marble = None
+cfg = None
+
+
+def load_llm(llm_name: str) -> None:
+    global model, tokenizer
+    model = AutoModelForCausalLM.from_pretrained(llm_name, device_map="auto")
+    tokenizer = AutoTokenizer.from_pretrained(llm_name)
+
+
+def init_marble(cfg_path: str) -> None:
+    global marble, cfg
+    cfg = load_config(cfg_path)
+    marble = MARBLE(cfg["core"])
+
+
+def inject_layer(position: str, mode: str = "intermediate") -> None:
+    global model, marble
+    if model is None or marble is None:
+        raise RuntimeError("Model and MARBLE must be initialised first")
+    model, _ = insert_into_torch_model(model, marble=marble, position=position, mode=mode)
+
+
+def interactive_chat() -> None:
+    global model, tokenizer, marble
+    if model is None or tokenizer is None or marble is None:
+        raise RuntimeError("Pipeline not initialised")
+    print("\nMARBLE-Enhanced Chat Interface Ready. Type 'exit' to quit.\n")
+    history = []
+    while True:
+        user_input = input("You: ")
+        if user_input.lower() == "exit":
+            break
+        history.append({"role": "user", "content": user_input})
+        prompt = "\n".join([f"{m['role']}: {m['content']}" for m in history]) + "\nassistant:"
+        inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
+        with torch.no_grad():
+            outputs = model.generate(**inputs, max_new_tokens=100, do_sample=True)
+        response = (
+            tokenizer.decode(outputs[0], skip_special_tokens=True)
+            .split("assistant:")[-1]
+            .strip()
+        )
+        print("MARBLE LLM:", response)
+        history.append({"role": "assistant", "content": response})
+        marble.brain.observe_input_output(user_input, response)
+        marble.brain.consolidate()
+
+
+def main() -> None:
+    llm_name = "TheBloke/Mistral-7B-Instruct-v0.2-GPTQ"
+    pipe = Pipeline()
+    pipe.add_step("load_llm", module=__name__, params={"llm_name": llm_name})
+    pipe.add_step("init_marble", module=__name__, params={"cfg_path": "config.yaml"})
+    pipe.add_step(
+        "inject_layer",
+        module=__name__,
+        params={"position": "model.layers.10", "mode": "intermediate"},
+    )
+    pipe.add_step("interactive_chat", module=__name__)
+    pipe.execute()
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+import json
+from typing import Any
+
+import marble_interface
+
+
+class Pipeline:
+    """Sequence of function calls executable with an optional MARBLE instance."""
+
+    def __init__(self, steps: list[dict] | None = None) -> None:
+        self.steps: list[dict] = steps or []
+
+    def add_step(self, func: str, *, module: str | None = None, params: dict | None = None) -> None:
+        self.steps.append({"func": func, "module": module, "params": params or {}})
+
+    def remove_step(self, index: int) -> None:
+        if index < 0 or index >= len(self.steps):
+            raise IndexError("index out of range")
+        self.steps.pop(index)
+
+    def move_step(self, old_index: int, new_index: int) -> None:
+        if old_index < 0 or old_index >= len(self.steps):
+            raise IndexError("old_index out of range")
+        if new_index < 0 or new_index >= len(self.steps):
+            raise IndexError("new_index out of range")
+        step = self.steps.pop(old_index)
+        self.steps.insert(new_index, step)
+
+    def execute(self, marble: Any | None = None) -> list[Any]:
+        results: list[Any] = []
+        for step in self.steps:
+            module_name = step.get("module")
+            func_name = step["func"]
+            params = step.get("params", {})
+            results.append(self._execute_function(module_name, func_name, marble, params))
+        return results
+
+    def _execute_function(self, module_name: str | None, func_name: str, marble: Any, params: dict) -> Any:
+        module = importlib.import_module(module_name) if module_name else marble_interface
+        if not hasattr(module, func_name):
+            raise ValueError(f"Unknown function: {func_name}")
+        func = getattr(module, func_name)
+        sig = inspect.signature(func)
+        kwargs = {}
+        for name, p in sig.parameters.items():
+            if name == "marble" and marble is not None:
+                kwargs[name] = marble
+                continue
+            if name in params:
+                kwargs[name] = params[name]
+            elif p.default is not inspect.Parameter.empty:
+                kwargs[name] = p.default
+            else:
+                raise ValueError(f"Missing parameter: {name}")
+        return func(**kwargs)
+
+    def save_json(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(self.steps, f, indent=2)
+
+    @classmethod
+    def load_json(cls, file_obj) -> "Pipeline":
+        steps = json.load(file_obj)
+        return cls(steps=steps)

--- a/tests/test_cli_pipeline.py
+++ b/tests/test_cli_pipeline.py
@@ -1,0 +1,24 @@
+import os, sys, subprocess, json
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from tests.test_core_functions import minimal_params
+
+
+def test_cli_pipeline(tmp_path):
+    cfg = tmp_path / "cfg.yaml"
+    import yaml
+
+    cfg.write_text(yaml.safe_dump({"core": minimal_params()}))
+    pipe_path = tmp_path / "pipe.json"
+    pipeline = [{"func": "count_marble_synapses"}]
+    pipe_path.write_text(json.dumps(pipeline))
+    result = subprocess.run([
+        sys.executable,
+        "cli.py",
+        "--config",
+        str(cfg),
+        "--pipeline",
+        str(pipe_path),
+    ], capture_output=True)
+    assert result.returncode == 0
+    assert b"[" in result.stdout
+

--- a/tests/test_pipeline_class.py
+++ b/tests/test_pipeline_class.py
@@ -1,0 +1,27 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from pipeline import Pipeline
+from marble_main import MARBLE
+from marble_interface import count_marble_synapses
+from tests.test_core_functions import minimal_params
+
+
+def test_pipeline_run(tmp_path):
+    params = minimal_params()
+    marble = MARBLE(params)
+    pipe = Pipeline([{"func": "count_marble_synapses"}])
+    results = pipe.execute(marble)
+    assert len(results) == 1
+    assert isinstance(results[0], int)
+
+
+def test_pipeline_save_load(tmp_path):
+    pipe = Pipeline([{"func": "count_marble_synapses"}])
+    path = tmp_path / "p.json"
+    pipe.save_json(path)
+    with open(path, "r", encoding="utf-8") as f:
+        loaded = Pipeline.load_json(f)
+    assert loaded.steps == pipe.steps
+
+


### PR DESCRIPTION
## Summary
- add `Pipeline` class for programmatic workflows
- add `--pipeline` option to CLI to execute JSON pipelines
- expose `insert_into_torch_model` helper
- provide example interactive LLM pipeline
- document pipeline usage and update tutorial
- add tests for new pipeline functionality

## Testing
- `pytest tests/test_pipeline_class.py -q`
- `pytest tests/test_cli_pipeline.py -q`
- `pytest tests/test_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6889eb70e9448327bcf23436bb70176b