### PR TITLE
Improve dataset iteration and pipeline JSON support

### DIFF
--- a/highlevel_pipeline.py
+++ b/highlevel_pipeline.py
@@ -350,7 +350,20 @@ class HighLevelPipeline:
         with open(path, "w", encoding="utf-8") as f:
             json.dump(self.steps, f, indent=2)
 
+    def to_json(self) -> str:
+        """Return a JSON string representing this pipeline."""
+        for step in self.steps:
+            if "callable" in step:
+                raise ValueError("Cannot serialise pipelines containing callables")
+        return json.dumps(self.steps, indent=2)
+
     @classmethod
     def load_json(cls, file_obj) -> "HighLevelPipeline":
         steps = json.load(file_obj)
+        return cls(steps=steps)
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "HighLevelPipeline":
+        """Construct a pipeline from a JSON string."""
+        steps = json.loads(json_str)
         return cls(steps=steps)

--- a/tests/test_bit_tensor_dataset.py
+++ b/tests/test_bit_tensor_dataset.py
@@ -121,3 +121,14 @@ def test_bit_tensor_dataset_custom_start_id():
     vocab_vals = list(ds.get_vocab().values())
     assert vocab_vals and min(vocab_vals) >= 700
     assert ds.start_id == 700
+
+
+def test_bit_tensor_dataset_iter_decoded_and_summary():
+    data = [(1, 2), (3, 4)]
+    ds = BitTensorDataset(data)
+    decoded = list(ds.iter_decoded())
+    assert decoded == data
+    info = ds.summary()
+    total = sum(a.numel() + b.numel() for a, b in ds)
+    expected_avg = float(total) / len(ds)
+    assert info["avg_pair_length"] == expected_avg

--- a/tests/test_highlevel_pipeline.py
+++ b/tests/test_highlevel_pipeline.py
@@ -245,3 +245,11 @@ def test_highlevel_pipeline_replace_and_update():
     hp.replace_step(0, lambda: "c")
     _, result = hp.run_step(0)
     assert result == "c"
+
+
+def test_highlevel_pipeline_json_methods():
+    hp = HighLevelPipeline()
+    hp.add_step("new_marble_system", module="marble_interface", params={})
+    json_str = hp.to_json()
+    clone = HighLevelPipeline.from_json(json_str)
+    assert clone.steps == hp.steps


### PR DESCRIPTION
## Summary
- extend `BitTensorDataset` with `iter_decoded`
- provide average pair length in `BitTensorDataset.summary`
- add `HighLevelPipeline.to_json` and `from_json`
- test new dataset iterator and pipeline JSON helpers

## Testing
- `pytest -q tests/test_bit_tensor_dataset.py`
- `pytest -q tests/test_highlevel_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_688be30b17e88327995a5876b9bf7af2