### PR TITLE
Add HighLevelPipeline builder

### DIFF
--- a/highlevel_pipeline.py
+++ b/highlevel_pipeline.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+import json
+from typing import Any, Callable
+
+import marble_interface
+
+
+class HighLevelPipeline:
+    """Build and execute sequential MARBLE operations."""
+
+    def __init__(self, steps: list[dict] | None = None) -> None:
+        self.steps: list[dict] = steps or []
+
+    def __getattr__(self, name: str) -> Callable:
+        if hasattr(marble_interface, name):
+            def wrapper(**params):
+                self.add_step(name, module="marble_interface", params=params)
+                return self
+            return wrapper
+        raise AttributeError(name)
+
+    def add_step(
+        self,
+        func: str | Callable,
+        *,
+        module: str | None = None,
+        params: dict | None = None,
+    ) -> 'HighLevelPipeline':
+        if callable(func):
+            module = module or func.__module__
+            func = func.__name__
+        self.steps.append({"func": func, "module": module, "params": params or {}})
+        return self
+
+    def execute(self, marble: Any | None = None) -> tuple[Any | None, list[Any]]:
+        current_marble = marble
+        results: list[Any] = []
+        for step in self.steps:
+            module_name = step.get("module")
+            func_name = step["func"]
+            params = step.get("params", {})
+            module = importlib.import_module(module_name) if module_name else marble_interface
+            if not hasattr(module, func_name):
+                raise ValueError(f"Unknown function: {func_name}")
+            func = getattr(module, func_name)
+            sig = inspect.signature(func)
+            kwargs = {}
+            for name, p in sig.parameters.items():
+                if name == "marble":
+                    kwargs[name] = current_marble
+                elif name in params:
+                    kwargs[name] = params[name]
+                elif p.default is not inspect.Parameter.empty:
+                    kwargs[name] = p.default
+                else:
+                    raise ValueError(f"Missing parameter: {name}")
+            result = func(**kwargs)
+            if isinstance(result, marble_interface.MARBLE):
+                current_marble = result
+            results.append(result)
+        return current_marble, results
+
+    def save_json(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(self.steps, f, indent=2)
+
+    @classmethod
+    def load_json(cls, file_obj) -> "HighLevelPipeline":
+        steps = json.load(file_obj)
+        return cls(steps=steps)

--- a/tests/test_highlevel_pipeline.py
+++ b/tests/test_highlevel_pipeline.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import yaml
+from tqdm import tqdm as std_tqdm
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import marble_imports
+import marble_brain
+import marble_main
+from marble_base import MetricsVisualizer
+from tests.test_core_functions import minimal_params
+
+import marble_interface
+from highlevel_pipeline import HighLevelPipeline
+
+
+def _config_path(tmp_path):
+    cfg = {"core": minimal_params(), "brain": {"save_dir": str(tmp_path)}}
+    p = tmp_path / "cfg.yaml"
+    with open(p, "w", encoding="utf-8") as f:
+        yaml.dump(cfg, f)
+    return p
+
+
+def test_highlevel_pipeline_runs(tmp_path):
+    marble_imports.tqdm = std_tqdm
+    marble_brain.tqdm = std_tqdm
+    marble_main.MetricsVisualizer = MetricsVisualizer
+
+    cfg = _config_path(tmp_path)
+    hp = HighLevelPipeline()
+    hp.new_marble_system(config_path=str(cfg))
+    hp.train_marble_system(train_examples=[(0.1, 0.2)], epochs=1)
+    marble, results = hp.execute()
+    assert isinstance(marble, marble_interface.MARBLE)
+    assert len(results) == 2
+
+
+def test_highlevel_pipeline_save_load(tmp_path):
+    hp = HighLevelPipeline()
+    hp.add_step("new_marble_system", module="marble_interface", params={})
+    json_path = tmp_path / "pipe.json"
+    hp.save_json(json_path)
+    with open(json_path, "r", encoding="utf-8") as f:
+        loaded = HighLevelPipeline.load_json(f)
+    assert loaded.steps == hp.steps


### PR DESCRIPTION
## Summary
- implement `HighLevelPipeline` for chaining Marble operations
- add tests for the new pipeline builder

## Testing
- `pytest tests/test_highlevel_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688b5417633483279a547c7f4d71c761