### PR TITLE
Fix dataloader defaults

### DIFF
--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -1,2 +1,1 @@
 tests/test_marble_interface.py::test_save_and_load_marble
-tests/test_marble_interface.py::test_export_and_import_core

--- a/marble_interface.py
+++ b/marble_interface.py
@@ -69,6 +69,8 @@ def save_marble_system(marble: MARBLE, path: str) -> None:
     brain_viz = None
     if hasattr(marble, "brain"):
         brain_viz = getattr(marble.brain, "metrics_visualizer", None)
+    nb_viz = getattr(marble.neuronenblitz, "metrics_visualizer", None)
+    dl_viz = getattr(marble.dataloader, "metrics_visualizer", None)
     fig = ax = ax_twin = csv_writer = json_writer = scheduler = None
     if viz is not None:
         fig = getattr(viz, "fig", None)
@@ -90,10 +92,18 @@ def save_marble_system(marble: MARBLE, path: str) -> None:
     if brain_viz is not None:
         brain_viz.close()
         marble.brain.metrics_visualizer = None
+    if nb_viz is not None:
+        marble.neuronenblitz.metrics_visualizer = None
+    if dl_viz is not None:
+        marble.dataloader.metrics_visualizer = None
     marble.metrics_visualizer = None
     with open(path, "wb") as f:
         dill.dump(marble, f)
     marble.metrics_visualizer = viz
+    if nb_viz is not None:
+        marble.neuronenblitz.metrics_visualizer = nb_viz
+    if dl_viz is not None:
+        marble.dataloader.metrics_visualizer = dl_viz
     if brain_viz is not None:
         marble.brain.metrics_visualizer = brain_viz
     if viz is not None:

--- a/marble_main.py
+++ b/marble_main.py
@@ -83,6 +83,9 @@ class MARBLE:
         dl_enabled = True
         dl_dtype = "uint8"
         tokenizer = None
+        track_meta = True
+        enable_rtc = False
+        rt_penalty = 0.0
         if dataloader_params is not None:
             dl_level = dataloader_params.get("compression_level", dl_level)
             dl_enabled = dataloader_params.get("compression_enabled", True)


### PR DESCRIPTION
## Summary
- fix dataloader default parameters to avoid UnboundLocalError
- clear metrics visualizers when saving
- update FAILEDTESTS

## Testing
- `pytest tests/test_marble_interface.py::test_export_and_import_core -q`
- `pytest tests/test_marble_interface.py::test_save_and_load_marble -q` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_688c5d555d5c83278bc35157a3e7b75a