### PR TITLE
Integrate BitTensorDataset with diffusion pipeline

### DIFF
--- a/tests/test_diffusion_pairs_pipeline.py
+++ b/tests/test_diffusion_pairs_pipeline.py
@@ -1,12 +1,14 @@
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from bit_tensor_dataset import BitTensorDataset
 from diffusion_core import DiffusionCore
 from diffusion_pairs_pipeline import DiffusionPairsPipeline
+from marble import DataLoader
 from tests.test_core_functions import minimal_params
 from tokenizer_utils import built_in_tokenizer
-from marble import DataLoader
 
 
 def test_diffusion_pairs_pipeline_trains(tmp_path):
@@ -45,4 +47,16 @@ def test_diffusion_pairs_pipeline_with_tokenizer(tmp_path):
     pipeline = DiffusionPairsPipeline(core, save_path=str(save_path), dataloader=dl)
     pairs = [("hello", "world"), ("foo", "bar")]
     pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+
+
+def test_diffusion_pairs_pipeline_bit_dataset(tmp_path):
+    params = minimal_params()
+    params["diffusion_steps"] = 1
+    core = DiffusionCore(params)
+    save_path = tmp_path / "bit.pkl"
+    pipeline = DiffusionPairsPipeline(core, save_path=str(save_path))
+    pairs = [("hi", "there"), ("foo", "bar")]
+    ds = BitTensorDataset(pairs)
+    pipeline.train(ds, epochs=1)
     assert save_path.is_file()


### PR DESCRIPTION
## Summary
- allow `DiffusionPairsPipeline` to consume `BitTensorDataset`
- test pipeline with bit-tensor data

## Testing
- `pytest tests/test_bit_tensor_dataset.py -q`
- `pytest tests/test_diffusion_pairs_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688b170e077883279cbda616cf3ca569