### PR TITLE
Update HighLevelPipeline defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ Nested modules are automatically resolved so ``HighLevelPipeline().marble_neuron
 The pipeline accepts custom callables and automatically tracks the active
 ``MARBLE`` instance whenever a step returns one, even if nested inside tuples or
 dicts.
+Dataset arguments are converted to :class:`BitTensorDataset` automatically with
+mixed mode enabled, no vocabulary size limit and a minimum word length and
+occurrence of ``4``. Additional argument names can be registered with
+``HighLevelPipeline.register_data_args`` to support custom features.
 Multiple MARBLE systems can be created in one session. Use the *Active Instance*
 selector in the sidebar to switch between them, duplicate a system for
 comparison or delete instances you no longer need.

--- a/tests/test_highlevel_pipeline.py
+++ b/tests/test_highlevel_pipeline.py
@@ -13,6 +13,7 @@ from tests.test_core_functions import minimal_params
 
 import marble_interface
 from highlevel_pipeline import HighLevelPipeline
+from bit_tensor_dataset import BitTensorDataset
 
 
 def _config_path(tmp_path):
@@ -90,3 +91,25 @@ def test_highlevel_pipeline_nested_module(tmp_path):
     hp.new_marble_system(config_path=str(cfg))
     hp.marble_neuronenblitz.learning.disable_rl(nb=None)
     assert hp.steps[-1]["module"] == "marble_neuronenblitz.learning"
+
+
+def test_highlevel_pipeline_default_bit_params():
+    hp = HighLevelPipeline()
+    ds = hp._maybe_bit_dataset([1, 2])
+    assert isinstance(ds, BitTensorDataset)
+    assert ds.mixed is True
+    assert ds.max_vocab_size is None
+    assert ds.min_word_length == 4
+    assert ds.min_occurrence == 4
+
+
+def test_highlevel_pipeline_register_data_args():
+    hp = HighLevelPipeline()
+
+    def grab(custom=None):
+        return custom
+
+    hp.register_data_args("custom")
+    hp.add_step(grab, params={"custom": [10, 11]})
+    _, results = hp.execute()
+    assert isinstance(results[0], BitTensorDataset)


### PR DESCRIPTION
## Summary
- default `HighLevelPipeline` to use BitTensorDataset for any dataset argument
- allow registering additional dataset argument names
- document BitTensorDataset defaults in README
- test new pipeline behaviour

## Testing
- `pytest tests/test_highlevel_pipeline.py`
- `pytest tests/test_bit_tensor_dataset.py`


------
https://chatgpt.com/codex/tasks/task_e_688b9189af508327b6b6330b89789e5c