### PR TITLE
Improve HighLevelPipeline step handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ Python API for building these workflows. Functions from ``marble_interface``
 can be added directly as methods while any repository module can be accessed via
 attribute notation, for example ``HighLevelPipeline().plugin_system.load_plugins``
 which appends a call to ``plugin_system.load_plugins``.
+The pipeline accepts custom callables and automatically tracks the active
+``MARBLE`` instance whenever a step returns one, even if nested inside tuples or
+dicts.
 Multiple MARBLE systems can be created in one session. Use the *Active Instance*
 selector in the sidebar to switch between them, duplicate a system for
 comparison or delete instances you no longer need.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1665,6 +1665,9 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
    sequence. The same pipelines can be saved as JSON and executed from the
    command line using ``python cli.py --pipeline mypipe.json`` or through the
    ``Pipeline``/``HighLevelPipeline`` classes in your own scripts.
+   Custom callables may be added as steps and any MARBLE instance returned
+   (even inside tuples or dictionaries) becomes the active system for the
+   following operations.
 12. **View the core graph** on the *Visualization* tab. Press **Generate Graph**
    to see an interactive display of neurons and synapses.
 13. **Inspect synaptic weights** on the *Weight Heatmap* tab. Set a maximum

--- a/tests/test_highlevel_pipeline.py
+++ b/tests/test_highlevel_pipeline.py
@@ -59,3 +59,22 @@ def test_highlevel_pipeline_cross_module(tmp_path):
     marble, results = hp.execute()
     assert isinstance(marble, marble_interface.MARBLE)
     assert results[0] is None
+
+
+def test_highlevel_pipeline_detect_marble_in_nested(tmp_path):
+    marble_imports.tqdm = std_tqdm
+    marble_brain.tqdm = std_tqdm
+    marble_main.MetricsVisualizer = MetricsVisualizer
+
+    cfg = _config_path(tmp_path)
+
+    def make_marble(marble=None):
+        return {"hooked": True}, marble_interface.new_marble_system(config_path=str(cfg))
+
+    hp = HighLevelPipeline()
+    hp.add_step(make_marble)
+    hp.train_marble_system(train_examples=[(0.0, 0.0)], epochs=1)
+    marble, results = hp.execute()
+    assert isinstance(marble, marble_interface.MARBLE)
+    assert isinstance(results[0], tuple)
+    assert results[0][0] == {"hooked": True}


### PR DESCRIPTION
## Summary
- support callable steps in `HighLevelPipeline` and track nested MARBLE returns
- prevent saving pipelines that contain callables
- document the improved pipeline usage in `README.md` and `TUTORIAL.md`
- test callable step execution and nested MARBLE detection

## Testing
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_runs -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_save_load -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_cross_module -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_detect_marble_in_nested -q`


------
https://chatgpt.com/codex/tasks/task_e_688b6935f7c48327b77a2c925ec8bf96