### PR TITLE
Add new BitTensor pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ storage.
 Several helper pipelines leverage ``BitTensorDataset`` to train various
 learning paradigms on arbitrary Python objects, including ``AutoencoderPipeline``,
 ``ContrastivePipeline``, ``DiffusionPairsPipeline``, ``UnifiedPairsPipeline``,
-``SemiSupervisedPairsPipeline`` and the new ``ImitationPairsPipeline`` and
-``FractalDimensionPairsPipeline``.
+``SemiSupervisedPairsPipeline`` and the new ``ImitationPairsPipeline``,
+``FractalDimensionPairsPipeline``, ``HebbianPipeline``, ``TransferPairsPipeline``
+and ``QuantumFluxPairsPipeline``.
 
 ### Command Line Usage
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1951,8 +1951,40 @@ reconstructed with the correct Python type during decoding.
    ```python
    from fractal_dimension_pairs_pipeline import FractalDimensionPairsPipeline
 
+  core = Core(minimal_params())
+  pipe = FractalDimensionPairsPipeline(core, use_vocab=True)
+  pairs = [("conceptA", "conceptB"), ("conceptC", "conceptD")]
+  pipe.train(pairs, epochs=1)
+  ```
+
+## Project 34 – Additional BitTensor Pipelines
+
+**Goal:** Try the latest pipelines that operate on bit-level representations.**
+
+1. **Hebbian learning on arbitrary objects:**
+   ```python
+   from hebbian_pipeline import HebbianPipeline
+
    core = Core(minimal_params())
-   pipe = FractalDimensionPairsPipeline(core, use_vocab=True)
-   pairs = [("conceptA", "conceptB"), ("conceptC", "conceptD")]
-   pipe.train(pairs, epochs=1)
+   pipe = HebbianPipeline(core, use_vocab=True)
+   data = ["alpha", "beta", "gamma"]
+   pipe.train(data, epochs=1)
+   ```
+2. **Fine-tune with transfer learning:**
+   ```python
+   from transfer_pairs_pipeline import TransferPairsPipeline
+
+   core = Core(minimal_params())
+   pipe = TransferPairsPipeline(core, freeze_fraction=0.3, use_vocab=True)
+   examples = [("old", "new"), ("stale", "fresh")]
+   pipe.train(examples, epochs=1)
+   ```
+3. **Experiment with quantum flux learning:**
+   ```python
+   from quantum_flux_pairs_pipeline import QuantumFluxPairsPipeline
+
+   core = Core(minimal_params())
+   pipe = QuantumFluxPairsPipeline(core, phase_rate=0.2, use_vocab=True)
+   examples = [("up", "down"), ("left", "right")]
+   pipe.train(examples, epochs=1)
    ```

--- a/hebbian_pipeline.py
+++ b/hebbian_pipeline.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pickle
+from typing import Any, Iterable
+
+from tokenizers import Tokenizer
+from torch.utils.data import Dataset
+
+from bit_tensor_dataset import BitTensorDataset
+from marble_core import DataLoader, Core
+from marble_neuronenblitz import Neuronenblitz
+from hebbian_learning import HebbianLearner
+from marble_imports import cp
+
+
+class HebbianPipeline:
+    """Train a :class:`HebbianLearner` on arbitrary objects."""
+
+    def __init__(
+        self,
+        core: Core,
+        save_path: str = "hebbian.pkl",
+        *,
+        dataloader: DataLoader | None = None,
+        tokenizer: Tokenizer | None = None,
+        use_vocab: bool = False,
+    ) -> None:
+        self.core = core
+        if dataloader is not None:
+            self.loader = dataloader
+            if tokenizer is not None:
+                self.loader.tokenizer = tokenizer
+        else:
+            self.loader = DataLoader(tokenizer=tokenizer)
+        self.save_path = save_path
+        self.use_vocab = use_vocab
+        self.last_dataset: BitTensorDataset | None = None
+        self.nb = Neuronenblitz(self.core)
+        self.learner = HebbianLearner(self.core, self.nb)
+
+    def _to_float(self, obj: Any) -> float:
+        tensor = self.loader.encode(obj)
+        if hasattr(tensor, "mean"):
+            return float(cp.asnumpy(tensor).astype(float).mean())
+        return float(tensor)
+
+    def train(self, data: Iterable[Any] | Dataset, epochs: int = 1) -> str:
+        if isinstance(data, Dataset):
+            if isinstance(data, BitTensorDataset):
+                bit_ds = data
+            else:
+                bit_ds = BitTensorDataset([(d, d) for d in data], use_vocab=self.use_vocab)
+        else:
+            bit_ds = BitTensorDataset([(d, d) for d in list(data)], use_vocab=self.use_vocab)
+
+        self.last_dataset = bit_ds
+        values = [self._to_float(bit_ds.tensor_to_object(inp)) for inp, _ in bit_ds]
+        self.learner.train(values, epochs=epochs)
+        with open(self.save_path, "wb") as f:
+            pickle.dump({"core": self.core, "neuronenblitz": self.nb}, f)
+        return self.save_path

