### PR TITLE
Improve BitTensorDataset and HighLevelPipeline

### DIFF
--- a/HIGHLEVEL_PIPELINE_TUTORIAL.md
+++ b/HIGHLEVEL_PIPELINE_TUTORIAL.md
@@ -59,7 +59,12 @@ receives inputs in a consistent format. The pipeline keeps track of the active
    marble, intermediate = hp.execute_until(1)
    marble, tail = hp.execute_from(1)
    ```
-7. **Custom callables** can be inserted when more control is required.
+7. **Modify steps** by replacing functions or updating parameters.
+   ```python
+   hp.replace_step(0, some_other_func)
+   hp.update_step_params(1, epochs=5)
+   ```
+8. **Custom callables** can be inserted when more control is required.
    ```python
    def print_summary(marble=None):
        print(marble.summary())

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ You can also pass an existing ``vocab`` dictionary to reuse the same mapping
 across multiple datasets for consistent encoding.
 ``BitTensorDataset.summary`` provides quick statistics about the stored pairs,
 vocabulary size and device placement for convenient logging.
+``BitTensorDataset.add_pair`` and ``BitTensorDataset.extend`` allow dynamically
+appending new training samples using the current vocabulary and device
+configuration.
 
 Several helper pipelines leverage ``BitTensorDataset`` to train various
 learning paradigms on arbitrary Python objects, including ``AutoencoderPipeline``,
@@ -170,7 +173,9 @@ Individual steps can be executed in isolation with ``HighLevelPipeline.run_step`
 or partial pipelines run via ``HighLevelPipeline.execute_until``. A complementary
 ``HighLevelPipeline.execute_from`` starts execution from an intermediate step.
 Steps can be inserted at arbitrary positions with ``HighLevelPipeline.insert_step``
-which helps debug complex workflows and restructure pipelines quickly.
+and existing steps replaced or tweaked with ``HighLevelPipeline.replace_step``
+and ``HighLevelPipeline.update_step_params`` which helps debug complex
+workflows and restructure pipelines quickly.
 You can run the same JSON pipelines from the command line using ``--pipeline``
 with ``cli.py`` or execute them programmatically through the ``Pipeline``
 class for full automation. A ``HighLevelPipeline`` helper offers a fluent

--- a/bit_tensor_dataset.py
+++ b/bit_tensor_dataset.py
@@ -282,6 +282,18 @@ class BitTensorDataset(Dataset):
         """Inverse of :meth:`encode_object`."""
         return self.tensor_to_object(tensor)
 
+    def add_pair(self, inp: Any, target: Any) -> None:
+        """Append a single ``(input, target)`` pair to the dataset."""
+        self.raw_data.append((inp, target))
+        in_tensor = self._obj_to_tensor(inp)
+        out_tensor = self._obj_to_tensor(target)
+        self.data.append((in_tensor, out_tensor))
+
+    def extend(self, pairs: Iterable[tuple[Any, Any]]) -> None:
+        """Add multiple pairs to the dataset."""
+        for inp, target in pairs:
+            self.add_pair(inp, target)
+
     def get_vocab(self):
         return self.vocab
 

--- a/highlevel_pipeline.py
+++ b/highlevel_pipeline.py
@@ -176,6 +176,29 @@ class HighLevelPipeline:
             step = {"func": func, "module": module, "params": params or {}}
         self.steps.insert(index, step)
 
+    def replace_step(
+        self,
+        index: int,
+        func: str | Callable,
+        *,
+        module: str | None = None,
+        params: dict | None = None,
+    ) -> None:
+        """Replace the step at ``index`` with ``func``."""
+        if index < 0 or index >= len(self.steps):
+            raise IndexError("index out of range")
+        if callable(func):
+            step = {"callable": func, "params": params or {}}
+        else:
+            step = {"func": func, "module": module, "params": params or {}}
+        self.steps[index] = step
+
+    def update_step_params(self, index: int, **params: Any) -> None:
+        """Update stored parameters for the step at ``index``."""
+        if index < 0 or index >= len(self.steps):
+            raise IndexError("index out of range")
+        self.steps[index].setdefault("params", {}).update(params)
+
     def duplicate(self) -> "HighLevelPipeline":
         """Return a deep copy of this pipeline."""
         return HighLevelPipeline(

--- a/tests/test_bit_tensor_dataset.py
+++ b/tests/test_bit_tensor_dataset.py
@@ -102,3 +102,12 @@ def test_bit_tensor_dataset_summary():
     assert info["vocab_size"] == ds.vocab_size()
     assert info["device"] == str(ds.device)
     assert info["compressed"] is False
+
+
+def test_bit_tensor_dataset_add_extend():
+    ds = BitTensorDataset([(0, 1)])
+    ds.add_pair(2, 3)
+    assert len(ds) == 2
+    ds.extend([(4, 5), (6, 7)])
+    assert len(ds) == 4
+    assert ds.tensor_to_object(ds[2][0]) == 4

--- a/tests/test_highlevel_pipeline.py
+++ b/tests/test_highlevel_pipeline.py
@@ -224,3 +224,17 @@ def test_highlevel_pipeline_insert_and_execute_from(tmp_path):
 
     marble2, rest = hp.execute_from(1, marble)
     assert rest[0] == "x"
+
+
+def test_highlevel_pipeline_replace_and_update():
+    hp = HighLevelPipeline()
+
+    def step_a(x=None):
+        return x
+
+    hp.add_step(step_a, params={"x": "a"})
+    hp.update_step_params(0, x="b")
+    assert hp.steps[0]["params"]["x"] == "b"
+    hp.replace_step(0, lambda: "c")
+    _, result = hp.run_step(0)
+    assert result == "c"


### PR DESCRIPTION
## Summary
- add `add_pair` and `extend` methods to `BitTensorDataset`
- expose `replace_step` and `update_step_params` on `HighLevelPipeline`
- document new features in README and tutorial
- test dataset extension and pipeline step updates

## Testing
- `pytest -q tests/test_bit_tensor_dataset.py`
- `pytest -q tests/test_highlevel_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_688bda89922c8327918f3436c3ffa3b8