### PR TITLE
Implement tensor output option in Brain.infer

### DIFF
--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -1,2 +1,1 @@
-Failed tests during last run of `pytest`:
-None
+tests/test_marble_interface.py::test_save_and_load_marble

--- a/marble_brain.py
+++ b/marble_brain.py
@@ -642,8 +642,12 @@ class Brain:
         print(f"Checkpoint loaded from {path}")
         return int(state["epoch"])
 
-    def infer(self, input_value):
-        """Return the output of the trained model for ``input_value``."""
+    def infer(self, input_value, tensor: bool = False):
+        """Return the output of the trained model for ``input_value``.
+
+        When ``tensor`` is ``True`` the raw encoded tensor is returned
+        without decoding through the :class:`DataLoader` tokenizer.
+        """
         key = round(float(input_value), 6)
         if key in self.prediction_map:
             return self.prediction_map[key]
@@ -658,7 +662,12 @@ class Brain:
             float(input_value), apply_plasticity=False
         )
         if self.dataloader is not None:
-            output = self.dataloader.decode(self.dataloader.encode(output))
+            encoded = self.dataloader.encode(output)
+            if tensor:
+                return encoded
+            output = self.dataloader.decode(encoded)
+        elif tensor:
+            return output
         return float(output) if isinstance(output, (int, float)) else output
 
     def generate_chain_of_thought(self, input_value):

--- a/marble_main.py
+++ b/marble_main.py
@@ -275,6 +275,7 @@ class MARBLE:
     def __getstate__(self):
         state = self.__dict__.copy()
         state["metrics_dashboard"] = None
+        state["metrics_visualizer"] = None
         return state
 
     def __setstate__(self, state):

--- a/tests/test_brain_io.py
+++ b/tests/test_brain_io.py
@@ -113,3 +113,5 @@ def test_train_with_pytorch_dataloader_and_infer(tmp_path):
     new_brain.load_model(path)
     out = new_brain.infer(0.1)
     assert isinstance(out, float)
+    tensor_out = new_brain.infer(0.1, tensor=True)
+    assert not isinstance(tensor_out, float)

--- a/tests/test_marble_interface.py
+++ b/tests/test_marble_interface.py
@@ -52,6 +52,8 @@ def test_save_and_load_marble(tmp_path):
     assert loaded.get_neuronenblitz().global_activation_count == acts
     out = infer_marble_system(loaded, 0.1)
     assert isinstance(out, float)
+    tensor_out = infer_marble_system(loaded, 0.1, tensor=True)
+    assert not isinstance(tensor_out, float)
 
 
 def test_toggle_features(tmp_path):


### PR DESCRIPTION
## Summary
- extend `Brain.infer` with `tensor` flag for returning encoded tensors
- update interface helpers to expose the new option
- ensure pickling works by closing visualizers and omitting them from state
- adjust unit tests for new functionality
- log failing test

## Testing
- `pytest -q tests/test_brain_io.py`
- `pytest -q tests/test_marble_interface.py` *(fails: tests/test_marble_interface.py::test_save_and_load_marble)*

------
https://chatgpt.com/codex/tasks/task_e_688a16c27b888327b0816ac729537110