### PR TITLE
Improve dataset and pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ even audio and arbitrary byte blobs without additional conversion steps. When
 operating directly on the bit level, ``BitTensorDataset`` can convert objects
 into binary tensors and optionally build a shared vocabulary for compact
 storage.
+You can also pass an existing ``vocab`` dictionary to reuse the same mapping
+across multiple datasets for consistent encoding.
 
 Several helper pipelines leverage ``BitTensorDataset`` to train various
 learning paradigms on arbitrary Python objects, including ``AutoencoderPipeline``,
@@ -156,8 +158,10 @@ pretrained model from the Hugging Face Hub and converting it into a MARBLE
 system with one click.
 Pipelines can be imported or exported as JSON and a **Custom Code** tab lets you
 run arbitrary Python snippets with the active MARBLE instance.
-Pipeline steps may also be reordered or removed directly from the UI so complex
-workflows can be iterated on quickly.
+Pipeline steps may also be reordered or removed directly from the UI. The same
+functionality is exposed programmatically via ``HighLevelPipeline.move_step``
+and ``HighLevelPipeline.remove_step`` so complex workflows can be iterated on
+quickly.
 You can run the same JSON pipelines from the command line using ``--pipeline``
 with ``cli.py`` or execute them programmatically through the ``Pipeline``
 class for full automation. A ``HighLevelPipeline`` helper offers a fluent
@@ -172,7 +176,9 @@ dicts.
 Dataset arguments are converted to :class:`BitTensorDataset` automatically with
 mixed mode enabled, no vocabulary size limit and a minimum word length and
 occurrence of ``4``.  All feature inputs are wrapped by default so every
-operation receives data in a consistent form. Additional argument names can be
+operation receives data in a consistent form. A pre-built vocabulary can be
+supplied via ``bit_dataset_params`` so multiple steps encode data identically.
+Additional argument names can be
 registered with ``HighLevelPipeline.register_data_args`` to support custom
 features. Arbitrary steps from any module may be chained without limitation,
 allowing any number or combination of MARBLE features and options to be expressed

--- a/highlevel_pipeline.py
+++ b/highlevel_pipeline.py
@@ -47,12 +47,14 @@ class HighLevelPipeline:
 
     The pipeline automatically wraps dataset-like arguments in
     :class:`BitTensorDataset` using ``mixed`` mode, no vocabulary size limit and
-    a minimum word length and occurrence of ``4``.  Functions from
+    a minimum word length and occurrence of ``4``.  A custom vocabulary may be
+    supplied so multiple datasets share the same token mapping. Functions from
     :mod:`marble_interface` as well as any other module within the repository
     can be appended dynamically via attribute access. There is no imposed limit
     on pipeline length so users may chain together an unlimited number of
-    operations.  This makes it possible to combine any MARBLE feature or option
-    in a single workflow simply by adding steps in the desired order.
+    operations. Steps can be reordered or removed, making it possible to
+    experiment with any MARBLE feature or option in a single workflow simply by
+    adding steps in the desired order.
     """
 
     DEFAULT_BIT_PARAMS = {
@@ -60,6 +62,7 @@ class HighLevelPipeline:
         "max_vocab_size": None,
         "min_word_length": 4,
         "min_occurrence": 4,
+        "vocab": None,
     }
 
     DEFAULT_DATA_ARGS = {
@@ -131,6 +134,21 @@ class HighLevelPipeline:
             self.steps.append({"func": func, "module": module, "params": params or {}})
         return self
 
+    def remove_step(self, index: int) -> None:
+        """Remove a step at ``index``."""
+        if index < 0 or index >= len(self.steps):
+            raise IndexError("index out of range")
+        self.steps.pop(index)
+
+    def move_step(self, old_index: int, new_index: int) -> None:
+        """Reorder a step from ``old_index`` to ``new_index``."""
+        if old_index < 0 or old_index >= len(self.steps):
+            raise IndexError("old_index out of range")
+        if new_index < 0 or new_index >= len(self.steps):
+            raise IndexError("new_index out of range")
+        step = self.steps.pop(old_index)
+        self.steps.insert(new_index, step)
+
     def _maybe_bit_dataset(self, obj: Any) -> Any:
         if not self.use_bit_dataset:
             return obj
@@ -158,6 +176,7 @@ class HighLevelPipeline:
             max_vocab_size=self.bit_dataset_params["max_vocab_size"],
             min_word_length=self.bit_dataset_params["min_word_length"],
             min_occurrence=self.bit_dataset_params["min_occurrence"],
+            vocab=self.bit_dataset_params.get("vocab"),
         )
 
     def _extract_marble(self, obj: Any) -> marble_interface.MARBLE | None:

--- a/tests/test_bit_tensor_dataset.py
+++ b/tests/test_bit_tensor_dataset.py
@@ -47,3 +47,13 @@ def test_vocab_only_mode_changes_output():
     with pytest.raises(Exception):
         ds.tensor_to_object(t_in)
 
+
+def test_custom_vocab_reuse():
+    data = [("x", "y")]
+    ds1 = BitTensorDataset(data, use_vocab=True)
+    vocab = ds1.get_vocab()
+    ds2 = BitTensorDataset(data, vocab=vocab)
+    assert ds2.get_vocab() == vocab
+    obj = ds2.tensor_to_object(ds2[0][0])
+    assert obj == "x"
+

--- a/tests/test_highlevel_pipeline.py
+++ b/tests/test_highlevel_pipeline.py
@@ -132,3 +132,31 @@ def test_highlevel_pipeline_multi_step_chain(tmp_path):
     marble, results = hp.execute()
     assert isinstance(marble, marble_interface.MARBLE)
     assert len(results) == 5
+
+
+def test_highlevel_pipeline_step_manipulation():
+    hp = HighLevelPipeline()
+
+    def a():
+        return "a"
+
+    def b():
+        return "b"
+
+    def c():
+        return "c"
+
+    hp.add_step(a)
+    hp.add_step(b)
+    hp.add_step(c)
+    hp.move_step(2, 0)
+    assert hp.steps[0]["callable"] == c
+    hp.remove_step(1)
+    assert len(hp.steps) == 2
+
+
+def test_highlevel_pipeline_shared_vocab_param():
+    vocab = {(1, 1): 300}
+    hp = HighLevelPipeline(bit_dataset_params={"vocab": vocab})
+    ds = hp._maybe_bit_dataset([0, 1])
+    assert ds.get_vocab() == vocab


### PR DESCRIPTION
## Summary
- extend BitTensorDataset with custom vocab support and encoding helpers
- allow HighLevelPipeline to reuse vocab and reorder/remove steps
- document new features
- test new dataset and pipeline capabilities

## Testing
- `pytest -q tests/test_bit_tensor_dataset.py`
- `pytest -q tests/test_highlevel_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_688bc7bd09688327a0432cd9151dea4f