### PR TITLE
Improve HighLevelPipeline defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,12 @@ The pipeline accepts custom callables and automatically tracks the active
 dicts.
 Dataset arguments are converted to :class:`BitTensorDataset` automatically with
 mixed mode enabled, no vocabulary size limit and a minimum word length and
-occurrence of ``4``. Additional argument names can be registered with
-``HighLevelPipeline.register_data_args`` to support custom features.
+occurrence of ``4``.  All feature inputs are wrapped by default so every
+operation receives data in a consistent form. Additional argument names can be
+registered with ``HighLevelPipeline.register_data_args`` to support custom
+features. Arbitrary steps from any module can be chained together, allowing any
+combination of MARBLE functionality to be expressed through a single
+``HighLevelPipeline`` instance.
 Multiple MARBLE systems can be created in one session. Use the *Active Instance*
 selector in the sidebar to switch between them, duplicate a system for
 comparison or delete instances you no longer need.

--- a/highlevel_pipeline.py
+++ b/highlevel_pipeline.py
@@ -43,7 +43,15 @@ class _ModuleWrapper:
 
 
 class HighLevelPipeline:
-    """Build and execute sequential MARBLE operations."""
+    """Build and execute sequential MARBLE operations.
+
+    The pipeline automatically wraps dataset-like arguments in
+    :class:`BitTensorDataset` using ``mixed`` mode, no vocabulary size limit and
+    a minimum word length and occurrence of ``4``.  Functions from
+    :mod:`marble_interface` as well as any other module within the repository
+    can be appended dynamically via attribute access, enabling arbitrary
+    combinations of MARBLE features to be executed in sequence.
+    """
 
     DEFAULT_BIT_PARAMS = {
         "mixed": True,
@@ -60,6 +68,7 @@ class HighLevelPipeline:
         "examples",
         "labeled_pairs",
         "unlabeled_inputs",
+        "features",
     }
 
     def __init__(


### PR DESCRIPTION
## Summary
- expand HighLevelPipeline documentation
- wrap dataset arguments named `features` by default
- document chaining capability in README
- add test covering multi-step pipeline

## Testing
- `pre-commit run --files highlevel_pipeline.py README.md tests/test_highlevel_pipeline.py`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_runs -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_save_load -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_cross_module -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_detect_marble_in_nested -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_nested_module -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_default_bit_params -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_register_data_args -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_multi_step_chain -q`


------
https://chatgpt.com/codex/tasks/task_e_688b938e67e883279d0c0ebbaeb951a6