### PR TITLE
Improve dataset and pipeline utilities

### DIFF
--- a/highlevel_pipeline.py
+++ b/highlevel_pipeline.py
@@ -209,6 +209,25 @@ class HighLevelPipeline:
             data_args=self.data_args.copy(),
         )
 
+    def get_step(self, index: int) -> dict:
+        """Return the step dictionary at ``index``."""
+
+        if index < 0 or index >= len(self.steps):
+            raise IndexError("index out of range")
+        return self.steps[index]
+
+    def list_steps(self) -> list[str]:
+        """Return a list of step names for introspection."""
+
+        names = []
+        for step in self.steps:
+            if "callable" in step:
+                names.append(step["callable"].__name__)
+            else:
+                mod = step.get("module", "marble_interface")
+                names.append(f"{mod}.{step['func']}")
+        return names
+
     def _execute_steps(
         self, steps: list[dict], marble: Any | None
     ) -> tuple[Any | None, list[Any]]:

--- a/marble_core.py
+++ b/marble_core.py
@@ -1712,6 +1712,21 @@ class Core:
         }
         return metrics
 
+    def summary(self) -> dict[str, Any]:
+        """Return high level statistics about the core."""
+
+        metrics = self.get_memory_usage_metrics()
+        tier_counts = {t: 0 for t in TIER_REGISTRY.keys()}
+        for n in self.neurons:
+            tier_counts[n.tier] = tier_counts.get(n.tier, 0) + 1
+        return {
+            "num_neurons": len(self.neurons),
+            "num_synapses": len(self.synapses),
+            "rep_size": self.rep_size,
+            "memory": metrics,
+            "tier_counts": tier_counts,
+        }
+
     def check_memory_usage(self) -> None:
         metrics = self.get_memory_usage_metrics()
         print(

--- a/marble_neuronenblitz/core.py
+++ b/marble_neuronenblitz/core.py
@@ -1744,3 +1744,14 @@ class Neuronenblitz:
 
         state = json.loads(json_str)
         return cls.from_dict(core, state)
+
+    def training_summary(self) -> dict:
+        """Return key statistics about recent training."""
+
+        last_err = self.error_history[-1] if self.error_history else 0.0
+        return {
+            "history_length": len(self.training_history),
+            "global_activations": self.global_activation_count,
+            "last_error": float(last_err),
+            "dropout_probability": float(self.dropout_probability),
+        }

--- a/tests/test_bit_tensor_dataset.py
+++ b/tests/test_bit_tensor_dataset.py
@@ -154,3 +154,13 @@ def test_bit_tensor_dataset_map_and_filter():
     ds.filter_pairs(lambda a, b: a > 2)
     assert len(ds) == 1
     assert ds.tensor_to_object(ds[0][0]) == 6
+
+
+def test_bit_tensor_dataset_split_shuffle_and_hash():
+    pairs = [(i, i + 1) for i in range(10)]
+    ds = BitTensorDataset(pairs)
+    ds.shuffle(generator=torch.Generator().manual_seed(0))
+    first, second = ds.split(0.6, shuffle=False)
+    assert len(first) == 6
+    assert len(second) == 4
+    assert ds.hash() == BitTensorDataset.from_json(ds.to_json()).hash()

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -132,6 +132,16 @@ def test_neuronenblitz_train_example_updates_history():
     assert nb.training_history
 
 
+def test_neuronenblitz_training_summary():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    nb.train_example(0.1, 0.0)
+    info = nb.training_summary()
+    assert info["history_length"] == len(nb.training_history)
+    assert info["global_activations"] == nb.global_activation_count
+
+
 def test_brain_validate_runs():
     random.seed(0)
     params = minimal_params()

--- a/tests/test_core_memory.py
+++ b/tests/test_core_memory.py
@@ -29,3 +29,12 @@ def test_check_memory_usage_updates_visualizer():
     core = Core(params, metrics_visualizer=mv)
     core.check_memory_usage()
     assert mv.updates
+
+
+def test_core_summary_contains_counts():
+    params = minimal_params()
+    core = Core(params)
+    info = core.summary()
+    assert info["num_neurons"] == len(core.neurons)
+    assert info["num_synapses"] == len(core.synapses)
+    assert set(info["memory"].keys())

--- a/tests/test_highlevel_pipeline.py
+++ b/tests/test_highlevel_pipeline.py
@@ -277,3 +277,15 @@ def test_highlevel_pipeline_summary_and_clear():
     assert info["num_steps"] == 1
     hp.clear_steps()
     assert hp.summary()["num_steps"] == 0
+
+
+def test_highlevel_pipeline_get_and_list_steps():
+    hp = HighLevelPipeline()
+
+    def a():
+        return "a"
+
+    hp.add_step(a)
+    assert hp.get_step(0)["callable"] == a
+    names = hp.list_steps()
+    assert names == ["a"]


### PR DESCRIPTION
## Summary
- expand `BitTensorDataset` with shuffle, split and hashing helpers
- add step inspection helpers to `HighLevelPipeline`
- expose `summary()` statistics in `Core`
- expose `training_summary()` in Neuronenblitz
- test new utilities

## Testing
- `pytest -q tests/test_bit_tensor_dataset.py`
- `pytest -q tests/test_highlevel_pipeline.py`
- `pytest -q tests/test_core_memory.py`
- `pytest -q tests/test_core_functions.py`

------
https://chatgpt.com/codex/tasks/task_e_688c44aaa69c8327bcafb099f4990808