### PR TITLE
Improve BitTensorDataset and HighLevelPipeline

### DIFF
--- a/HIGHLEVEL_PIPELINE_TUTORIAL.md
+++ b/HIGHLEVEL_PIPELINE_TUTORIAL.md
@@ -55,10 +55,12 @@ receives inputs in a consistent format. The pipeline keeps track of the active
    ```
 6. **Execute specific steps** to debug a workflow.
    ```python
-   marble, result = hp.run_step(0)
-   marble, intermediate = hp.execute_until(1)
-   marble, tail = hp.execute_from(1)
-   ```
+  marble, result = hp.run_step(0)
+  marble, intermediate = hp.execute_until(1)
+  marble, tail = hp.execute_from(1)
+  for m, res in hp.execute_stream():
+      print("step result", res)
+  ```
 7. **Modify steps** by replacing functions or updating parameters.
    ```python
    hp.replace_step(0, some_other_func)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ before conversion, reducing dataset size when storing large objects.
 You can also pass an existing ``vocab`` dictionary to reuse the same mapping
 across multiple datasets for consistent encoding.
 ``BitTensorDataset.summary`` provides quick statistics about the stored pairs,
-vocabulary size and device placement for convenient logging.
+vocabulary size, device placement and now also the total and average byte
+footprint for convenient logging. Datasets can be serialised to JSON with
+``BitTensorDataset.to_json`` and reconstructed using ``BitTensorDataset.from_json``.
 ``BitTensorDataset.add_pair`` and ``BitTensorDataset.extend`` allow dynamically
 appending new training samples using the current vocabulary and device
 configuration.
@@ -172,6 +174,8 @@ summarised using ``HighLevelPipeline.describe`` for easy logging.
 Individual steps can be executed in isolation with ``HighLevelPipeline.run_step``
 or partial pipelines run via ``HighLevelPipeline.execute_until``. A complementary
 ``HighLevelPipeline.execute_from`` starts execution from an intermediate step.
+``HighLevelPipeline.execute_stream`` yields results after each step, allowing
+progressive inspection of pipeline execution.
 Steps can be inserted at arbitrary positions with ``HighLevelPipeline.insert_step``
 and existing steps replaced or tweaked with ``HighLevelPipeline.replace_step``
 and ``HighLevelPipeline.update_step_params`` which helps debug complex

--- a/highlevel_pipeline.py
+++ b/highlevel_pipeline.py
@@ -324,6 +324,13 @@ class HighLevelPipeline:
     def execute(self, marble: Any | None = None) -> tuple[Any | None, list[Any]]:
         return self._execute_steps(self.steps, marble)
 
+    def execute_stream(self, marble: Any | None = None):
+        """Yield ``(marble, result)`` tuples after each step executes."""
+        current_marble = marble
+        for step in self.steps:
+            current_marble, result = self._execute_steps([step], current_marble)
+            yield current_marble, result[0]
+
     def run_step(self, index: int, marble: Any | None = None) -> tuple[Any | None, Any]:
         """Execute a single step at ``index`` and return the result."""
         if index < 0 or index >= len(self.steps):

--- a/tests/test_bit_tensor_dataset.py
+++ b/tests/test_bit_tensor_dataset.py
@@ -132,3 +132,15 @@ def test_bit_tensor_dataset_iter_decoded_and_summary():
     total = sum(a.numel() + b.numel() for a, b in ds)
     expected_avg = float(total) / len(ds)
     assert info["avg_pair_length"] == expected_avg
+
+
+def test_bit_tensor_dataset_json_roundtrip():
+    data = [("x", "y"), ("a", "b")]
+    ds = BitTensorDataset(data, use_vocab=True, compress=True, start_id=300)
+    json_str = ds.to_json()
+    clone = BitTensorDataset.from_json(json_str)
+    assert list(clone.iter_decoded()) == data
+    assert clone.start_id == 300
+    assert clone.get_vocab() == ds.get_vocab()
+    info = clone.summary()
+    assert "total_bytes" in info and info["total_bytes"] > 0

--- a/tests/test_highlevel_pipeline.py
+++ b/tests/test_highlevel_pipeline.py
@@ -253,3 +253,18 @@ def test_highlevel_pipeline_json_methods():
     json_str = hp.to_json()
     clone = HighLevelPipeline.from_json(json_str)
     assert clone.steps == hp.steps
+
+
+def test_highlevel_pipeline_execute_stream(tmp_path):
+    marble_imports.tqdm = std_tqdm
+    marble_brain.tqdm = std_tqdm
+    marble_main.MetricsVisualizer = MetricsVisualizer
+
+    cfg = _config_path(tmp_path)
+    hp = HighLevelPipeline()
+    hp.new_marble_system(config_path=str(cfg))
+    hp.train_marble_system(train_examples=[(0.0, 0.0)], epochs=1)
+
+    results = list(hp.execute_stream())
+    assert isinstance(results[-1][0], marble_interface.MARBLE)
+    assert len(results) == 2


### PR DESCRIPTION
## Summary
- extend `BitTensorDataset.summary` with byte statistics
- support JSON serialisation for `BitTensorDataset`
- add `execute_stream` helper to `HighLevelPipeline`
- document new features in README and tutorial
- test the new dataset and pipeline functionality

## Testing
- `pytest tests/test_bit_tensor_dataset.py -q`
- `pytest tests/test_highlevel_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688be5017bc88327bc9c20874780ac17