### PR TITLE
Implement tokenizer support and embed in checkpoints

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -305,6 +305,9 @@ Each entry is listed under its section heading.
 
 ## dataloader
 - tensor_dtype
+- tokenizer_type
+- tokenizer_json
+- tokenizer_vocab_size
 
 ## experiment_tracker
 - enabled

--- a/TODO.md
+++ b/TODO.md
@@ -241,4 +241,8 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [x] Update yaml-manual with plugin parameters.
    - [x] Add troubleshooting section.
    - [x] Provide example configuration files.
+116. [ ] Complete remaining items from ``dataupgradetodo.md``
+   - [ ] Extend dataset loading utilities to leverage the enhanced ``DataLoader``.
+   - [ ] Add migration tests for old checkpoints without embedded tokenizers.
+   - [ ] Document tokenizer training workflow in more detail.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1650,3 +1650,13 @@ python main.py
 ```
 
 to train using the default settings.
+
+## Tokenizing Text Input
+
+MARBLE's ``DataLoader`` can transparently tokenize strings using the
+``tokenizers`` library. Set ``tokenizer_type`` in the ``dataloader`` section of
+``config.yaml`` (for example ``bert_wordpiece``) or provide a path via
+``tokenizer_json`` to load a custom tokenizer. When enabled, all text data is
+converted to token IDs before being fed into the network and decoded back after
+inference. The ``tokenizer_vocab_size`` parameter controls the vocabulary size
+when training a tokenizer from scratch using the YAML configuration.

--- a/config.yaml
+++ b/config.yaml
@@ -320,6 +320,9 @@ data_compressor:
   compression_algorithm: "zlib"
 dataloader:
   tensor_dtype: "uint8"
+  tokenizer_type: null
+  tokenizer_json: null
+  tokenizer_vocab_size: 30000
 experiment_tracker:
   enabled: false
   project: "marble"

--- a/config_loader.py
+++ b/config_loader.py
@@ -111,6 +111,9 @@ def create_marble_from_config(
         "compression_enabled": compression_enabled,
         "tensor_dtype": tensor_dtype,
     }
+    for key in ["tokenizer_type", "tokenizer_json", "tokenizer_vocab_size"]:
+        if key in dataloader_cfg:
+            dataloader_params[key] = dataloader_cfg[key]
 
     autograd_params = cfg.get("autograd", {})
     gw_cfg = cfg.get("global_workspace", {})

--- a/config_schema.py
+++ b/config_schema.py
@@ -60,6 +60,15 @@ CONFIG_SCHEMA = {
                 "compression_algorithm": {"type": "string", "enum": ["zlib", "lzma"]},
             },
         },
+        "dataloader": {
+            "type": "object",
+            "properties": {
+                "tensor_dtype": {"type": "string"},
+                "tokenizer_type": {"type": ["string", "null"]},
+                "tokenizer_json": {"type": ["string", "null"]},
+                "tokenizer_vocab_size": {"type": "integer", "minimum": 1},
+            },
+        },
         "plugins": {
             "type": ["array", "string"],
             "items": {"type": "string"},

--- a/marble_brain.py
+++ b/marble_brain.py
@@ -594,6 +594,13 @@ class Brain:
             "random_state": random.getstate(),
             "numpy_state": np.random.get_state(),
         }
+        if (
+            self.dataloader is not None
+            and getattr(self.dataloader, "tokenizer", None) is not None
+        ):
+            from tokenizer_utils import tokenizer_to_json
+
+            state["tokenizer_json"] = tokenizer_to_json(self.dataloader.tokenizer)
         import gzip
         import tempfile
 
@@ -628,6 +635,10 @@ class Brain:
         self.lobe_manager = state["lobe_manager"]
         random.setstate(state["random_state"])
         np.random.set_state(state["numpy_state"])
+        if "tokenizer_json" in state and self.dataloader is not None:
+            from tokenizer_utils import tokenizer_from_json
+
+            self.dataloader.tokenizer = tokenizer_from_json(state["tokenizer_json"])
         print(f"Checkpoint loaded from {path}")
         return int(state["epoch"])
 

--- a/marble_core.py
+++ b/marble_core.py
@@ -19,6 +19,7 @@ from marble_base import MetricsVisualizer
 from marble_imports import *  # noqa: F401,F403,F405
 import torch
 import torch.distributed as dist
+from tokenizers import Tokenizer
 
 
 def init_distributed(world_size: int, rank: int = 0, backend: str = "gloo") -> bool:
@@ -1369,6 +1370,7 @@ class DataLoader:
         metrics_visualizer: "MetricsVisualizer | None" = None,
         tensor_dtype: str = "uint8",
         *,
+        tokenizer: "Tokenizer | None" = None,
         track_metadata: bool = True,
         round_trip_penalty: float = 0.0,
         enable_round_trip_check: bool = False,
@@ -1383,6 +1385,7 @@ class DataLoader:
         )
         self.metrics_visualizer = metrics_visualizer
         self.tensor_dtype = cp.dtype(tensor_dtype)
+        self.tokenizer = tokenizer
         self.track_metadata = track_metadata
         self.round_trip_penalty = round_trip_penalty
         self.enable_round_trip_check = enable_round_trip_check
@@ -1397,8 +1400,16 @@ class DataLoader:
         return a == b
 
     def encode(self, data: Any) -> np.ndarray:
+        tokenized = False
+        original_type = data.__class__
+        if self.tokenizer is not None and isinstance(data, str):
+            ids = self.tokenizer.encode(data).ids
+            data = np.asarray(ids, dtype=np.int32)
+            tokenized = True
         if self.track_metadata:
-            meta = {"module": data.__class__.__module__, "type": data.__class__.__name__}
+            meta = {"module": original_type.__module__, "type": original_type.__name__}
+            if tokenized:
+                meta["tokenized"] = True
             payload = {"__marble_meta__": meta, "payload": data}
             serialized = pickle.dumps(payload)
         else:
@@ -1424,7 +1435,16 @@ class DataLoader:
             self.metrics_visualizer.update({"compression_ratio": ratio})
         data = pickle.loads(serialized)
         if isinstance(data, dict) and "__marble_meta__" in data and "payload" in data:
-            data = data["payload"]
+            meta = data["__marble_meta__"]
+            payload = data["payload"]
+            if meta.get("tokenized") and self.tokenizer is not None:
+                if isinstance(payload, np.ndarray):
+                    tokens = payload.tolist()
+                else:
+                    tokens = list(payload)
+                data = self.tokenizer.decode(tokens)
+            else:
+                data = payload
         return data
 
     def round_trip_penalty_for(self, value: Any) -> float:

--- a/marble_main.py
+++ b/marble_main.py
@@ -82,15 +82,28 @@ class MARBLE:
         dl_level = 6
         dl_enabled = True
         dl_dtype = "uint8"
+        tokenizer = None
         if dataloader_params is not None:
             dl_level = dataloader_params.get("compression_level", dl_level)
             dl_enabled = dataloader_params.get("compression_enabled", True)
             dl_dtype = dataloader_params.get("tensor_dtype", dl_dtype)
+            tok_type = dataloader_params.get("tokenizer_type")
+            tok_json = dataloader_params.get("tokenizer_json")
+            tok_vocab = dataloader_params.get("tokenizer_vocab_size", 30000)
+            if tok_json:
+                from tokenizer_utils import load_tokenizer
+
+                tokenizer = load_tokenizer(tok_json)
+            elif tok_type:
+                from tokenizer_utils import built_in_tokenizer
+
+                tokenizer = built_in_tokenizer(tok_type, vocab_size=tok_vocab)
         self.dataloader = DataLoader(
             compression_level=dl_level,
             compression_enabled=dl_enabled,
             metrics_visualizer=self.metrics_visualizer,
             tensor_dtype=dl_dtype,
+            tokenizer=tokenizer,
         )
 
         nb_defaults = {

--- a/tests/test_tokenizer_dataloader.py
+++ b/tests/test_tokenizer_dataloader.py
@@ -1,0 +1,44 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import numpy as np
+from marble import DataLoader
+from tokenizer_utils import built_in_tokenizer
+
+
+def test_dataloader_tokenizer_roundtrip(tmp_path):
+    text_file = tmp_path / "train.txt"
+    text_file.write_text("hello world\nhello marble")
+    tok = built_in_tokenizer("bert_wordpiece", lowercase=True)
+    tok.train([str(text_file)], vocab_size=20)
+    dl = DataLoader(tokenizer=tok)
+    text = "hello marble"
+    encoded = dl.encode(text)
+    decoded = dl.decode(encoded)
+    assert decoded == text
+
+def test_checkpoint_preserves_tokenizer(tmp_path):
+    from marble_core import Core
+    from marble_neuronenblitz import Neuronenblitz
+    from marble_brain import Brain
+    from tests.test_core_functions import minimal_params
+
+    text_file = tmp_path / "train.txt"
+    text_file.write_text("hello world")
+    tok = built_in_tokenizer("bert_wordpiece", lowercase=True)
+    tok.train([str(text_file)], vocab_size=20)
+    dl = DataLoader(tokenizer=tok)
+
+    core = Core(minimal_params())
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, dl, save_dir=str(tmp_path))
+    ckpt = tmp_path / "ckpt.pkl"
+    brain.save_checkpoint(str(ckpt), epoch=1)
+
+    new_dl = DataLoader()
+    new_brain = Brain(core, nb, new_dl, save_dir=str(tmp_path))
+    new_brain.load_checkpoint(str(ckpt))
+    assert new_brain.dataloader.tokenizer is not None
+    encoded = new_brain.dataloader.encode("hello world")
+    decoded = new_brain.dataloader.decode(encoded)
+    assert decoded == "hello world"

--- a/tokenizer_utils.py
+++ b/tokenizer_utils.py
@@ -1,0 +1,67 @@
+"""Utilities for working with Hugging Face tokenizers."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from tokenizers import Tokenizer
+from tokenizers.models import BPE, WordPiece, Unigram
+from tokenizers.normalizers import NFD, Lowercase, StripAccents, Sequence
+from tokenizers.pre_tokenizers import Whitespace
+from tokenizers.trainers import BpeTrainer, WordPieceTrainer, UnigramTrainer
+from tokenizers import (
+    BertWordPieceTokenizer,
+    ByteLevelBPETokenizer,
+    CharBPETokenizer,
+    SentencePieceBPETokenizer,
+    SentencePieceUnigramTokenizer,
+)
+
+
+def load_tokenizer(path: str) -> Tokenizer:
+    """Load a tokenizer from a JSON file."""
+    return Tokenizer.from_file(path)
+
+
+def built_in_tokenizer(name: str, **kwargs) -> Tokenizer:
+    """Instantiate a built-in tokenizer by name."""
+    mapping = {
+        "bert_wordpiece": BertWordPieceTokenizer,
+        "byte_level_bpe": ByteLevelBPETokenizer,
+        "char_bpe": CharBPETokenizer,
+        "sentencepiece_bpe": SentencePieceBPETokenizer,
+        "sentencepiece_unigram": SentencePieceUnigramTokenizer,
+    }
+    if name not in mapping:
+        raise ValueError(f"Unsupported tokenizer: {name}")
+    return mapping[name](**kwargs)
+
+
+def train_tokenizer(files: Iterable[str], model: str, vocab_size: int = 30000, **kwargs) -> Tokenizer:
+    """Train a tokenizer model from text files."""
+    if model == "wordpiece":
+        tokenizer = Tokenizer(WordPiece())
+        tokenizer.normalizer = Sequence([NFD(), Lowercase(), StripAccents()])
+        tokenizer.pre_tokenizer = Whitespace()
+        trainer = WordPieceTrainer(vocab_size=vocab_size, **kwargs)
+    elif model == "bpe":
+        tokenizer = Tokenizer(BPE())
+        tokenizer.pre_tokenizer = Whitespace()
+        trainer = BpeTrainer(vocab_size=vocab_size, **kwargs)
+    elif model == "unigram":
+        tokenizer = Tokenizer(Unigram())
+        trainer = UnigramTrainer(vocab_size=vocab_size, **kwargs)
+    else:
+        raise ValueError(f"Unsupported model: {model}")
+    tokenizer.train(files, trainer)
+    return tokenizer
+
+
+def tokenizer_to_json(tokenizer: Tokenizer) -> str:
+    """Return the JSON representation of ``tokenizer``."""
+    return tokenizer.to_str()
+
+
+def tokenizer_from_json(data: str) -> Tokenizer:
+    """Load a tokenizer from a JSON string."""
+    return Tokenizer.from_str(data)

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -769,6 +769,15 @@ dataloader:
   # valid dtype name like ``"uint8"`` or ``"int16"``. Wider dtypes can prevent
   # overflow with exceptionally large payloads but increase memory usage.
   tensor_dtype: String specifying the dtype of encoded tensors.
+  tokenizer_type: Name of a built-in tokenizer from the ``tokenizers`` library
+    such as ``bert_wordpiece`` or ``byte_level_bpe``. When set, the DataLoader
+    converts all string inputs to token IDs using this tokenizer.
+  tokenizer_json: Path to a tokenizer JSON file to load instead of using a
+    built-in tokenizer. This allows custom vocabularies trained on your own
+    dataset.
+  tokenizer_vocab_size: Vocabulary size to use when training a tokenizer via
+    YAML configuration. The parameter is ignored when ``tokenizer_json`` is
+    provided.
 
 experiment_tracker:
   # Optional integration with external experiment tracking services such as


### PR DESCRIPTION
## Summary
- add tokenizer utilities and support in DataLoader
- embed tokenizer JSON in checkpoints
- load tokenizer from checkpoints
- allow configuration of tokenizer via YAML
- document new parameters in yaml-manual and tutorial
- add tests for tokenizer roundtrip and checkpoint
- note remaining tasks in TODO

## Testing
- `pytest tests/test_marble_dataloader.py -q`
- `pytest tests/test_torch_interop.py::test_brain_checkpoint -q`
- `pytest tests/test_tokenizer_dataloader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688a09b314688327b409610ce486f311