### PR TITLE
Add new BitTensorDataset pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ operating directly on the bit level, ``BitTensorDataset`` can convert objects
 into binary tensors and optionally build a shared vocabulary for compact
 storage.
 
+Several helper pipelines leverage ``BitTensorDataset`` to train various
+learning paradigms on arbitrary Python objects, including ``AutoencoderPipeline``,
+``ContrastivePipeline``, ``DiffusionPairsPipeline``, ``UnifiedPairsPipeline``,
+``SemiSupervisedPairsPipeline`` and the new ``ImitationPairsPipeline`` and
+``FractalDimensionPairsPipeline``.
+
 ### Command Line Usage
 
 Common tasks can be performed via ``cli.py``. Train a model, evaluate it and

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1933,3 +1933,26 @@ reconstructed with the correct Python type during decoding.
    pipe.train(labeled, unlabeled, epochs=1)
    ```
    Both pipelines automatically convert objects to bit-level tensors so you can train on any Python data structure.
+
+## Project 33 – Advanced BitTensor Pipelines
+
+**Goal:** Explore imitation and fractal-dimension learning with arbitrary inputs.
+
+1. **Train the imitation pipeline** on example demonstrations:
+   ```python
+   from imitation_pairs_pipeline import ImitationPairsPipeline
+
+   core = Core(minimal_params())
+   pipe = ImitationPairsPipeline(core, use_vocab=True)
+   demos = [("left", "move"), ("right", "move")]
+   pipe.train(demos, epochs=1)
+   ```
+2. **Model fractal dimension adjustments** using another dataset:
+   ```python
+   from fractal_dimension_pairs_pipeline import FractalDimensionPairsPipeline
+
+   core = Core(minimal_params())
+   pipe = FractalDimensionPairsPipeline(core, use_vocab=True)
+   pairs = [("conceptA", "conceptB"), ("conceptC", "conceptD")]
+   pipe.train(pairs, epochs=1)
+   ```

--- a/fractal_dimension_pairs_pipeline.py
+++ b/fractal_dimension_pairs_pipeline.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pickle
+from typing import Any, Iterable, Tuple
+
+from tokenizers import Tokenizer
+from torch.utils.data import Dataset
+
+from bit_tensor_dataset import BitTensorDataset
+from marble_core import DataLoader, Core
+from marble_neuronenblitz import Neuronenblitz
+from fractal_dimension_learning import FractalDimensionLearner
+from marble_imports import cp
+
+
+class FractalDimensionPairsPipeline:
+    """Train ``FractalDimensionLearner`` on ``(input, target)`` pairs."""
+
+    def __init__(
+        self,
+        core: Core,
+        save_path: str = "fractal_dim.pkl",
+        *,
+        dataloader: DataLoader | None = None,
+        tokenizer: Tokenizer | None = None,
+        use_vocab: bool = False,
+    ) -> None:
+        self.core = core
+        if dataloader is not None:
+            self.loader = dataloader
+            if tokenizer is not None:
+                self.loader.tokenizer = tokenizer
+        else:
+            self.loader = DataLoader(tokenizer=tokenizer)
+        self.save_path = save_path
+        self.use_vocab = use_vocab
+        self.last_dataset: BitTensorDataset | None = None
+        self.nb = Neuronenblitz(self.core)
+        self.learner = FractalDimensionLearner(self.core, self.nb)
+
+    def _to_float(self, obj: Any) -> float:
+        tensor = self.loader.encode(obj)
+        if hasattr(tensor, "mean"):
+            return float(cp.asnumpy(tensor).astype(float).mean())
+        return float(tensor)
+
+    def train(self, pairs: Iterable[Tuple[Any, Any]] | Dataset, epochs: int = 1) -> str:
+        if isinstance(pairs, Dataset):
+            if isinstance(pairs, BitTensorDataset):
+                bit_ds = pairs
+            else:
+                bit_ds = BitTensorDataset([(i, t) for i, t in pairs], use_vocab=self.use_vocab)
+        else:
+            bit_ds = BitTensorDataset(list(pairs), use_vocab=self.use_vocab)
+
+        self.last_dataset = bit_ds
+
+        examples = [
+            (self._to_float(bit_ds.tensor_to_object(inp)), self._to_float(bit_ds.tensor_to_object(tgt)))
+            for inp, tgt in bit_ds
+        ]
+
+        self.learner.train(examples, epochs=epochs)
+        with open(self.save_path, "wb") as f:
+            pickle.dump({"core": self.core, "neuronenblitz": self.nb}, f)
+        return self.save_path

--- a/imitation_pairs_pipeline.py
+++ b/imitation_pairs_pipeline.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pickle
+from typing import Any, Iterable, Tuple
+
+from tokenizers import Tokenizer
+from torch.utils.data import Dataset
+
+from bit_tensor_dataset import BitTensorDataset
+from marble_core import DataLoader, Core
+from marble_neuronenblitz import Neuronenblitz
+from imitation_learning import ImitationLearner
+from marble_imports import cp
+
+
+class ImitationPairsPipeline:
+    """Train ``ImitationLearner`` on ``(input, action)`` pairs."""
+
+    def __init__(
+        self,
+        core: Core,
+        save_path: str = "imitation.pkl",
+        *,
+        dataloader: DataLoader | None = None,
+        tokenizer: Tokenizer | None = None,
+        use_vocab: bool = False,
+    ) -> None:
+        self.core = core
+        if dataloader is not None:
+            self.loader = dataloader
+            if tokenizer is not None:
+                self.loader.tokenizer = tokenizer
+        else:
+            self.loader = DataLoader(tokenizer=tokenizer)
+        self.save_path = save_path
+        self.use_vocab = use_vocab
+        self.last_dataset: BitTensorDataset | None = None
+        self.nb = Neuronenblitz(self.core)
+        self.learner = ImitationLearner(self.core, self.nb)
+
+    def _to_float(self, obj: Any) -> float:
+        tensor = self.loader.encode(obj)
+        if hasattr(tensor, "mean"):
+            return float(cp.asnumpy(tensor).astype(float).mean())
+        return float(tensor)
+
+    def train(self, pairs: Iterable[Tuple[Any, Any]] | Dataset, epochs: int = 1) -> str:
+        if isinstance(pairs, Dataset):
+            if isinstance(pairs, BitTensorDataset):
+                bit_ds = pairs
+            else:
+                bit_ds = BitTensorDataset([(i, t) for i, t in pairs], use_vocab=self.use_vocab)
+        else:
+            bit_ds = BitTensorDataset(list(pairs), use_vocab=self.use_vocab)
+
+        self.last_dataset = bit_ds
+
+        for inp, tgt in bit_ds:
+            in_obj = bit_ds.tensor_to_object(inp)
+            tgt_obj = bit_ds.tensor_to_object(tgt)
+            self.learner.record(self._to_float(in_obj), self._to_float(tgt_obj))
+
+        self.learner.train(epochs=epochs)
+        with open(self.save_path, "wb") as f:
+            pickle.dump({"core": self.core, "neuronenblitz": self.nb}, f)
+        return self.save_path

--- a/tests/test_fractal_dimension_pairs_pipeline.py
+++ b/tests/test_fractal_dimension_pairs_pipeline.py
@@ -1,0 +1,67 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fractal_dimension_pairs_pipeline import FractalDimensionPairsPipeline
+from bit_tensor_dataset import BitTensorDataset
+from marble_core import Core, DataLoader
+from tokenizer_utils import built_in_tokenizer
+from tests.test_core_functions import minimal_params
+
+
+def test_fractal_dimension_pipeline_trains(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "frac.pkl"
+    pipeline = FractalDimensionPairsPipeline(core, save_path=str(save_path))
+    pairs = [(0.1, 0.2), (0.3, 0.4)]
+    out_path = pipeline.train(pairs, epochs=1)
+    assert out_path == str(save_path)
+    assert save_path.is_file()
+
+
+def test_fractal_dimension_pipeline_non_numeric(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "frac.pkl"
+    pipeline = FractalDimensionPairsPipeline(core, save_path=str(save_path))
+    pairs = [("hello", "greet"), ("world", "noun")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+
+
+def test_fractal_dimension_pipeline_with_tokenizer(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    text_file = tmp_path / "train.txt"
+    text_file.write_text("hello world")
+    tok = built_in_tokenizer("bert_wordpiece", lowercase=True)
+    tok.train([str(text_file)], vocab_size=20)
+    dl = DataLoader(tokenizer=tok)
+    save_path = tmp_path / "tok_frac.pkl"
+    pipeline = FractalDimensionPairsPipeline(core, save_path=str(save_path), dataloader=dl)
+    pairs = [("hello", "world"), ("foo", "bar")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+
+
+def test_fractal_dimension_pipeline_bit_dataset(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "bit_frac.pkl"
+    pipeline = FractalDimensionPairsPipeline(core, save_path=str(save_path))
+    pairs = [("hi", "there"), ("foo", "bar")]
+    ds = BitTensorDataset(pairs)
+    pipeline.train(ds, epochs=1)
+    assert save_path.is_file()
+
+
+def test_fractal_dimension_pipeline_auto_bit_dataset(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "auto_frac.pkl"
+    pipeline = FractalDimensionPairsPipeline(core, save_path=str(save_path), use_vocab=True)
+    pairs = [("a", "b"), ("c", "d")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+    assert isinstance(pipeline.last_dataset, BitTensorDataset)
+    assert pipeline.last_dataset.get_vocab() is not None

--- a/tests/test_imitation_pairs_pipeline.py
+++ b/tests/test_imitation_pairs_pipeline.py
@@ -1,0 +1,67 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from imitation_pairs_pipeline import ImitationPairsPipeline
+from bit_tensor_dataset import BitTensorDataset
+from marble_core import Core, DataLoader
+from tokenizer_utils import built_in_tokenizer
+from tests.test_core_functions import minimal_params
+
+
+def test_imitation_pairs_pipeline_trains(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "imit.pkl"
+    pipeline = ImitationPairsPipeline(core, save_path=str(save_path))
+    pairs = [(0.1, 0.2), (0.3, 0.4)]
+    out_path = pipeline.train(pairs, epochs=1)
+    assert out_path == str(save_path)
+    assert save_path.is_file()
+
+
+def test_imitation_pairs_pipeline_non_numeric(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "imit.pkl"
+    pipeline = ImitationPairsPipeline(core, save_path=str(save_path))
+    pairs = [("hello", "greet"), ("world", "noun")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+
+
+def test_imitation_pairs_pipeline_with_tokenizer(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    text_file = tmp_path / "train.txt"
+    text_file.write_text("hello world")
+    tok = built_in_tokenizer("bert_wordpiece", lowercase=True)
+    tok.train([str(text_file)], vocab_size=20)
+    dl = DataLoader(tokenizer=tok)
+    save_path = tmp_path / "tok_imit.pkl"
+    pipeline = ImitationPairsPipeline(core, save_path=str(save_path), dataloader=dl)
+    pairs = [("hello", "world"), ("foo", "bar")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+
+
+def test_imitation_pairs_pipeline_bit_dataset(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "bit_imit.pkl"
+    pipeline = ImitationPairsPipeline(core, save_path=str(save_path))
+    pairs = [("hi", "there"), ("foo", "bar")]
+    ds = BitTensorDataset(pairs)
+    pipeline.train(ds, epochs=1)
+    assert save_path.is_file()
+
+
+def test_imitation_pairs_pipeline_auto_bit_dataset(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "auto_imit.pkl"
+    pipeline = ImitationPairsPipeline(core, save_path=str(save_path), use_vocab=True)
+    pairs = [("a", "b"), ("c", "d")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+    assert isinstance(pipeline.last_dataset, BitTensorDataset)
+    assert pipeline.last_dataset.get_vocab() is not None


### PR DESCRIPTION
## Summary
- implement `ImitationPairsPipeline` and `FractalDimensionPairsPipeline`
- mention new pipelines in the README
- extend tutorial with Project 33 covering the new pipelines
- add unit tests for both pipelines

## Testing
- `pytest tests/test_imitation_pairs_pipeline.py -q`
- `pytest tests/test_fractal_dimension_pairs_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688b3c06cba883278e02a3faf683e372