### PR TITLE
Add optional NumPy output for Mandelbrot

### DIFF
--- a/marble_core.py
+++ b/marble_core.py
@@ -1241,6 +1241,8 @@ def compute_mandelbrot(
     max_iter: int = 256,
     escape_radius: float = 2.0,
     power: int = 2,
+    *,
+    as_numpy: bool = False,
 ):
     """Return a Mandelbrot set fragment as a 2D array.
 
@@ -1259,6 +1261,9 @@ def compute_mandelbrot(
         Absolute value beyond which points are marked as diverging.
     power : int, optional
         Exponent applied during iteration, allowing fractal variations.
+    as_numpy : bool, optional
+        When ``True`` the result is returned as a NumPy array even if GPU
+        acceleration is available. ``False`` by default.
     """
 
     x = cp.linspace(xmin, xmax, width)
@@ -1274,6 +1279,8 @@ def compute_mandelbrot(
             break
         Z[mask] = Z[mask] ** power + C[mask]
         mandelbrot[mask] = i
+    if as_numpy and hasattr(cp, "asnumpy"):
+        return cp.asnumpy(mandelbrot)
     return mandelbrot
 
 

--- a/tests/test_mandelbrot_numpy.py
+++ b/tests/test_mandelbrot_numpy.py
@@ -1,0 +1,8 @@
+import numpy as np
+from marble_core import compute_mandelbrot
+
+
+def test_compute_mandelbrot_as_numpy():
+    arr = compute_mandelbrot(-2, 1, -1.5, 1.5, 3, 3, as_numpy=True)
+    assert isinstance(arr, np.ndarray)
+    assert arr.shape == (3, 3)


### PR DESCRIPTION
## Summary
- extend `compute_mandelbrot` to optionally return a NumPy array
- document new option in the docstring
- test new behaviour

## Testing
- `pytest tests/test_core_functions.py::test_compute_mandelbrot_shape -q`
- `pytest tests/test_core_functions.py::test_compute_mandelbrot_parameters_change_output -q`
- `pytest tests/test_mandelbrot_caching.py::test_mandelbrot_cache_hits -q`
- `pytest tests/test_mandelbrot_numpy.py::test_compute_mandelbrot_as_numpy -q`


------
https://chatgpt.com/codex/tasks/task_e_688bc4fc3b948327bb2ac39334e2bdda