### PR TITLE
Fix pickling issue in MetricsVisualizer

### DIFF
--- a/marble_base.py
+++ b/marble_base.py
@@ -270,6 +270,18 @@ class MetricsVisualizer:
         if self.backup_scheduler:
             self.backup_scheduler.stop()
 
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        state["writer"] = None
+        state["_csv_writer"] = None
+        state["_json_writer"] = None
+        state["backup_scheduler"] = None
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+
+
     def __del__(self) -> None:
         self.close()
 


### PR DESCRIPTION
## Summary
- add `__getstate__` and `__setstate__` to `MetricsVisualizer` to remove
  unpicklable fields when persisting

## Testing
- `pytest tests/test_marble_interface.py::test_save_and_load_marble -q` *(fails: TypeError: cannot pickle 'EncodedFile' instances)*

------
https://chatgpt.com/codex/tasks/task_e_688c6326e59c83278ac903a3b92a3c73