### PR TITLE
Expose config in HighLevelPipeline

### DIFF
--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -1,1 +1,2 @@
 tests/test_marble_interface.py::test_save_and_load_marble
+tests/test_marble_interface.py::test_export_and_import_core

--- a/marble_interface.py
+++ b/marble_interface.py
@@ -34,9 +34,12 @@ warnings.filterwarnings(
 )
 
 
-def new_marble_system(config_path: str | None = None) -> MARBLE:
-    """Instantiate a :class:`MARBLE` system from an optional YAML config."""
-    return create_marble_from_config(config_path)
+def new_marble_system(
+    config_path: str | None = None, *, config: dict | None = None
+) -> MARBLE:
+    """Instantiate a :class:`MARBLE` system from a YAML file or dictionary."""
+
+    return create_marble_from_config(config_path, overrides=config)
 
 
 def configure_marble_system(marble: MARBLE, config: str | dict) -> None:
@@ -536,6 +539,7 @@ def attach_marble_layer(
 
     if isinstance(model_or_path, str):
         from torch_model_io import load_model_auto
+
         model = load_model_auto(model_or_path)
     else:
         model = model_or_path
@@ -583,4 +587,5 @@ def attach_marble_layer(
 def save_attached_model(model: torch.nn.Module, path: str) -> None:
     """Persist ``model`` with attached MARBLE to ``path``."""
     from torch_model_io import save_entire_model
+
     save_entire_model(model, path)

--- a/tests/test_highlevel_pipeline.py
+++ b/tests/test_highlevel_pipeline.py
@@ -319,3 +319,14 @@ def test_highlevel_pipeline_execute_range(tmp_path):
     marble, results = hp.execute_range(0, 1)
     assert isinstance(marble, marble_interface.MARBLE)
     assert len(results) == 2
+
+
+def test_highlevel_pipeline_config_dot_access(tmp_path):
+    hp = HighLevelPipeline()
+    hp.config.core.width = 2
+    hp.config.core.height = 2
+    hp.config.core.max_iter = 1
+    hp.config.brain.save_dir = str(tmp_path)
+    hp.new_marble_system()
+    marble, _ = hp.execute()
+    assert marble.get_core().params["width"] == 2


### PR DESCRIPTION
## Summary
- allow `HighLevelPipeline` to load and expose YAML configuration via `config` attribute
- automatically pass configuration when creating or configuring a MARBLE system
- extend pipeline summary output
- update interface helper to accept config dictionaries
- test accessing and using configuration via dot notation
- note failing marble interface tests

## Testing
- `pytest -q tests/test_highlevel_pipeline.py::test_highlevel_pipeline_config_dot_access`
- `pytest -q tests/test_highlevel_pipeline.py`
- `pytest -q tests/test_marble_interface.py::test_save_and_load_marble` *(fails)*
- `pytest -q tests/test_marble_interface.py::test_export_and_import_core` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_688c578db78c8327a49666aebb1e871b