### PR TITLE
Feature upgrades across dataset, pipeline and core

### DIFF
--- a/bit_tensor_dataset.py
+++ b/bit_tensor_dataset.py
@@ -596,3 +596,21 @@ class BitTensorDataset(Dataset):
 
         digest = hashlib.sha256(self.to_json().encode("utf-8")).hexdigest()
         return digest
+
+    @staticmethod
+    def collate_fn(
+        batch: list[tuple[torch.Tensor, torch.Tensor]],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Pad and stack a list of dataset items into batch tensors.
+
+        This helper allows :class:`~torch.utils.data.DataLoader` to handle
+        variable-length encoded examples. Each input and target tensor is padded
+        to the longest sequence in the batch using zero padding. The resulting
+        tensors have shape ``(batch, max_len, features)`` where ``features`` is
+        either ``8`` for raw bit streams or ``1`` for vocabulary tokens.
+        """
+
+        inputs, targets = zip(*batch)
+        padded_in = torch.nn.utils.rnn.pad_sequence(inputs, batch_first=True)
+        padded_out = torch.nn.utils.rnn.pad_sequence(targets, batch_first=True)
+        return padded_in, padded_out

--- a/highlevel_pipeline.py
+++ b/highlevel_pipeline.py
@@ -369,6 +369,15 @@ class HighLevelPipeline:
             raise IndexError("index out of range")
         return self._execute_steps(self.steps[index:], marble)
 
+    def execute_range(
+        self, start: int, end: int, marble: Any | None = None
+    ) -> tuple[Any | None, list[Any]]:
+        """Execute steps from ``start`` to ``end`` inclusive."""
+
+        if start < 0 or end >= len(self.steps) or start > end:
+            raise IndexError("invalid range")
+        return self._execute_steps(self.steps[start : end + 1], marble)
+
     def save_json(self, path: str) -> None:
         for step in self.steps:
             if "callable" in step:

--- a/marble_core.py
+++ b/marble_core.py
@@ -1680,6 +1680,15 @@ class Core:
         if self.weight_init_type == "xavier_uniform":
             limit = math.sqrt(6.0 / (fan_in + fan_out))
             return random.uniform(-limit, limit)
+        if self.weight_init_type == "xavier_normal":
+            std = math.sqrt(2.0 / (fan_in + fan_out))
+            return random.gauss(0.0, std)
+        if self.weight_init_type == "kaiming_uniform":
+            limit = math.sqrt(6.0 / fan_in)
+            return random.uniform(-limit, limit)
+        if self.weight_init_type == "kaiming_normal":
+            std = math.sqrt(2.0 / fan_in)
+            return random.gauss(0.0, std)
         if self.weight_init_type == "constant":
             return self.weight_init_mean
         raise ValueError(f"Unknown weight_init_type: {self.weight_init_type}")

--- a/marble_neuronenblitz/core.py
+++ b/marble_neuronenblitz/core.py
@@ -1755,3 +1755,19 @@ class Neuronenblitz:
             "last_error": float(last_err),
             "dropout_probability": float(self.dropout_probability),
         }
+
+    def reset_learning_state(self) -> None:
+        """Clear caches and optimiser state used during training."""
+
+        with self.lock:
+            self._momentum.clear()
+            self._eligibility_traces.clear()
+            self._prev_gradients.clear()
+            self._path_usage.clear()
+            self.wander_cache.clear()
+            self._cache_order.clear()
+            self.subpath_cache.clear()
+            self._subpath_order.clear()
+            self.replay_buffer.clear()
+            self.replay_priorities.clear()
+            self._grad_sq.clear()

--- a/tests/test_bit_tensor_dataset.py
+++ b/tests/test_bit_tensor_dataset.py
@@ -164,3 +164,13 @@ def test_bit_tensor_dataset_split_shuffle_and_hash():
     assert len(first) == 6
     assert len(second) == 4
     assert ds.hash() == BitTensorDataset.from_json(ds.to_json()).hash()
+
+
+def test_bit_tensor_dataset_collate_fn():
+    data = [("a", "b" * 2), ("long", "c")]
+    ds = BitTensorDataset(data, use_vocab=True)
+    loader = torch.utils.data.DataLoader(ds, batch_size=2, collate_fn=BitTensorDataset.collate_fn)
+    batch = next(iter(loader))
+    inp, out = batch
+    assert inp.ndim == 3 and out.ndim == 3
+    assert inp.shape[0] == 2 and out.shape[0] == 2

--- a/tests/test_highlevel_pipeline.py
+++ b/tests/test_highlevel_pipeline.py
@@ -289,3 +289,18 @@ def test_highlevel_pipeline_get_and_list_steps():
     assert hp.get_step(0)["callable"] == a
     names = hp.list_steps()
     assert names == ["a"]
+
+
+def test_highlevel_pipeline_execute_range(tmp_path):
+    marble_imports.tqdm = std_tqdm
+    marble_brain.tqdm = std_tqdm
+    marble_main.MetricsVisualizer = MetricsVisualizer
+
+    cfg = _config_path(tmp_path)
+    hp = HighLevelPipeline()
+    hp.new_marble_system(config_path=str(cfg))
+    hp.train_marble_system(train_examples=[(0, 0)], epochs=1)
+
+    marble, results = hp.execute_range(0, 1)
+    assert isinstance(marble, marble_interface.MARBLE)
+    assert len(results) == 2

--- a/tests/test_neuronenblitz_reset.py
+++ b/tests/test_neuronenblitz_reset.py
@@ -1,0 +1,19 @@
+import random
+import numpy as np
+from marble_core import Core, Neuron
+from marble_neuronenblitz import Neuronenblitz
+from tests.test_core_functions import minimal_params
+
+
+def test_reset_learning_state_clears_caches():
+    random.seed(0)
+    np.random.seed(0)
+    core = Core(minimal_params())
+    core.neurons = [Neuron(0, value=0.0), Neuron(1, value=0.0)]
+    core.add_synapse(0, 1, weight=1.0)
+    nb = Neuronenblitz(core, split_probability=0.0, alternative_connection_prob=0.0,
+                        backtrack_probability=0.0, backtrack_enabled=False)
+    nb.dynamic_wander(1.0, apply_plasticity=False)
+    assert nb.wander_cache
+    nb.reset_learning_state()
+    assert not nb.wander_cache

--- a/tests/test_weight_init_strategies.py
+++ b/tests/test_weight_init_strategies.py
@@ -1,0 +1,26 @@
+import math
+import random
+from marble_core import Core
+from tests.test_core_functions import minimal_params
+
+
+def _make_core(init_type):
+    p = minimal_params()
+    p["weight_init_type"] = init_type
+    p["weight_init_min"] = -0.5
+    p["weight_init_max"] = 0.5
+    return Core(p)
+
+
+def test_xavier_normal_range():
+    core = _make_core("xavier_normal")
+    w = core._init_weight(fan_in=3, fan_out=4)
+    std = math.sqrt(2.0 / (3 + 4))
+    assert abs(w) < 4 * std
+
+
+def test_kaiming_uniform_range():
+    core = _make_core("kaiming_uniform")
+    w = core._init_weight(fan_in=5)
+    limit = math.sqrt(6.0 / 5)
+    assert -limit <= w <= limit

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -129,8 +129,11 @@ core:
   weight_init_type: Distribution used for initial synapse weights. ``"uniform"``
     samples values between ``weight_init_min`` and ``weight_init_max``.
     ``"normal"`` draws from a normal distribution with ``weight_init_mean``
-    and ``weight_init_std``. ``"xavier_uniform"`` uses Xavier uniform
-    initialization based on the connection fan-in and fan-out.
+    and ``weight_init_std``. ``"xavier_uniform"`` and ``"xavier_normal"`` use
+    Xavier initialisation based on both the fan-in and fan-out of each
+    connection. ``"kaiming_uniform"`` and ``"kaiming_normal"`` implement
+    Kaiming (He) initialisation for deeper networks. ``"constant"`` sets all
+    weights to ``weight_init_mean``.
   weight_init_strategy: Strategy for the message passing MLP weights. Supports
     ``"uniform"`` and ``"normal"`` with the same semantics as
     ``weight_init_type``.


### PR DESCRIPTION
## Summary
- add `collate_fn` helper to `BitTensorDataset` for DataLoader padding
- implement `execute_range` in `HighLevelPipeline`
- extend synapse weight initialisation strategies
- document new options in the YAML manual
- expose `reset_learning_state` in Neuronenblitz
- add corresponding unit tests

## Testing
- `pytest tests/test_bit_tensor_dataset.py -q`
- `pytest tests/test_highlevel_pipeline.py -q`
- `pytest tests/test_weight_init_strategies.py -q`
- `pytest tests/test_neuronenblitz_reset.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688c529a3b9083279f2a7957021d4a81