### PR TITLE
Add new BitTensor dataset pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ Several helper pipelines leverage ``BitTensorDataset`` to train various
 learning paradigms on arbitrary Python objects, including ``AutoencoderPipeline``,
 ``ContrastivePipeline``, ``DiffusionPairsPipeline``, ``UnifiedPairsPipeline``,
 ``SemiSupervisedPairsPipeline`` and the new ``ImitationPairsPipeline``,
-``FractalDimensionPairsPipeline``, ``HebbianPipeline``, ``TransferPairsPipeline``
-and ``QuantumFluxPairsPipeline``.
+``FractalDimensionPairsPipeline``, ``HebbianPipeline``, ``TransferPairsPipeline``,
+``QuantumFluxPairsPipeline``, ``CurriculumPairsPipeline``,
+``HarmonicResonancePairsPipeline`` and ``ConceptualIntegrationPipeline``.
 
 ### Command Line Usage
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1988,3 +1988,38 @@ reconstructed with the correct Python type during decoding.
    examples = [("up", "down"), ("left", "right")]
    pipe.train(examples, epochs=1)
    ```
+
+## Project 35 – Curriculum and Harmonic Pipelines
+
+**Goal:** Explore additional pipelines that work on bit-level data.**
+
+1. **Train a curriculum learning pipeline:**
+   ```python
+   from curriculum_pairs_pipeline import CurriculumPairsPipeline
+   from marble_core import Core
+   from tests.test_core_functions import minimal_params
+
+   core = Core(minimal_params())
+   pipe = CurriculumPairsPipeline(core, use_vocab=True)
+   pairs = [("easy", "task"), ("hard", "task")]
+   pipe.train(pairs, epochs=1)
+   ```
+2. **Use harmonic resonance learning on pairs:**
+   ```python
+   from harmonic_resonance_pairs_pipeline import HarmonicResonancePairsPipeline
+
+   core = Core(minimal_params())
+   pipe = HarmonicResonancePairsPipeline(core, use_vocab=True)
+   pairs = [("tone", "A"), ("tone", "B")]
+   pipe.train(pairs, epochs=1)
+   ```
+3. **Integrate concepts from arbitrary objects:**
+   ```python
+   from conceptual_integration_pipeline import ConceptualIntegrationPipeline
+
+   core = Core(minimal_params())
+   pipe = ConceptualIntegrationPipeline(core, use_vocab=True)
+   data = ["alpha", "beta", "gamma"]
+   pipe.train(data, epochs=1)
+   ```
+

--- a/conceptual_integration_pipeline.py
+++ b/conceptual_integration_pipeline.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pickle
+from typing import Any, Iterable
+
+from tokenizers import Tokenizer
+from torch.utils.data import Dataset
+
+from bit_tensor_dataset import BitTensorDataset
+from marble_core import DataLoader, Core
+from marble_neuronenblitz import Neuronenblitz
+from conceptual_integration import ConceptualIntegrationLearner
+from marble_imports import cp
+
+
+class ConceptualIntegrationPipeline:
+    """Train ``ConceptualIntegrationLearner`` on arbitrary inputs."""
+
+    def __init__(
+        self,
+        core: Core,
+        save_path: str = "concept_integration.pkl",
+        *,
+        dataloader: DataLoader | None = None,
+        tokenizer: Tokenizer | None = None,
+        use_vocab: bool = False,
+    ) -> None:
+        self.core = core
+        if dataloader is not None:
+            self.loader = dataloader
+            if tokenizer is not None:
+                self.loader.tokenizer = tokenizer
+        else:
+            self.loader = DataLoader(tokenizer=tokenizer)
+        self.save_path = save_path
+        self.use_vocab = use_vocab
+        self.last_dataset: BitTensorDataset | None = None
+        self.nb = Neuronenblitz(self.core)
+        self.learner = ConceptualIntegrationLearner(self.core, self.nb)
+
+    def _to_float(self, obj: Any) -> float:
+        tensor = self.loader.encode(obj)
+        if hasattr(tensor, "mean"):
+            return float(cp.asnumpy(tensor).astype(float).mean())
+        return float(tensor)
+
+    def train(self, data: Iterable[Any] | Dataset, epochs: int = 1) -> str:
+        if isinstance(data, Dataset):
+            if isinstance(data, BitTensorDataset):
+                bit_ds = data
+            else:
+                bit_ds = BitTensorDataset([(d, d) for d in data], use_vocab=self.use_vocab)
+        else:
+            bit_ds = BitTensorDataset([(d, d) for d in list(data)], use_vocab=self.use_vocab)
+
+        self.last_dataset = bit_ds
+
+        inputs = [self._to_float(bit_ds.tensor_to_object(inp)) for inp, _ in bit_ds]
+        self.learner.train(inputs, epochs=epochs)
+        with open(self.save_path, "wb") as f:
+            pickle.dump({"core": self.core, "neuronenblitz": self.nb}, f)
+        return self.save_path

--- a/curriculum_pairs_pipeline.py
+++ b/curriculum_pairs_pipeline.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pickle
+from typing import Any, Iterable, Tuple, Callable
+
+from tokenizers import Tokenizer
+from torch.utils.data import Dataset
+
+from bit_tensor_dataset import BitTensorDataset
+from marble_core import DataLoader, Core
+from marble_neuronenblitz import Neuronenblitz
+from curriculum_learning import CurriculumLearner
+from marble_imports import cp
+
+
+class CurriculumPairsPipeline:
+    """Train ``CurriculumLearner`` on ``(input, target)`` pairs."""
+
+    def __init__(
+        self,
+        core: Core,
+        save_path: str = "curriculum.pkl",
+        *,
+        difficulty_fn: Callable[[tuple[Any, Any]], float] | None = None,
+        schedule: str = "linear",
+        dataloader: DataLoader | None = None,
+        tokenizer: Tokenizer | None = None,
+        use_vocab: bool = False,
+    ) -> None:
+        self.core = core
+        if dataloader is not None:
+            self.loader = dataloader
+            if tokenizer is not None:
+                self.loader.tokenizer = tokenizer
+        else:
+            self.loader = DataLoader(tokenizer=tokenizer)
+        self.save_path = save_path
+        self.use_vocab = use_vocab
+        self.last_dataset: BitTensorDataset | None = None
+        self.nb = Neuronenblitz(self.core)
+        self.learner = CurriculumLearner(
+            self.core, self.nb, difficulty_fn=difficulty_fn, schedule=schedule
+        )
+
+    def _to_float(self, obj: Any) -> float:
+        tensor = self.loader.encode(obj)
+        if hasattr(tensor, "mean"):
+            return float(cp.asnumpy(tensor).astype(float).mean())
+        return float(tensor)
+
+    def train(self, pairs: Iterable[Tuple[Any, Any]] | Dataset, epochs: int = 1) -> str:
+        if isinstance(pairs, Dataset):
+            if isinstance(pairs, BitTensorDataset):
+                bit_ds = pairs
+            else:
+                bit_ds = BitTensorDataset([(i, t) for i, t in pairs], use_vocab=self.use_vocab)
+        else:
+            bit_ds = BitTensorDataset(list(pairs), use_vocab=self.use_vocab)
+
+        self.last_dataset = bit_ds
+
+        examples = [
+            (self._to_float(bit_ds.tensor_to_object(inp)), self._to_float(bit_ds.tensor_to_object(tgt)))
+            for inp, tgt in bit_ds
+        ]
+
+        self.learner.train(examples, epochs=epochs)
+        with open(self.save_path, "wb") as f:
+            pickle.dump({"core": self.core, "neuronenblitz": self.nb}, f)
+        return self.save_path

--- a/harmonic_resonance_pairs_pipeline.py
+++ b/harmonic_resonance_pairs_pipeline.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pickle
+from typing import Any, Iterable, Tuple
+
+from tokenizers import Tokenizer
+from torch.utils.data import Dataset
+
+from bit_tensor_dataset import BitTensorDataset
+from marble_core import DataLoader, Core
+from marble_neuronenblitz import Neuronenblitz
+from harmonic_resonance_learning import HarmonicResonanceLearner
+from marble_imports import cp
+
+
+class HarmonicResonancePairsPipeline:
+    """Train ``HarmonicResonanceLearner`` on ``(input, target)`` pairs."""
+
+    def __init__(
+        self,
+        core: Core,
+        save_path: str = "harmonic_resonance.pkl",
+        *,
+        base_frequency: float = 1.0,
+        decay: float = 0.99,
+        dataloader: DataLoader | None = None,
+        tokenizer: Tokenizer | None = None,
+        use_vocab: bool = False,
+    ) -> None:
+        self.core = core
+        if dataloader is not None:
+            self.loader = dataloader
+            if tokenizer is not None:
+                self.loader.tokenizer = tokenizer
+        else:
+            self.loader = DataLoader(tokenizer=tokenizer)
+        self.save_path = save_path
+        self.use_vocab = use_vocab
+        self.last_dataset: BitTensorDataset | None = None
+        self.nb = Neuronenblitz(self.core)
+        self.learner = HarmonicResonanceLearner(
+            self.core, self.nb, base_frequency=base_frequency, decay=decay
+        )
+
+    def _to_float(self, obj: Any) -> float:
+        tensor = self.loader.encode(obj)
+        if hasattr(tensor, "mean"):
+            return float(cp.asnumpy(tensor).astype(float).mean())
+        return float(tensor)
+
+    def train(self, pairs: Iterable[Tuple[Any, Any]] | Dataset, epochs: int = 1) -> str:
+        if isinstance(pairs, Dataset):
+            if isinstance(pairs, BitTensorDataset):
+                bit_ds = pairs
+            else:
+                bit_ds = BitTensorDataset([(i, t) for i, t in pairs], use_vocab=self.use_vocab)
+        else:
+            bit_ds = BitTensorDataset(list(pairs), use_vocab=self.use_vocab)
+
+        self.last_dataset = bit_ds
+
+        examples = [
+            (self._to_float(bit_ds.tensor_to_object(inp)), self._to_float(bit_ds.tensor_to_object(tgt)))
+            for inp, tgt in bit_ds
+        ]
+
+        for _ in range(int(epochs)):
+            for inp, tgt in examples:
+                self.learner.train_step(inp, tgt)
+        with open(self.save_path, "wb") as f:
+            pickle.dump({"core": self.core, "neuronenblitz": self.nb}, f)
+        return self.save_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -134,3 +134,4 @@ xxhash==3.5.0
 yarl==1.20.1
 zipp==3.23.0
 openpyxl==3.1.2
+et_xmlfile==2.0.0

--- a/tests/test_conceptual_integration_pipeline.py
+++ b/tests/test_conceptual_integration_pipeline.py
@@ -1,0 +1,67 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from conceptual_integration_pipeline import ConceptualIntegrationPipeline
+from bit_tensor_dataset import BitTensorDataset
+from marble_core import Core, DataLoader
+from tokenizer_utils import built_in_tokenizer
+from tests.test_core_functions import minimal_params
+
+
+def test_conceptual_integration_pipeline_trains(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "cip.pkl"
+    pipeline = ConceptualIntegrationPipeline(core, save_path=str(save_path))
+    data = [0.1, 0.2, 0.3]
+    out_path = pipeline.train(data, epochs=1)
+    assert out_path == str(save_path)
+    assert save_path.is_file()
+
+
+def test_conceptual_integration_pipeline_non_numeric(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "cip.pkl"
+    pipeline = ConceptualIntegrationPipeline(core, save_path=str(save_path))
+    data = ["foo", "bar"]
+    pipeline.train(data, epochs=1)
+    assert save_path.is_file()
+
+
+def test_conceptual_integration_pipeline_with_tokenizer(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    text_file = tmp_path / "train.txt"
+    text_file.write_text("hello world")
+    tok = built_in_tokenizer("bert_wordpiece", lowercase=True)
+    tok.train([str(text_file)], vocab_size=20)
+    dl = DataLoader(tokenizer=tok)
+    save_path = tmp_path / "tok_cip.pkl"
+    pipeline = ConceptualIntegrationPipeline(core, save_path=str(save_path), dataloader=dl)
+    data = ["hello", "world"]
+    pipeline.train(data, epochs=1)
+    assert save_path.is_file()
+
+
+def test_conceptual_integration_pipeline_bit_dataset(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "bit_cip.pkl"
+    pipeline = ConceptualIntegrationPipeline(core, save_path=str(save_path))
+    data = ["hi", "there"]
+    ds = BitTensorDataset([(d, d) for d in data])
+    pipeline.train(ds, epochs=1)
+    assert save_path.is_file()
+
+
+def test_conceptual_integration_pipeline_auto_bit_dataset(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "auto_cip.pkl"
+    pipeline = ConceptualIntegrationPipeline(core, save_path=str(save_path), use_vocab=True)
+    data = ["a", "b", "c"]
+    pipeline.train(data, epochs=1)
+    assert save_path.is_file()
+    assert isinstance(pipeline.last_dataset, BitTensorDataset)
+    assert pipeline.last_dataset.get_vocab() is not None

--- a/tests/test_curriculum_pairs_pipeline.py
+++ b/tests/test_curriculum_pairs_pipeline.py
@@ -1,0 +1,67 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from curriculum_pairs_pipeline import CurriculumPairsPipeline
+from bit_tensor_dataset import BitTensorDataset
+from marble_core import Core, DataLoader
+from tokenizer_utils import built_in_tokenizer
+from tests.test_core_functions import minimal_params
+
+
+def test_curriculum_pairs_pipeline_trains(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "curr.pkl"
+    pipeline = CurriculumPairsPipeline(core, save_path=str(save_path))
+    pairs = [(0.1, 0.2), (0.3, 0.4)]
+    out_path = pipeline.train(pairs, epochs=1)
+    assert out_path == str(save_path)
+    assert save_path.is_file()
+
+
+def test_curriculum_pairs_pipeline_non_numeric(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "curr.pkl"
+    pipeline = CurriculumPairsPipeline(core, save_path=str(save_path))
+    pairs = [("hello", "world"), ("foo", "bar")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+
+
+def test_curriculum_pairs_pipeline_with_tokenizer(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    text_file = tmp_path / "train.txt"
+    text_file.write_text("hello world")
+    tok = built_in_tokenizer("bert_wordpiece", lowercase=True)
+    tok.train([str(text_file)], vocab_size=20)
+    dl = DataLoader(tokenizer=tok)
+    save_path = tmp_path / "tok_curr.pkl"
+    pipeline = CurriculumPairsPipeline(core, save_path=str(save_path), dataloader=dl)
+    pairs = [("hello", "world"), ("foo", "bar")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+
+
+def test_curriculum_pairs_pipeline_bit_dataset(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "bit_curr.pkl"
+    pipeline = CurriculumPairsPipeline(core, save_path=str(save_path))
+    pairs = [("hi", "there"), ("foo", "bar")]
+    ds = BitTensorDataset(pairs)
+    pipeline.train(ds, epochs=1)
+    assert save_path.is_file()
+
+
+def test_curriculum_pairs_pipeline_auto_bit_dataset(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "auto_curr.pkl"
+    pipeline = CurriculumPairsPipeline(core, save_path=str(save_path), use_vocab=True)
+    pairs = [("a", "b"), ("c", "d")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+    assert isinstance(pipeline.last_dataset, BitTensorDataset)
+    assert pipeline.last_dataset.get_vocab() is not None

--- a/tests/test_harmonic_resonance_pairs_pipeline.py
+++ b/tests/test_harmonic_resonance_pairs_pipeline.py
@@ -1,0 +1,67 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from harmonic_resonance_pairs_pipeline import HarmonicResonancePairsPipeline
+from bit_tensor_dataset import BitTensorDataset
+from marble_core import Core, DataLoader
+from tokenizer_utils import built_in_tokenizer
+from tests.test_core_functions import minimal_params
+
+
+def test_harmonic_resonance_pipeline_trains(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "harm.pkl"
+    pipeline = HarmonicResonancePairsPipeline(core, save_path=str(save_path))
+    pairs = [(0.1, 0.2), (0.3, 0.4)]
+    out_path = pipeline.train(pairs, epochs=1)
+    assert out_path == str(save_path)
+    assert save_path.is_file()
+
+
+def test_harmonic_resonance_pipeline_non_numeric(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "harm.pkl"
+    pipeline = HarmonicResonancePairsPipeline(core, save_path=str(save_path))
+    pairs = [("foo", "bar"), ("baz", "qux")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+
+
+def test_harmonic_resonance_pipeline_with_tokenizer(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    text_file = tmp_path / "train.txt"
+    text_file.write_text("hello world")
+    tok = built_in_tokenizer("bert_wordpiece", lowercase=True)
+    tok.train([str(text_file)], vocab_size=20)
+    dl = DataLoader(tokenizer=tok)
+    save_path = tmp_path / "tok_harm.pkl"
+    pipeline = HarmonicResonancePairsPipeline(core, save_path=str(save_path), dataloader=dl)
+    pairs = [("hello", "world"), ("foo", "bar")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+
+
+def test_harmonic_resonance_pipeline_bit_dataset(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "bit_harm.pkl"
+    pipeline = HarmonicResonancePairsPipeline(core, save_path=str(save_path))
+    pairs = [("hi", "there"), ("foo", "bar")]
+    ds = BitTensorDataset(pairs)
+    pipeline.train(ds, epochs=1)
+    assert save_path.is_file()
+
+
+def test_harmonic_resonance_pipeline_auto_bit_dataset(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    save_path = tmp_path / "auto_harm.pkl"
+    pipeline = HarmonicResonancePairsPipeline(core, save_path=str(save_path), use_vocab=True)
+    pairs = [("a", "b"), ("c", "d")]
+    pipeline.train(pairs, epochs=1)
+    assert save_path.is_file()
+    assert isinstance(pipeline.last_dataset, BitTensorDataset)
+    assert pipeline.last_dataset.get_vocab() is not None


### PR DESCRIPTION
## Summary
- implement CurriculumPairsPipeline, HarmonicResonancePairsPipeline and ConceptualIntegrationPipeline
- document new pipelines in README and TUTORIAL
- add tests for each new pipeline
- add missing dependency entry in requirements.txt

## Testing
- `pytest tests/test_curriculum_pairs_pipeline.py -q`
- `pytest tests/test_harmonic_resonance_pairs_pipeline.py -q`
- `pytest tests/test_conceptual_integration_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688b503a82788327a27b1b62a1aba1e0