### PR TITLE
Add training support to DiffusionPairsPipeline

### DIFF
--- a/diffusion_pairs_pipeline.py
+++ b/diffusion_pairs_pipeline.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Tuple
+import pickle
+
+from diffusion_core import DiffusionCore
+from marble_neuronenblitz import Neuronenblitz
+from marble_brain import Brain
+from marble_imports import cp
+from marble_core import DataLoader
+
+
+class DiffusionPairsPipeline:
+    """Train a MARBLE with ``DiffusionCore`` on ``(input, expected)`` pairs.
+
+    The pipeline converts arbitrary input and target objects to numeric values
+    using the :class:`DataLoader` embedded in ``DiffusionCore`` so it works with
+    any data type. After training for the requested number of epochs, the full
+    model (core and neuronenblitz) is pickled to ``save_path`` for later
+    inference.
+    """
+
+    def __init__(self, core: DiffusionCore, save_path: str = "trained_marble.pkl") -> None:
+        self.core = core
+        self.loader = core.loader if hasattr(core, "loader") else DataLoader()
+        self.save_path = save_path
+        self.nb = Neuronenblitz(self.core)
+        self.brain = Brain(self.core, self.nb, self.loader)
+
+    def _to_float(self, obj: Any) -> float:
+        tensor = self.loader.encode(obj)
+        if hasattr(tensor, "mean"):
+            return float(cp.asnumpy(tensor).astype(float).mean())
+        return float(tensor)
+
+    def train(self, pairs: Iterable[Tuple[Any, Any]], epochs: int = 1) -> str:
+        examples = [(self._to_float(i), self._to_float(t)) for i, t in pairs]
+        self.nb.train(examples, epochs=epochs)
+        with open(self.save_path, "wb") as f:
+            pickle.dump({"core": self.core, "neuronenblitz": self.nb}, f)
+        return self.save_path

--- a/tests/test_diffusion_pairs_pipeline.py
+++ b/tests/test_diffusion_pairs_pipeline.py
@@ -1,0 +1,30 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from diffusion_core import DiffusionCore
+from diffusion_pairs_pipeline import DiffusionPairsPipeline
+from tests.test_core_functions import minimal_params
+
+
+def test_diffusion_pairs_pipeline_trains(tmp_path):
+    params = minimal_params()
+    params["diffusion_steps"] = 1
+    core = DiffusionCore(params)
+    save_path = tmp_path / "model.pkl"
+    pipeline = DiffusionPairsPipeline(core, save_path=str(save_path))
+    pairs = [(0.0, 0.1), (0.2, 0.3)]
+    out_path = pipeline.train(pairs, epochs=1)
+    assert out_path == str(save_path)
+    assert save_path.is_file()
+
+
+def test_diffusion_pairs_pipeline_non_numeric(tmp_path):
+    params = minimal_params()
+    params["diffusion_steps"] = 1
+    core = DiffusionCore(params)
+    save_path = tmp_path / "model.pkl"
+    pipeline = DiffusionPairsPipeline(core, save_path=str(save_path))
+    pairs = [("hello", "foo"), ("world", "bar")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()


### PR DESCRIPTION
## Summary
- modify `DiffusionPairsPipeline` to train using DiffusionCore
- save the trained core and neuronenblitz to disk
- update unit tests to verify training and saving

## Testing
- `pytest tests/test_diffusion_pairs_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6889ef4c5a808327aa44db24fdc8a8f1