### PR TITLE
Integrate DataLoader with dataset_loader

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -241,8 +241,8 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [x] Update yaml-manual with plugin parameters.
    - [x] Add troubleshooting section.
    - [x] Provide example configuration files.
-116. [ ] Complete remaining items from ``dataupgradetodo.md``
-   - [ ] Extend dataset loading utilities to leverage the enhanced ``DataLoader``.
-   - [ ] Add migration tests for old checkpoints without embedded tokenizers.
-   - [ ] Document tokenizer training workflow in more detail.
+116. [x] Complete remaining items from ``dataupgradetodo.md``
+   - [x] Extend dataset loading utilities to leverage the enhanced ``DataLoader``.
+   - [x] Add migration tests for old checkpoints without embedded tokenizers.
+   - [x] Document tokenizer training workflow in more detail.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1660,3 +1660,16 @@ MARBLE's ``DataLoader`` can transparently tokenize strings using the
 converted to token IDs before being fed into the network and decoded back after
 inference. The ``tokenizer_vocab_size`` parameter controls the vocabulary size
 when training a tokenizer from scratch using the YAML configuration.
+
+To train a tokenizer yourself use ``tokenizer_utils.train_tokenizer`` and save
+the resulting object to JSON:
+
+```python
+from tokenizer_utils import train_tokenizer, tokenizer_to_json
+tok = train_tokenizer(["data/train.txt"], model="wordpiece", vocab_size=8000)
+with open("my_tokenizer.json", "w") as f:
+    f.write(tokenizer_to_json(tok))
+```
+
+Set ``tokenizer_json: my_tokenizer.json`` in ``config.yaml`` to use this
+tokenizer for both training and inference.

--- a/marble_interface.py
+++ b/marble_interface.py
@@ -85,8 +85,13 @@ def save_marble_system(marble: MARBLE, path: str) -> None:
         viz.backup_scheduler = None
     if brain_viz is not None:
         brain_viz.close()
+        marble.brain.metrics_visualizer = None
+    marble.metrics_visualizer = None
     with open(path, "wb") as f:
         dill.dump(marble, f)
+    marble.metrics_visualizer = viz
+    if brain_viz is not None:
+        marble.brain.metrics_visualizer = brain_viz
     if viz is not None:
         viz.fig = fig
         viz.ax = ax

--- a/tests/test_checkpoint_migration.py
+++ b/tests/test_checkpoint_migration.py
@@ -5,6 +5,7 @@ import numpy as np
 from marble_core import Core
 from marble_neuronenblitz import Neuronenblitz
 from marble_brain import Brain
+from marble import DataLoader
 from tests.test_core_functions import minimal_params
 
 
@@ -34,3 +35,19 @@ def test_checkpoint_migration(tmp_path):
     assert epoch == 1
     assert "markers" in ctx and "goals" in ctx and "tom" in ctx
     assert len(brain.neuronenblitz.replay_buffer[0]) == 5
+
+
+def test_checkpoint_migration_no_tokenizer(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    dl = DataLoader()
+    brain = Brain(core, nb, dl, save_dir=str(tmp_path))
+    ckpt = tmp_path / "old_no_tok.pkl"
+    brain.save_checkpoint(str(ckpt), epoch=1)
+
+    new_dl = DataLoader()
+    new_brain = Brain(core, nb, new_dl, save_dir=str(tmp_path))
+    epoch = new_brain.load_checkpoint(str(ckpt))
+    assert epoch == 1
+    assert new_brain.dataloader.tokenizer is None

--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -8,6 +8,7 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from dataset_loader import load_dataset
+from marble import DataLoader
 
 
 def _serve_directory(directory, port):
@@ -115,4 +116,14 @@ def test_offline_mode(tmp_path):
     assert pairs == [(9, 10)]
     with pytest.raises(FileNotFoundError):
         load_dataset(url, cache_dir=tmp_path / "missing", offline=True)
+
+
+def test_load_dataset_with_dataloader(tmp_path):
+    csv_path = tmp_path / "dl.csv"
+    csv_path.write_text("input,target\nhello,world\n")
+    dl = DataLoader()
+    pairs = load_dataset(str(csv_path), dataloader=dl)
+    inp, tgt = pairs[0]
+    assert dl.decode(inp) == "hello"
+    assert dl.decode(tgt) == "world"
 


### PR DESCRIPTION
## Summary
- integrate DataLoader encoding into dataset_loader
- support DataLoader parameter in Hugging Face dataset loader
- add dataset loader tests for encoded mode
- add checkpoint migration test without tokenizer
- document tokenizer training workflow in tutorial
- update TODO
- track failing test

## Testing
- `pytest -q tests/test_dataset_loader.py`
- `pytest -q tests/test_marble_interface.py::test_save_and_load_marble` *(fails)*
- `pytest -q tests/test_checkpoint_migration.py`

------
https://chatgpt.com/codex/tasks/task_e_688a221c0c408327aa394b25e8f43f5c