### PR TITLE
Improve BitTensorDataset and pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ The pipeline accepts custom callables and automatically tracks the active
 ``MARBLE`` instance whenever a step returns one, even if nested inside tuples or
 dicts.
 Dataset arguments are converted to :class:`BitTensorDataset` automatically with
-mixed mode enabled, no vocabulary size limit and a minimum word length and
-occurrence of ``4``.  All feature inputs are wrapped by default so every
+mixed mode enabled, no vocabulary size limit and a minimum word length of ``4``
+and maximum length of ``8``. Tensors are stored on GPU when available. All feature inputs are wrapped by default so every
 operation receives data in a consistent form. A pre-built vocabulary can be
 supplied via ``bit_dataset_params`` so multiple steps encode data identically.
 Additional argument names can be

--- a/highlevel_pipeline.py
+++ b/highlevel_pipeline.py
@@ -47,7 +47,8 @@ class HighLevelPipeline:
 
     The pipeline automatically wraps dataset-like arguments in
     :class:`BitTensorDataset` using ``mixed`` mode, no vocabulary size limit and
-    a minimum word length and occurrence of ``4``.  A custom vocabulary may be
+    a minimum and maximum word length of ``4`` and ``8`` with automatic device
+    placement. A custom vocabulary may be
     supplied so multiple datasets share the same token mapping. Functions from
     :mod:`marble_interface` as well as any other module within the repository
     can be appended dynamically via attribute access. There is no imposed limit
@@ -61,8 +62,10 @@ class HighLevelPipeline:
         "mixed": True,
         "max_vocab_size": None,
         "min_word_length": 4,
+        "max_word_length": 8,
         "min_occurrence": 4,
         "vocab": None,
+        "device": None,
     }
 
     DEFAULT_DATA_ARGS = {
@@ -175,8 +178,10 @@ class HighLevelPipeline:
             mixed=self.bit_dataset_params["mixed"],
             max_vocab_size=self.bit_dataset_params["max_vocab_size"],
             min_word_length=self.bit_dataset_params["min_word_length"],
+            max_word_length=self.bit_dataset_params["max_word_length"],
             min_occurrence=self.bit_dataset_params["min_occurrence"],
             vocab=self.bit_dataset_params.get("vocab"),
+            device=self.bit_dataset_params["device"],
         )
 
     def _extract_marble(self, obj: Any) -> marble_interface.MARBLE | None:

--- a/tests/test_bit_tensor_dataset.py
+++ b/tests/test_bit_tensor_dataset.py
@@ -1,6 +1,8 @@
 import os
 import sys
+
 import pytest
+import torch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -57,3 +59,17 @@ def test_custom_vocab_reuse():
     obj = ds2.tensor_to_object(ds2[0][0])
     assert obj == "x"
 
+
+def test_max_word_length_respected():
+    data = [("abcd", "efgh"), ("ijkl", "mnop")]
+    ds = BitTensorDataset(data, use_vocab=True, max_word_length=3)
+    vocab = ds.get_vocab()
+    assert all(len(pattern) <= 3 for pattern in vocab)
+
+
+def test_dataset_device_setting():
+    data = [(1, 2)]
+    ds = BitTensorDataset(data, device="cpu")
+    assert ds[0][0].device == torch.device("cpu")
+    obj = ds.tensor_to_object(ds[0][0])
+    assert obj == 1

--- a/tests/test_highlevel_pipeline.py
+++ b/tests/test_highlevel_pipeline.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+import torch
 import yaml
 from tqdm import tqdm as std_tqdm
 
@@ -102,7 +103,10 @@ def test_highlevel_pipeline_default_bit_params():
     assert ds.mixed is True
     assert ds.max_vocab_size is None
     assert ds.min_word_length == 4
+    assert ds.max_word_length == 8
     assert ds.min_occurrence == 4
+    expected_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    assert ds.device == expected_device
 
 
 def test_highlevel_pipeline_register_data_args():
@@ -160,3 +164,9 @@ def test_highlevel_pipeline_shared_vocab_param():
     hp = HighLevelPipeline(bit_dataset_params={"vocab": vocab})
     ds = hp._maybe_bit_dataset([0, 1])
     assert ds.get_vocab() == vocab
+
+
+def test_highlevel_pipeline_custom_device():
+    hp = HighLevelPipeline(bit_dataset_params={"device": "cpu"})
+    ds = hp._maybe_bit_dataset([5, 6])
+    assert ds.device == torch.device("cpu")


### PR DESCRIPTION
## Summary
- extend `BitTensorDataset` with device support and max word length
- update `HighLevelPipeline` to pass new parameters
- revise docs for new defaults
- add tests for the new features

## Testing
- `pre-commit run --files bit_tensor_dataset.py highlevel_pipeline.py README.md tests/test_bit_tensor_dataset.py tests/test_highlevel_pipeline.py`
- `pytest -q tests/test_bit_tensor_dataset.py`
- `pytest -q tests/test_highlevel_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_688bca040f108327b11cd686e612d7d4