### PR TITLE
Use BitTensorDataset in training pipeline

### DIFF
--- a/tests/test_diffusion_pairs_pipeline.py
+++ b/tests/test_diffusion_pairs_pipeline.py
@@ -60,3 +60,16 @@ def test_diffusion_pairs_pipeline_bit_dataset(tmp_path):
     ds = BitTensorDataset(pairs)
     pipeline.train(ds, epochs=1)
     assert save_path.is_file()
+
+
+def test_diffusion_pairs_pipeline_auto_bit_dataset(tmp_path):
+    params = minimal_params()
+    params["diffusion_steps"] = 1
+    core = DiffusionCore(params)
+    save_path = tmp_path / "auto.pkl"
+    pipeline = DiffusionPairsPipeline(core, save_path=str(save_path), use_vocab=True)
+    pairs = [("a", "b"), ("c", "d")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+    assert isinstance(pipeline.last_dataset, BitTensorDataset)
+    assert pipeline.last_dataset.get_vocab() is not None


### PR DESCRIPTION
## Summary
- update `DiffusionPairsPipeline` to always convert incoming pairs to `BitTensorDataset`
- expose `last_dataset` and allow optional vocabulary
- add tests for new behaviour

## Testing
- `pytest -q tests/test_bit_tensor_dataset.py`
- `pytest -q tests/test_diffusion_pairs_pipeline.py`
- `pytest -q tests/test_dataset_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_688b31086a408327b8a5c217fbf644e1