### PR TITLE
Implement round-trip loader config

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -305,6 +305,9 @@ Each entry is listed under its section heading.
 
 ## dataloader
 - tensor_dtype
+- track_metadata
+- enable_round_trip_check
+- round_trip_penalty
 - tokenizer_type
 - tokenizer_json
 - tokenizer_vocab_size

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1673,3 +1673,13 @@ with open("my_tokenizer.json", "w") as f:
 
 Set ``tokenizer_json: my_tokenizer.json`` in ``config.yaml`` to use this
 tokenizer for both training and inference.
+
+### Enabling Round-Trip Integrity Checks
+
+The ``dataloader`` section also exposes ``enable_round_trip_check`` and
+``round_trip_penalty``. When enabled, each training example is encoded and then
+decoded again. If the decoded value differs from the original, the specified
+penalty is added to the training loss. This helps detect issues with
+tokenization or custom serialization. ``track_metadata`` should remain ``true``
+unless you have strict storage constraints because it ensures objects are
+reconstructed with the correct Python type during decoding.

--- a/config.yaml
+++ b/config.yaml
@@ -320,6 +320,9 @@ data_compressor:
   compression_algorithm: "zlib"
 dataloader:
   tensor_dtype: "uint8"
+  track_metadata: true
+  enable_round_trip_check: false
+  round_trip_penalty: 0.0
   tokenizer_type: null
   tokenizer_json: null
   tokenizer_vocab_size: 30000

--- a/config_loader.py
+++ b/config_loader.py
@@ -110,6 +110,9 @@ def create_marble_from_config(
         "compression_level": compression_level,
         "compression_enabled": compression_enabled,
         "tensor_dtype": tensor_dtype,
+        "track_metadata": dataloader_cfg.get("track_metadata", True),
+        "enable_round_trip_check": dataloader_cfg.get("enable_round_trip_check", False),
+        "round_trip_penalty": dataloader_cfg.get("round_trip_penalty", 0.0),
     }
     for key in ["tokenizer_type", "tokenizer_json", "tokenizer_vocab_size"]:
         if key in dataloader_cfg:

--- a/config_schema.py
+++ b/config_schema.py
@@ -64,6 +64,9 @@ CONFIG_SCHEMA = {
             "type": "object",
             "properties": {
                 "tensor_dtype": {"type": "string"},
+                "track_metadata": {"type": "boolean"},
+                "enable_round_trip_check": {"type": "boolean"},
+                "round_trip_penalty": {"type": "number", "minimum": 0},
                 "tokenizer_type": {"type": ["string", "null"]},
                 "tokenizer_json": {"type": ["string", "null"]},
                 "tokenizer_vocab_size": {"type": "integer", "minimum": 1},

--- a/marble_main.py
+++ b/marble_main.py
@@ -87,6 +87,9 @@ class MARBLE:
             dl_level = dataloader_params.get("compression_level", dl_level)
             dl_enabled = dataloader_params.get("compression_enabled", True)
             dl_dtype = dataloader_params.get("tensor_dtype", dl_dtype)
+            track_meta = dataloader_params.get("track_metadata", True)
+            enable_rtc = dataloader_params.get("enable_round_trip_check", False)
+            rt_penalty = dataloader_params.get("round_trip_penalty", 0.0)
             tok_type = dataloader_params.get("tokenizer_type")
             tok_json = dataloader_params.get("tokenizer_json")
             tok_vocab = dataloader_params.get("tokenizer_vocab_size", 30000)
@@ -104,6 +107,9 @@ class MARBLE:
             metrics_visualizer=self.metrics_visualizer,
             tensor_dtype=dl_dtype,
             tokenizer=tokenizer,
+            track_metadata=track_meta,
+            enable_round_trip_check=enable_rtc,
+            round_trip_penalty=rt_penalty,
         )
 
         nb_defaults = {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -236,3 +236,18 @@ def test_partial_config_merges_defaults(tmp_path):
     default = load_config()
     assert cfg["core"]["width"] == 5
     assert cfg["core"]["height"] == default["core"]["height"]
+
+
+def test_dataloader_round_trip_config(tmp_path):
+    cfg = load_config()
+    dl_cfg = cfg.setdefault("dataloader", {})
+    dl_cfg["enable_round_trip_check"] = True
+    dl_cfg["round_trip_penalty"] = 0.7
+    dl_cfg["track_metadata"] = False
+    cfg_path = tmp_path / "rt.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(cfg, f)
+    marble = create_marble_from_config(str(cfg_path))
+    assert marble.dataloader.enable_round_trip_check is True
+    assert marble.dataloader.round_trip_penalty == 0.7
+    assert marble.dataloader.track_metadata is False

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -769,6 +769,16 @@ dataloader:
   # valid dtype name like ``"uint8"`` or ``"int16"``. Wider dtypes can prevent
   # overflow with exceptionally large payloads but increase memory usage.
   tensor_dtype: String specifying the dtype of encoded tensors.
+  track_metadata: When ``true`` each encoded object is stored with metadata
+    describing its original Python module and type. This ensures decoding
+    faithfully recreates the value even when tokenization or compression is
+    applied.
+  enable_round_trip_check: Set to ``true`` to verify that decoding an encoded
+    value returns an object equal to the original during training. If the
+    objects differ the ``round_trip_penalty`` is added to the loss.
+  round_trip_penalty: Floating point penalty applied when the round-trip check
+    fails. Typical values range from ``0.1`` to ``1.0`` depending on how strongly
+    you want to discourage irreversible transformations.
   tokenizer_type: Name of a built-in tokenizer from the ``tokenizers`` library
     such as ``bert_wordpiece`` or ``byte_level_bpe``. When set, the DataLoader
     converts all string inputs to token IDs using this tokenizer.


### PR DESCRIPTION
## Summary
- expose new dataloader options in YAML
- parse the new options in `config_loader`
- pass them through in `marble_main`
- document configuration fields and tutorial updates
- add regression test for dataloader config

## Testing
- `pytest -q tests/test_config.py`
- `pytest -q tests/test_marble_dataloader.py`

------
https://chatgpt.com/codex/tasks/task_e_688a4d01ed508327a64c0e16269e3c85