### PR TITLE
Implement metadata and round‑trip checks for DataLoader

### DIFF
--- a/marble_brain.py
+++ b/marble_brain.py
@@ -159,6 +159,7 @@ class Brain:
         self.neuronenblitz = neuronenblitz
         self.nb = neuronenblitz
         self.dataloader = dataloader
+        self.neuronenblitz.dataloader = dataloader
         self.save_threshold = save_threshold
         self.max_saved_models = max_saved_models
         self.save_dir = save_dir
@@ -645,7 +646,9 @@ class Brain:
         output, _ = self.neuronenblitz.dynamic_wander(
             float(input_value), apply_plasticity=False
         )
-        return float(output)
+        if self.dataloader is not None:
+            output = self.dataloader.decode(self.dataloader.encode(output))
+        return float(output) if isinstance(output, (int, float)) else output
 
     def generate_chain_of_thought(self, input_value):
         """Return output and a chain of reasoning steps for the given input."""

--- a/marble_neuronenblitz/core.py
+++ b/marble_neuronenblitz/core.py
@@ -287,6 +287,7 @@ class Neuronenblitz:
         self.torrent_client = torrent_client
         self.torrent_map = torrent_map if torrent_map is not None else {}
         self.metrics_visualizer = metrics_visualizer
+        self.dataloader = None
         self.last_message_passing_change = 0.0
         self.lock = threading.RLock()
         self.error_history = deque(maxlen=100)
@@ -1384,6 +1385,8 @@ class Neuronenblitz:
                 else:
                     output_value, path = self.dynamic_wander(input_value)
                     error = self._compute_loss(target_value, output_value)
+                    if self.dataloader is not None:
+                        error += self.dataloader.round_trip_penalty_for(input_value)
                 path_length = self.apply_weight_updates_and_attention(path, error)
             else:
                 if self.use_mixed_precision and torch.cuda.is_available():
@@ -1394,6 +1397,8 @@ class Neuronenblitz:
                 else:
                     output_value, path = self.dynamic_wander(input_value)
                     error = self._compute_loss(target_value, output_value)
+                    if self.dataloader is not None:
+                        error += self.dataloader.round_trip_penalty_for(input_value)
                 path_length = self.apply_weight_updates_and_attention(path, error)
             self.add_to_replay(input_value, target_value, error)
             self.error_history.append(abs(error))

--- a/tests/test_marble_dataloader.py
+++ b/tests/test_marble_dataloader.py
@@ -61,3 +61,29 @@ def test_marble_dataloader_array_custom_dtype():
     assert str(tensor.dtype) == "int16"
     decoded = dl.decode_array(tensor)
     assert np.allclose(decoded, arr)
+
+
+def test_marble_dataloader_various_types_roundtrip():
+    dl = DataLoader()
+    samples = [
+        "text",
+        np.ones((2, 2), dtype=np.uint8),
+        b"\x00\x01\x02",
+    ]
+    for item in samples:
+        restored = dl.decode(dl.encode(item))
+        if isinstance(item, np.ndarray):
+            assert np.array_equal(restored, item)
+        else:
+            assert restored == item
+
+
+class _NeverEqual:
+    def __eq__(self, other):
+        return False
+
+
+def test_round_trip_penalty():
+    dl = DataLoader(enable_round_trip_check=True, round_trip_penalty=0.5)
+    obj = _NeverEqual()
+    assert dl.round_trip_penalty_for(obj) == 0.5


### PR DESCRIPTION
## Summary
- extend `DataLoader` with metadata tracking and round‑trip penalty
- apply round‑trip checking in Neuronenblitz training
- make `Brain` pass the dataloader to Neuronenblitz and decode inference outputs
- test various dataloader round trips and penalty handling

## Testing
- `pytest -q tests/test_marble_dataloader.py`
- `pytest -q tests/test_brain_io.py`


------
https://chatgpt.com/codex/tasks/task_e_688a06a4228c8327957cd1d96b253915