### PR TITLE
Use cloudpickle for marble saving

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -135,3 +135,4 @@ yarl==1.20.1
 zipp==3.23.0
 openpyxl==3.1.2
 et_xmlfile==2.0.0
+cloudpickle==3.1.1


### PR DESCRIPTION
## Summary
- swap pickle backend for marble save/load from dill to cloudpickle
- record new dependency in requirements

## Testing
- `pytest tests/test_marble_interface.py::test_save_and_load_marble -q` *(fails: TypeError: cannot pickle '_thread.lock' object)*

------
https://chatgpt.com/codex/tasks/task_e_688c6ade2fd48327827e5541f56884f7