--- a/quantum_flux_pairs_pipeline.py
+++ b/quantum_flux_pairs_pipeline.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pickle
+from typing import Any, Iterable
+
+from tokenizers import Tokenizer
+from torch.utils.data import Dataset
+
+from bit_tensor_dataset import BitTensorDataset
+from marble_core import DataLoader, Core
+from marble_neuronenblitz import Neuronenblitz
+from quantum_flux_learning import QuantumFluxLearner
+from marble_imports import cp
+
+
+class QuantumFluxPairsPipeline:
+    """Train ``QuantumFluxLearner`` on ``(input, target)`` pairs."""
+
+    def __init__(
+        self,
+        core: Core,
+        save_path: str = "quantum_flux.pkl",
+        *,
+        phase_rate: float = 0.1,
+        dataloader: DataLoader | None = None,
+        tokenizer: Tokenizer | None = None,
+        use_vocab: bool = False,
+    ) -> None:
+        self.core = core
+        if dataloader is not None:
+            self.loader = dataloader
+            if tokenizer is not None:
+                self.loader.tokenizer = tokenizer
+        else:
+            self.loader = DataLoader(tokenizer=tokenizer)
+        self.save_path = save_path
+        self.use_vocab = use_vocab
+        self.last_dataset: BitTensorDataset | None = None
+        self.nb = Neuronenblitz(self.core)
+        self.learner = QuantumFluxLearner(self.core, self.nb, phase_rate=phase_rate)
+
+    def _to_float(self, obj: Any) -> float:
+        tensor = self.loader.encode(obj)
+        if hasattr(tensor, "mean"):
+            return float(cp.asnumpy(tensor).astype(float).mean())
+        return float(tensor)
+
+    def train(self, pairs: Iterable[tuple[Any, Any]] | Dataset, epochs: int = 1) -> str:
+        if isinstance(pairs, Dataset):
+            if isinstance(pairs, BitTensorDataset):
+                bit_ds = pairs
+            else:
+                bit_ds = BitTensorDataset([(i, t) for i, t in pairs], use_vocab=self.use_vocab)
+        else:
+            bit_ds = BitTensorDataset(list(pairs), use_vocab=self.use_vocab)
+
+        self.last_dataset = bit_ds
+        list_pairs = [
+            (self._to_float(bit_ds.tensor_to_object(inp)), self._to_float(bit_ds.tensor_to_object(tgt)))
+            for inp, tgt in bit_ds
+        ]
+        self.learner.train(list_pairs, epochs=epochs)
+        with open(self.save_path, "wb") as f:
+            pickle.dump({"core": self.core, "neuronenblitz": self.nb}, f)
+        return self.save_path

