### PR TITLE
Improve BitTensorDataset and HighLevelPipeline

### DIFF
--- a/HIGHLEVEL_PIPELINE_TUTORIAL.md
+++ b/HIGHLEVEL_PIPELINE_TUTORIAL.md
@@ -57,6 +57,7 @@ receives inputs in a consistent format. The pipeline keeps track of the active
    ```python
    marble, result = hp.run_step(0)
    marble, intermediate = hp.execute_until(1)
+   marble, tail = hp.execute_from(1)
    ```
 7. **Custom callables** can be inserted when more control is required.
    ```python

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ storage. A ``compress`` option uses ``zlib`` to shrink the byte representation
 before conversion, reducing dataset size when storing large objects.
 You can also pass an existing ``vocab`` dictionary to reuse the same mapping
 across multiple datasets for consistent encoding.
+``BitTensorDataset.summary`` provides quick statistics about the stored pairs,
+vocabulary size and device placement for convenient logging.
 
 Several helper pipelines leverage ``BitTensorDataset`` to train various
 learning paradigms on arbitrary Python objects, including ``AutoencoderPipeline``,
@@ -165,8 +167,10 @@ and ``HighLevelPipeline.remove_step`` so complex workflows can be iterated on
 quickly. Pipelines can be duplicated with ``HighLevelPipeline.duplicate`` and
 summarised using ``HighLevelPipeline.describe`` for easy logging.
 Individual steps can be executed in isolation with ``HighLevelPipeline.run_step``
-or partial pipelines run via ``HighLevelPipeline.execute_until`` which helps
-debug complex workflows.
+or partial pipelines run via ``HighLevelPipeline.execute_until``. A complementary
+``HighLevelPipeline.execute_from`` starts execution from an intermediate step.
+Steps can be inserted at arbitrary positions with ``HighLevelPipeline.insert_step``
+which helps debug complex workflows and restructure pipelines quickly.
 You can run the same JSON pipelines from the command line using ``--pipeline``
 with ``cli.py`` or execute them programmatically through the ``Pipeline``
 class for full automation. A ``HighLevelPipeline`` helper offers a fluent

--- a/bit_tensor_dataset.py
+++ b/bit_tensor_dataset.py
@@ -298,6 +298,26 @@ class BitTensorDataset(Dataset):
         """Yield each ``(input, target)`` pair in sequence."""
         return iter(self.data)
 
+    def summary(self) -> dict[str, Any]:
+        """Return basic statistics about the dataset.
+
+        The summary includes the number of stored pairs, the current
+        vocabulary size and whether compression is enabled. The device the
+        tensors reside on is also reported. This helper simplifies logging and
+        debugging by providing a quick overview of key attributes.
+        """
+
+        total_elements = sum(
+            a.numel() + b.numel() for a, b in self.data
+        )
+        return {
+            "num_pairs": len(self.data),
+            "vocab_size": self.vocab_size(),
+            "device": str(self.device),
+            "compressed": self.compress,
+            "total_elements": int(total_elements),
+        }
+
     def save(self, path: str) -> None:
         """Persist dataset tensors and metadata to ``path``."""
         payload = {

--- a/highlevel_pipeline.py
+++ b/highlevel_pipeline.py
@@ -154,6 +154,28 @@ class HighLevelPipeline:
         step = self.steps.pop(old_index)
         self.steps.insert(new_index, step)
 
+    def insert_step(
+        self,
+        index: int,
+        func: str | Callable,
+        *,
+        module: str | None = None,
+        params: dict | None = None,
+    ) -> None:
+        """Insert ``func`` as a step at ``index``.
+
+        The same rules as :meth:`add_step` apply for callables versus named
+        functions. ``index`` may point to the end of the list to append.
+        """
+
+        if index < 0 or index > len(self.steps):
+            raise IndexError("index out of range")
+        if callable(func):
+            step = {"callable": func, "params": params or {}}
+        else:
+            step = {"func": func, "module": module, "params": params or {}}
+        self.steps.insert(index, step)
+
     def duplicate(self) -> "HighLevelPipeline":
         """Return a deep copy of this pipeline."""
         return HighLevelPipeline(
@@ -289,6 +311,12 @@ class HighLevelPipeline:
         if index < 0 or index >= len(self.steps):
             raise IndexError("index out of range")
         return self._execute_steps(self.steps[: index + 1], marble)
+
+    def execute_from(self, index: int, marble: Any | None = None) -> tuple[Any | None, list[Any]]:
+        """Execute pipeline steps starting at ``index`` until the end."""
+        if index < 0 or index >= len(self.steps):
+            raise IndexError("index out of range")
+        return self._execute_steps(self.steps[index:], marble)
 
     def save_json(self, path: str) -> None:
         for step in self.steps:

--- a/tests/test_bit_tensor_dataset.py
+++ b/tests/test_bit_tensor_dataset.py
@@ -92,3 +92,13 @@ def test_bit_tensor_dataset_iteration_and_save_load(tmp_path):
     loaded = BitTensorDataset.load(save_path)
     assert len(loaded) == 2
     assert loaded.tensor_to_object(loaded[0][0]) == 1
+
+
+def test_bit_tensor_dataset_summary():
+    pairs = [(1, 2), (3, 4)]
+    ds = BitTensorDataset(pairs, use_vocab=True)
+    info = ds.summary()
+    assert info["num_pairs"] == 2
+    assert info["vocab_size"] == ds.vocab_size()
+    assert info["device"] == str(ds.device)
+    assert info["compressed"] is False

--- a/tests/test_highlevel_pipeline.py
+++ b/tests/test_highlevel_pipeline.py
@@ -205,3 +205,22 @@ def test_highlevel_pipeline_run_step_and_execute_until(tmp_path):
     marble2, results = hp.execute_until(1)
     assert isinstance(marble2, marble_interface.MARBLE)
     assert len(results) == 2
+
+
+def test_highlevel_pipeline_insert_and_execute_from(tmp_path):
+    marble_imports.tqdm = std_tqdm
+    marble_brain.tqdm = std_tqdm
+    marble_main.MetricsVisualizer = MetricsVisualizer
+
+    cfg = _config_path(tmp_path)
+    hp = HighLevelPipeline()
+    hp.new_marble_system(config_path=str(cfg))
+    hp.train_marble_system(train_examples=[(0, 0)], epochs=1)
+
+    hp.insert_step(1, lambda marble=None: "x")
+
+    marble, results = hp.execute()
+    assert len(results) == 3
+
+    marble2, rest = hp.execute_from(1, marble)
+    assert rest[0] == "x"


### PR DESCRIPTION
## Summary
- add `summary` to BitTensorDataset for quick dataset stats
- allow inserting pipeline steps at arbitrary positions
- add `execute_from` for executing the remainder of a pipeline
- document new features in README and HIGHLEVEL_PIPELINE_TUTORIAL
- test the new dataset and pipeline features

## Testing
- `pytest -q tests/test_bit_tensor_dataset.py`
- `pytest -q tests/test_highlevel_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_688bd8be74f083279cd2922095ae70ea