### PR TITLE
Add activation heatmap colormap parameter

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -63,6 +63,7 @@ Each entry is listed under its section heading.
 - noise_schedule
 - workspace_broadcast
 - activation_output_dir
+- activation_colormap
 - memory_system
 - cwfl
 - harmonic

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ diffusion models can be trained and sampled entirely within MARBLE.
 When ``workspace_broadcast`` is enabled the final sample of each diffusion run
 is published through the Global Workspace so other modules can react in real
 time.
+Activation heatmaps for each run can be written by setting
+``activation_output_dir`` and selecting a colour map with
+``activation_colormap`` (e.g. ``"plasma"``) in the configuration.
 
 MARBLE can train on datasets provided as lists of ``(input, target)`` pairs or using PyTorch-style ``Dataset``/``DataLoader`` objects. Each sample must expose an ``input`` and ``target`` field. After training and saving a model, ``Brain.infer`` generates outputs when given only an input value.
 For quick experiments without external files you can generate synthetic regression pairs using ``synthetic_dataset.generate_sine_wave_dataset``.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1850,7 +1850,8 @@ plugins and components.
    the diffusion engine stores each step in hierarchical memory, trains the
    continuous weight field, adapts representations via harmonic resonance and
    fractal learning and finally writes an activation heatmap to the configured
-   directory.
+   directory. The colour map used for this heatmap can be selected with
+   ``activation_colormap``.
 
 Running this project demonstrates the new ``DiffusionCore`` which integrates
 Neuronenblitz wandering, hybrid memory and remote offloading to support

--- a/activation_visualization.py
+++ b/activation_visualization.py
@@ -4,11 +4,24 @@ import matplotlib.pyplot as plt
 from marble_core import Core
 
 
-def plot_activation_heatmap(core: Core, path: str) -> None:
-    """Plot a heatmap of all neuron representations and save it to ``path``."""
+def plot_activation_heatmap(core: Core, path: str, *, cmap: str = "viridis") -> None:
+    """Plot a heatmap of all neuron representations and save it to ``path``.
+
+    Parameters
+    ----------
+    core:
+        The :class:`~marble_core.Core` instance whose neuron activations will
+        be visualised.
+    path:
+        Destination filepath for the generated image.
+    cmap:
+        Matplotlib colour map to apply when rendering the heatmap. Examples are
+        ``"viridis"`` (default), ``"plasma"`` or any name accepted by
+        :func:`matplotlib.pyplot.colormaps`.
+    """
     reps = np.stack([n.representation for n in core.neurons])
     plt.figure(figsize=(8, 6))
-    plt.imshow(reps, aspect="auto", interpolation="nearest", cmap="viridis")
+    plt.imshow(reps, aspect="auto", interpolation="nearest", cmap=cmap)
     plt.xlabel("Representation Index")
     plt.ylabel("Neuron ID")
     plt.colorbar(label="Activation")

--- a/config.yaml
+++ b/config.yaml
@@ -77,6 +77,7 @@ core:
   noise_schedule: "linear"
   workspace_broadcast: false
   activation_output_dir: "activations"
+  activation_colormap: "viridis"
   memory_system:
     long_term_path: "diffusion_memory.pkl"
     threshold: 0.5

--- a/diffusion_core.py
+++ b/diffusion_core.py
@@ -50,6 +50,7 @@ class DiffusionCore(Core):
         harmonic_params: dict | None = None,
         fractal_params: dict | None = None,
         activation_output_dir: str | None = None,
+        activation_colormap: str | None = None,
         plugin_dirs: list[str] | None = None,
     ) -> None:
         params = params.copy() if params is not None else {}
@@ -63,6 +64,8 @@ class DiffusionCore(Core):
             params.setdefault("noise_schedule", noise_schedule)
         if workspace_broadcast is not None:
             params.setdefault("workspace_broadcast", workspace_broadcast)
+        if activation_colormap is not None:
+            params.setdefault("activation_colormap", activation_colormap)
         super().__init__(params, metrics_visualizer=metrics_visualizer)
         self.diffusion_steps = int(self.params.get("diffusion_steps", 10))
         self.noise_start = float(self.params.get("noise_start", 1.0))
@@ -129,6 +132,7 @@ class DiffusionCore(Core):
                 target_dimension=fractal_params.get("target_dimension", 4.0),
             )
         self.activation_output_dir = activation_output_dir
+        self.activation_colormap = self.params.get("activation_colormap", "viridis")
         if plugin_dirs:
             load_plugins(plugin_dirs)
 
@@ -209,7 +213,7 @@ class DiffusionCore(Core):
         if self.activation_output_dir is not None:
             path = os.path.join(self.activation_output_dir, f"diffusion_{len(self.history)}.png")
             os.makedirs(os.path.dirname(path), exist_ok=True)
-            plot_activation_heatmap(self, path)
+            plot_activation_heatmap(self, path, cmap=self.activation_colormap)
         if (
             self.remote_client is not None
             and self.get_usage_by_tier("vram")

--- a/tests/test_activation_utils.py
+++ b/tests/test_activation_utils.py
@@ -10,5 +10,5 @@ def test_activation_heatmap(tmp_path):
     core = Core(params)
     perform_message_passing(core)
     out_file = tmp_path / "heat.png"
-    plot_activation_heatmap(core, out_file)
+    plot_activation_heatmap(core, out_file, cmap="plasma")
     assert out_file.exists() and out_file.stat().st_size > 0

--- a/tests/test_diffusion_core_additional_features.py
+++ b/tests/test_diffusion_core_additional_features.py
@@ -11,6 +11,7 @@ def test_diffusion_core_additional_features(tmp_path):
     params = minimal_params()
     params["diffusion_steps"] = 1
     params["activation_output_dir"] = str(tmp_path)
+    params["activation_colormap"] = "plasma"
     params["memory_system"] = {
         "long_term_path": str(tmp_path / "lt.pkl"),
         "threshold": 0.5,
@@ -30,6 +31,7 @@ def test_diffusion_core_additional_features(tmp_path):
         harmonic_params=params["harmonic"],
         fractal_params=params["fractal"],
         activation_output_dir=params["activation_output_dir"],
+        activation_colormap=params["activation_colormap"],
     )
     out = core.diffuse(0.1)
     assert isinstance(out, float)

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -188,6 +188,11 @@ core:
   activation_output_dir: Directory where a heatmap of neuron activations is
     written after every diffusion run. Useful for visualising internal state
     evolution. The directory is created automatically if it does not exist.
+  activation_colormap: Name of the Matplotlib colour map used for activation
+    heatmaps. Popular options are ``"viridis"``, ``"plasma"`` and
+    ``"cividis"``. Choose a map that provides good contrast when visualising
+    neuron activations. Custom names accepted by
+    :func:`matplotlib.pyplot.colormaps` may also be used.
   memory_system:
     long_term_path: File used for persistent storage of diffusion outputs. Both
       short- and long-term layers are utilised so recent results can be cached


### PR DESCRIPTION
## Summary
- support setting a custom colormap for activation heatmaps
- document the `activation_colormap` setting in README, TUTORIAL, yaml manual and config docs
- adjust DiffusionCore and heatmap plotting utilities to honour the new setting
- update tests for activation heatmaps and diffusion features

## Testing
- `pytest tests/test_activation_utils.py -q`
- `pytest tests/test_diffusion_core.py -q`
- `pytest tests/test_diffusion_core_features.py -q`
- `pytest tests/test_diffusion_core_extra_features.py -q`
- `pytest tests/test_diffusion_core_additional_features.py -q`
- `pytest tests/test_diffusion_pairs_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688bc2b5be588327910aa08719eaff37