### PR TITLE
Add tokenizer support to pipelines

### DIFF
--- a/diffusion_pairs_pipeline.py
+++ b/diffusion_pairs_pipeline.py
@@ -8,6 +8,7 @@ from marble_neuronenblitz import Neuronenblitz
 from marble_brain import Brain
 from marble_imports import cp
 from marble_core import DataLoader
+from tokenizers import Tokenizer
 
 
 class DiffusionPairsPipeline:
@@ -20,9 +21,25 @@ class DiffusionPairsPipeline:
     inference.
     """
 
-    def __init__(self, core: DiffusionCore, save_path: str = "trained_marble.pkl") -> None:
+    def __init__(
+        self,
+        core: DiffusionCore,
+        save_path: str = "trained_marble.pkl",
+        *,
+        dataloader: DataLoader | None = None,
+        tokenizer: Tokenizer | None = None,
+    ) -> None:
         self.core = core
-        self.loader = core.loader if hasattr(core, "loader") else DataLoader()
+        if dataloader is not None:
+            self.loader = dataloader
+            if tokenizer is not None:
+                self.loader.tokenizer = tokenizer
+        elif hasattr(core, "loader"):
+            if tokenizer is not None:
+                core.loader.tokenizer = tokenizer
+            self.loader = core.loader
+        else:
+            self.loader = DataLoader(tokenizer=tokenizer)
         self.save_path = save_path
         self.nb = Neuronenblitz(self.core)
         self.brain = Brain(self.core, self.nb, self.loader)

--- a/preprocessing_pipeline.py
+++ b/preprocessing_pipeline.py
@@ -3,13 +3,29 @@ import pickle
 import hashlib
 from typing import Callable, Iterable, Sequence, Any, List
 
+from tokenizers import Tokenizer
+from marble import DataLoader
+
 
 class PreprocessingPipeline:
     """Apply preprocessing functions to data with result caching."""
 
-    def __init__(self, steps: Sequence[Callable[[Any], Any]], cache_dir: str = "preproc_cache") -> None:
+    def __init__(
+        self,
+        steps: Sequence[Callable[[Any], Any]],
+        cache_dir: str = "preproc_cache",
+        *,
+        dataloader: DataLoader | None = None,
+        tokenizer: Tokenizer | None = None,
+    ) -> None:
         self.steps = list(steps)
         self.cache_dir = cache_dir
+        if dataloader is not None:
+            self.dataloader = dataloader
+            if tokenizer is not None:
+                self.dataloader.tokenizer = tokenizer
+        else:
+            self.dataloader = DataLoader(tokenizer=tokenizer) if tokenizer is not None else None
 
     def _cache_path(self, dataset_id: str) -> str:
         os.makedirs(self.cache_dir, exist_ok=True)
@@ -21,10 +37,16 @@ class PreprocessingPipeline:
         path = self._cache_path(dataset_id)
         if os.path.exists(path):
             with open(path, "rb") as f:
-                return pickle.load(f)
+                cached = pickle.load(f)
+            if self.dataloader is not None:
+                cached = [self.dataloader.decode(item) for item in cached]
+            return cached
         processed = list(data)
         for step in self.steps:
             processed = [step(item) for item in processed]
+        to_store = processed
+        if self.dataloader is not None:
+            to_store = [self.dataloader.encode(item) for item in processed]
         with open(path, "wb") as f:
-            pickle.dump(processed, f)
+            pickle.dump(to_store, f)
         return processed

--- a/tests/test_diffusion_pairs_pipeline.py
+++ b/tests/test_diffusion_pairs_pipeline.py
@@ -5,6 +5,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from diffusion_core import DiffusionCore
 from diffusion_pairs_pipeline import DiffusionPairsPipeline
 from tests.test_core_functions import minimal_params
+from tokenizer_utils import built_in_tokenizer
+from marble import DataLoader
 
 
 def test_diffusion_pairs_pipeline_trains(tmp_path):
@@ -26,5 +28,21 @@ def test_diffusion_pairs_pipeline_non_numeric(tmp_path):
     save_path = tmp_path / "model.pkl"
     pipeline = DiffusionPairsPipeline(core, save_path=str(save_path))
     pairs = [("hello", "foo"), ("world", "bar")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+
+
+def test_diffusion_pairs_pipeline_with_tokenizer(tmp_path):
+    params = minimal_params()
+    params["diffusion_steps"] = 1
+    core = DiffusionCore(params)
+    text_file = tmp_path / "train.txt"
+    text_file.write_text("hello world")
+    tok = built_in_tokenizer("bert_wordpiece", lowercase=True)
+    tok.train([str(text_file)], vocab_size=20)
+    dl = DataLoader(tokenizer=tok)
+    save_path = tmp_path / "tok_model.pkl"
+    pipeline = DiffusionPairsPipeline(core, save_path=str(save_path), dataloader=dl)
+    pairs = [("hello", "world"), ("foo", "bar")]
     pipeline.train(pairs, epochs=1)
     assert save_path.is_file()

--- a/tests/test_pipeline_class.py
+++ b/tests/test_pipeline_class.py
@@ -9,7 +9,7 @@ from tests.test_core_functions import minimal_params
 
 def test_pipeline_run(tmp_path):
     params = minimal_params()
-    marble = MARBLE(params)
+    marble = MARBLE(params, dataloader_params={})
     pipe = Pipeline([{"func": "count_marble_synapses"}])
     results = pipe.execute(marble)
     assert len(results) == 1

--- a/tests/test_preprocessing_pipeline.py
+++ b/tests/test_preprocessing_pipeline.py
@@ -1,5 +1,7 @@
 import sys, os; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from preprocessing_pipeline import PreprocessingPipeline
+from tokenizer_utils import built_in_tokenizer
+from marble import DataLoader
 
 
 def test_preprocessing_pipeline(tmp_path):
@@ -11,4 +13,20 @@ def test_preprocessing_pipeline(tmp_path):
     assert result1 == [3, 5, 7]
     # Run again to use cache
     result2 = pp.process(data, dataset_id="test")
+    assert result2 == result1
+
+
+def test_preprocessing_pipeline_with_tokenizer(tmp_path):
+    steps = [lambda x: x]
+    cache_dir = tmp_path / "tok_cache"
+    text_file = tmp_path / "train.txt"
+    text_file.write_text("hello world")
+    tok = built_in_tokenizer("bert_wordpiece", lowercase=True)
+    tok.train([str(text_file)], vocab_size=20)
+    dl = DataLoader(tokenizer=tok)
+    pp = PreprocessingPipeline(steps, cache_dir=str(cache_dir), dataloader=dl)
+    data = ["hello", "world"]
+    result1 = pp.process(data, dataset_id="tok")
+    assert result1 == ["hello", "world"]
+    result2 = pp.process(data, dataset_id="tok")
     assert result2 == result1


### PR DESCRIPTION
## Summary
- accept tokenizer options in `DiffusionPairsPipeline`
- optionally use tokenizer-aware dataloader in `PreprocessingPipeline`
- adapt tests for new pipeline functionality
- ensure pipeline tests instantiate MARBLE with dataloader params

## Testing
- `pytest tests/test_diffusion_pairs_pipeline.py::test_diffusion_pairs_pipeline_trains -q`
- `pytest tests/test_diffusion_pairs_pipeline.py::test_diffusion_pairs_pipeline_non_numeric -q`
- `pytest tests/test_diffusion_pairs_pipeline.py::test_diffusion_pairs_pipeline_with_tokenizer -q`
- `pytest tests/test_preprocessing_pipeline.py::test_preprocessing_pipeline -q`
- `pytest tests/test_preprocessing_pipeline.py::test_preprocessing_pipeline_with_tokenizer -q`
- `pytest tests/test_pipeline_class.py -q`
- `pytest tests/test_tokenizer_dataloader.py -q`
- `pytest tests/test_dataset_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688a5781d2888327aec97343fc1e6570