### PR TITLE
Add context manager to MemoryPool

### DIFF
--- a/memory_pool.py
+++ b/memory_pool.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from collections import deque
-from typing import Callable
+from typing import Callable, Iterator
+import contextlib
 
 
 class MemoryPool:
@@ -22,3 +23,23 @@ class MemoryPool:
     def release(self, obj: object) -> None:
         if len(self._free) < self.max_size:
             self._free.append(obj)
+
+    def preallocate(self, count: int) -> None:
+        """Pre-fill the pool with ``count`` new objects."""
+        for _ in range(count):
+            if len(self._free) >= self.max_size:
+                break
+            self._free.append(self.factory())
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        """Return the number of available objects in the pool."""
+        return len(self._free)
+
+    @contextlib.contextmanager
+    def borrow(self) -> Iterator[object]:
+        """Context manager yielding an allocated object and releasing it on exit."""
+        obj = self.allocate()
+        try:
+            yield obj
+        finally:
+            self.release(obj)

--- a/tests/test_memory_pool.py
+++ b/tests/test_memory_pool.py
@@ -11,3 +11,14 @@ def test_memory_pool_allocate_release():
     b = pool.allocate()
     assert a is b
     pool.release(b)
+
+
+def test_memory_pool_preallocate_and_borrow():
+    pool = MemoryPool(Dummy, max_size=3)
+    pool.preallocate(2)
+    assert len(pool) == 2
+    with pool.borrow() as obj:
+        assert isinstance(obj, Dummy)
+        obj.value = 42
+    # object should have been released back to pool
+    assert len(pool) == 2


### PR DESCRIPTION
## Summary
- enhance `MemoryPool` with `preallocate`, `__len__`, and a `borrow` context manager
- test new functionality in `test_memory_pool`
- verify select tests

## Testing
- `pytest tests/test_memory_pool.py`
- `pytest tests/test_utils.py`
- `pytest tests/test_activation_utils.py`
- `pytest tests/test_attention_module.py`


------
https://chatgpt.com/codex/tasks/task_e_688bbf5015c48327b76ba09acc6aa5ac