--- a/tests/test_hebbian_pipeline.py
+++ b/tests/test_hebbian_pipeline.py
@@ -1,0 +1,68 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from hebbian_pipeline import HebbianPipeline
+from bit_tensor_dataset import BitTensorDataset
+from marble_core import Core, DataLoader
+from tokenizer_utils import built_in_tokenizer
+from tests.test_core_functions import minimal_params
+
+
+def test_hebbian_pipeline_trains(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "hebb.pkl"
+    pipeline = HebbianPipeline(core, save_path=str(save_path))
+    data = [0.1, 0.2, 0.3]
+    out_path = pipeline.train(data, epochs=1)
+    assert out_path == str(save_path)
+    assert save_path.is_file()
+
+
+def test_hebbian_pipeline_non_numeric(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "hebb.pkl"
+    pipeline = HebbianPipeline(core, save_path=str(save_path))
+    data = ["foo", "bar"]
+    pipeline.train(data, epochs=1)
+    assert save_path.is_file()
+
+
+def test_hebbian_pipeline_with_tokenizer(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    text_file = tmp_path / "train.txt"
+    text_file.write_text("hello world")
+    tok = built_in_tokenizer("bert_wordpiece", lowercase=True)
+    tok.train([str(text_file)], vocab_size=20)
+    dl = DataLoader(tokenizer=tok)
+    save_path = tmp_path / "tok_hebb.pkl"
+    pipeline = HebbianPipeline(core, save_path=str(save_path), dataloader=dl)
+    data = ["hello", "world"]
+    pipeline.train(data, epochs=1)
+    assert save_path.is_file()
+
+
+def test_hebbian_pipeline_bit_dataset(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "bit_hebb.pkl"
+    pipeline = HebbianPipeline(core, save_path=str(save_path))
+    data = ["hi", "there"]
+    ds = BitTensorDataset([(d, d) for d in data])
+    pipeline.train(ds, epochs=1)
+    assert save_path.is_file()
+
+
+def test_hebbian_pipeline_auto_bit_dataset(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "auto_hebb.pkl"
+    pipeline = HebbianPipeline(core, save_path=str(save_path), use_vocab=True)
+    data = ["a", "b", "c"]
+    pipeline.train(data, epochs=1)
+    assert save_path.is_file()
+    assert isinstance(pipeline.last_dataset, BitTensorDataset)
+    assert pipeline.last_dataset.get_vocab() is not None

--- a/tests/test_quantum_flux_pairs_pipeline.py
+++ b/tests/test_quantum_flux_pairs_pipeline.py
@@ -1,0 +1,68 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from quantum_flux_pairs_pipeline import QuantumFluxPairsPipeline
+from bit_tensor_dataset import BitTensorDataset
+from marble_core import Core, DataLoader
+from tokenizer_utils import built_in_tokenizer
+from tests.test_core_functions import minimal_params
+
+
+def test_quantum_flux_pairs_pipeline_trains(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "qf.pkl"
+    pipeline = QuantumFluxPairsPipeline(core, save_path=str(save_path))
+    pairs = [(0.1, 0.2), (0.3, 0.4)]
+    out_path = pipeline.train(pairs, epochs=1)
+    assert out_path == str(save_path)
+    assert save_path.is_file()
+
+
+def test_quantum_flux_pairs_pipeline_non_numeric(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "qf.pkl"
+    pipeline = QuantumFluxPairsPipeline(core, save_path=str(save_path))
+    pairs = [("a", "b"), ("c", "d")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+
+
+def test_quantum_flux_pairs_pipeline_with_tokenizer(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    text_file = tmp_path / "train.txt"
+    text_file.write_text("hello world")
+    tok = built_in_tokenizer("bert_wordpiece", lowercase=True)
+    tok.train([str(text_file)], vocab_size=20)
+    dl = DataLoader(tokenizer=tok)
+    save_path = tmp_path / "tok_qf.pkl"
+    pipeline = QuantumFluxPairsPipeline(core, save_path=str(save_path), dataloader=dl)
+    pairs = [("hello", "world"), ("foo", "bar")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+
+
+def test_quantum_flux_pairs_pipeline_bit_dataset(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "bit_qf.pkl"
+    pipeline = QuantumFluxPairsPipeline(core, save_path=str(save_path))
+    pairs = [("hi", "there"), ("foo", "bar")]
+    ds = BitTensorDataset(pairs)
+    pipeline.train(ds, epochs=1)
+    assert save_path.is_file()
+
+
+def test_quantum_flux_pairs_pipeline_auto_bit_dataset(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "auto_qf.pkl"
+    pipeline = QuantumFluxPairsPipeline(core, save_path=str(save_path), use_vocab=True)
+    pairs = [("a", "b"), ("c", "d")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+    assert isinstance(pipeline.last_dataset, BitTensorDataset)
+    assert pipeline.last_dataset.get_vocab() is not None

--- a/tests/test_transfer_pairs_pipeline.py
+++ b/tests/test_transfer_pairs_pipeline.py
@@ -1,0 +1,68 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from transfer_pairs_pipeline import TransferPairsPipeline
+from bit_tensor_dataset import BitTensorDataset
+from marble_core import Core, DataLoader
+from tokenizer_utils import built_in_tokenizer
+from tests.test_core_functions import minimal_params
+
+
+def test_transfer_pairs_pipeline_trains(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "trans.pkl"
+    pipeline = TransferPairsPipeline(core, save_path=str(save_path))
+    pairs = [(0.1, 0.2), (0.3, 0.4)]
+    out_path = pipeline.train(pairs, epochs=1)
+    assert out_path == str(save_path)
+    assert save_path.is_file()
+
+
+def test_transfer_pairs_pipeline_non_numeric(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "trans.pkl"
+    pipeline = TransferPairsPipeline(core, save_path=str(save_path))
+    pairs = [("a", "b"), ("c", "d")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+
+
+def test_transfer_pairs_pipeline_with_tokenizer(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    text_file = tmp_path / "train.txt"
+    text_file.write_text("hello world")
+    tok = built_in_tokenizer("bert_wordpiece", lowercase=True)
+    tok.train([str(text_file)], vocab_size=20)
+    dl = DataLoader(tokenizer=tok)
+    save_path = tmp_path / "tok_trans.pkl"
+    pipeline = TransferPairsPipeline(core, save_path=str(save_path), dataloader=dl)
+    pairs = [("hello", "world"), ("foo", "bar")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+
+
+def test_transfer_pairs_pipeline_bit_dataset(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "bit_trans.pkl"
+    pipeline = TransferPairsPipeline(core, save_path=str(save_path))
+    pairs = [("hi", "there"), ("foo", "bar")]
+    ds = BitTensorDataset(pairs)
+    pipeline.train(ds, epochs=1)
+    assert save_path.is_file()
+
+
+def test_transfer_pairs_pipeline_auto_bit_dataset(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "auto_trans.pkl"
+    pipeline = TransferPairsPipeline(core, save_path=str(save_path), use_vocab=True)
+    pairs = [("a", "b"), ("c", "d")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+    assert isinstance(pipeline.last_dataset, BitTensorDataset)
+    assert pipeline.last_dataset.get_vocab() is not None

--- a/transfer_pairs_pipeline.py
+++ b/transfer_pairs_pipeline.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pickle
+from typing import Any, Iterable
+
+from tokenizers import Tokenizer
+from torch.utils.data import Dataset
+
+from bit_tensor_dataset import BitTensorDataset
+from marble_core import DataLoader, Core
+from marble_neuronenblitz import Neuronenblitz
+from transfer_learning import TransferLearner
+from marble_imports import cp
+
+
+class TransferPairsPipeline:
+    """Fine-tune using :class:`TransferLearner` on ``(input, target)`` pairs."""
+
+    def __init__(
+        self,
+        core: Core,
+        save_path: str = "transfer.pkl",
+        *,
+        freeze_fraction: float = 0.5,
+        dataloader: DataLoader | None = None,
+        tokenizer: Tokenizer | None = None,
+        use_vocab: bool = False,
+    ) -> None:
+        self.core = core
+        if dataloader is not None:
+            self.loader = dataloader
+            if tokenizer is not None:
+                self.loader.tokenizer = tokenizer
+        else:
+            self.loader = DataLoader(tokenizer=tokenizer)
+        self.save_path = save_path
+        self.use_vocab = use_vocab
+        self.last_dataset: BitTensorDataset | None = None
+        self.nb = Neuronenblitz(self.core)
+        self.learner = TransferLearner(self.core, self.nb, freeze_fraction=freeze_fraction)
+
+    def _to_float(self, obj: Any) -> float:
+        tensor = self.loader.encode(obj)
+        if hasattr(tensor, "mean"):
+            return float(cp.asnumpy(tensor).astype(float).mean())
+        return float(tensor)
+
+    def train(self, pairs: Iterable[tuple[Any, Any]] | Dataset, epochs: int = 1) -> str:
+        if isinstance(pairs, Dataset):
+            if isinstance(pairs, BitTensorDataset):
+                bit_ds = pairs
+            else:
+                bit_ds = BitTensorDataset([(i, t) for i, t in pairs], use_vocab=self.use_vocab)
+        else:
+            bit_ds = BitTensorDataset(list(pairs), use_vocab=self.use_vocab)
+
+        self.last_dataset = bit_ds
+        list_pairs = [
+            (self._to_float(bit_ds.tensor_to_object(inp)), self._to_float(bit_ds.tensor_to_object(tgt)))
+            for inp, tgt in bit_ds
+        ]
+        self.learner.train(list_pairs, epochs=epochs)
+        with open(self.save_path, "wb") as f:
+            pickle.dump({"core": self.core, "neuronenblitz": self.nb}, f)
+        return self.save_path


### PR DESCRIPTION
## Summary
- implement `HebbianPipeline`, `TransferPairsPipeline` and `QuantumFluxPairsPipeline`
- add tests for the new pipelines
- document new pipelines in README
- extend tutorial with Project 34 covering the new pipelines

## Testing
- `pytest -q tests/test_hebbian_pipeline.py`
- `pytest -q tests/test_transfer_pairs_pipeline.py`
- `pytest -q tests/test_quantum_flux_pairs_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_688b4c5504a0832786d13dedab2ea660