### PR TITLE
Add compression option and pipeline utilities

### DIFF
--- a/HIGHLEVEL_PIPELINE_TUTORIAL.md
+++ b/HIGHLEVEL_PIPELINE_TUTORIAL.md
@@ -41,6 +41,11 @@ receives inputs in a consistent format. The pipeline keeps track of the active
    ```python
    marble, results = hp.execute()
    ```
+4. **Duplicate or inspect** pipelines as needed.
+   ```python
+   clone = hp.duplicate()
+   print(hp.describe())
+   ```
 4. **Save or load** pipelines using JSON for reproducibility.
    ```python
    hp.save_json("workflow.json")

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ possible to train on multimodal pairs such as text-to-image, image-to-text or
 even audio and arbitrary byte blobs without additional conversion steps. When
 operating directly on the bit level, ``BitTensorDataset`` can convert objects
 into binary tensors and optionally build a shared vocabulary for compact
-storage.
+storage. A ``compress`` option uses ``zlib`` to shrink the byte representation
+before conversion, reducing dataset size when storing large objects.
 You can also pass an existing ``vocab`` dictionary to reuse the same mapping
 across multiple datasets for consistent encoding.
 
@@ -161,7 +162,8 @@ run arbitrary Python snippets with the active MARBLE instance.
 Pipeline steps may also be reordered or removed directly from the UI. The same
 functionality is exposed programmatically via ``HighLevelPipeline.move_step``
 and ``HighLevelPipeline.remove_step`` so complex workflows can be iterated on
-quickly.
+quickly. Pipelines can be duplicated with ``HighLevelPipeline.duplicate`` and
+summarised using ``HighLevelPipeline.describe`` for easy logging.
 You can run the same JSON pipelines from the command line using ``--pipeline``
 with ``cli.py`` or execute them programmatically through the ``Pipeline``
 class for full automation. A ``HighLevelPipeline`` helper offers a fluent

--- a/tests/test_bit_tensor_dataset.py
+++ b/tests/test_bit_tensor_dataset.py
@@ -73,3 +73,11 @@ def test_dataset_device_setting():
     assert ds[0][0].device == torch.device("cpu")
     obj = ds.tensor_to_object(ds[0][0])
     assert obj == 1
+
+
+def test_bit_tensor_dataset_compression():
+    data = [("long string" * 10, 123)]
+    ds = BitTensorDataset(data, compress=True)
+    encoded, _ = ds[0]
+    decoded = ds.tensor_to_object(encoded)
+    assert decoded == data[0][0]

--- a/tests/test_highlevel_pipeline.py
+++ b/tests/test_highlevel_pipeline.py
@@ -107,6 +107,7 @@ def test_highlevel_pipeline_default_bit_params():
     assert ds.min_occurrence == 4
     expected_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     assert ds.device == expected_device
+    assert ds.compress is False
 
 
 def test_highlevel_pipeline_register_data_args():
@@ -170,3 +171,18 @@ def test_highlevel_pipeline_custom_device():
     hp = HighLevelPipeline(bit_dataset_params={"device": "cpu"})
     ds = hp._maybe_bit_dataset([5, 6])
     assert ds.device == torch.device("cpu")
+
+
+def test_highlevel_pipeline_compress_param():
+    hp = HighLevelPipeline(bit_dataset_params={"compress": True})
+    ds = hp._maybe_bit_dataset(["x", "y"])
+    assert ds.compress is True
+
+
+def test_highlevel_pipeline_duplicate_and_describe():
+    hp = HighLevelPipeline()
+    hp.add_step(lambda: "a")
+    clone = hp.duplicate()
+    assert clone.steps == hp.steps
+    desc = hp.describe()
+    assert "0:" in desc


### PR DESCRIPTION
## Summary
- add optional zlib compression to `BitTensorDataset`
- expose `compress` parameter through `HighLevelPipeline`
- implement `duplicate` and `describe` helpers in `HighLevelPipeline`
- document new features in README and tutorial
- test dataset compression and pipeline utilities

## Testing
- `pytest tests/test_bit_tensor_dataset.py::test_roundtrip_no_vocab -q`
- `pytest tests/test_bit_tensor_dataset.py::test_roundtrip_with_vocab -q`
- `pytest tests/test_bit_tensor_dataset.py::test_vocab_options_max_size_and_occurrence -q`
- `pytest tests/test_bit_tensor_dataset.py::test_vocab_only_mode_changes_output -q`
- `pytest tests/test_bit_tensor_dataset.py::test_custom_vocab_reuse -q`
- `pytest tests/test_bit_tensor_dataset.py::test_max_word_length_respected -q`
- `pytest tests/test_bit_tensor_dataset.py::test_dataset_device_setting -q`
- `pytest tests/test_bit_tensor_dataset.py::test_bit_tensor_dataset_compression -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_runs -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_save_load -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_cross_module -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_detect_marble_in_nested -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_nested_module -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_default_bit_params -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_register_data_args -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_multi_step_chain -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_step_manipulation -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_shared_vocab_param -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_custom_device -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_duplicate_and_describe -q`
- `pytest tests/test_highlevel_pipeline.py::test_highlevel_pipeline_compress_param -q`


------
https://chatgpt.com/codex/tasks/task_e_688bd401bab88327a81a1923f1236103