### PR TITLE
Fix MARBLE pickling

### DIFF
--- a/hybrid_memory.py
+++ b/hybrid_memory.py
@@ -123,3 +123,12 @@ class HybridMemory:
         for k in excess:
             self.symbolic_memory.data.pop(k, None)
         self.symbolic_memory._save()
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        state["core"] = None
+        state["nb"] = None
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)

--- a/marble_brain.py
+++ b/marble_brain.py
@@ -977,6 +977,8 @@ class Brain:
         state["auto_fire_thread"] = None
         state["dream_thread"] = None
         state["metrics_visualizer"] = None
+        state["remote_client"] = None
+        state["torrent_client"] = None
         return state
 
     def __setstate__(self, state):
@@ -988,6 +990,9 @@ class Brain:
             from marble_base import MetricsVisualizer
 
             self.metrics_visualizer = MetricsVisualizer()
+        # Remote and torrent clients cannot be restored automatically
+        self.remote_client = None
+        self.torrent_client = None
 
 
 class BenchmarkManager:

--- a/marble_main.py
+++ b/marble_main.py
@@ -285,6 +285,8 @@ class MARBLE:
         state = self.__dict__.copy()
         state["metrics_dashboard"] = None
         state["metrics_visualizer"] = None
+        state["benchmark_manager"] = None
+        state["hybrid_memory"] = None
         return state
 
     def __setstate__(self, state):
@@ -296,6 +298,16 @@ class MARBLE:
                 pass
         if self.metrics_visualizer is None:
             self.metrics_visualizer = MetricsVisualizer()
+        if self.hybrid_memory is not None:
+            try:
+                self.hybrid_memory.core = self.core
+                self.hybrid_memory.nb = self.neuronenblitz
+            except Exception:
+                pass
+        if self.benchmark_manager is None:
+            self.benchmark_manager = BenchmarkManager(self)
+        else:
+            self.benchmark_manager.marble = self
 
 
 def insert_into_torch_model(

--- a/marble_neuronenblitz/core.py
+++ b/marble_neuronenblitz/core.py
@@ -363,11 +363,15 @@ class Neuronenblitz:
     def __getstate__(self):
         state = self.__dict__.copy()
         state["lock"] = None
+        state["remote_client"] = None
+        state["torrent_client"] = None
         return state
 
     def __setstate__(self, state):
         self.__dict__.update(state)
         self.lock = threading.RLock()
+        self.remote_client = None
+        self.torrent_client = None
 
     def _compute_loss(self, target_value, output_value):
         """Return loss using either ``loss_module`` or ``loss_fn``."""


### PR DESCRIPTION
## Summary
- ensure Brain and Neuronenblitz drop remote and torrent clients when pickling
- exclude benchmark manager and hybrid memory from MARBLE state
- reconnect hybrid memory and benchmark manager after loading
- make HybridMemory picklable

## Testing
- `pytest tests/test_marble_interface.py::test_save_and_load_marble -q`
- `pytest tests/test_streamlit_playground.py::test_save_load_and_core_roundtrip -q`
- `pytest tests/test_hybrid_memory.py::test_hybrid_memory_store_and_retrieve -q`
- `pytest tests/test_hybrid_memory.py::test_hybrid_memory_forget -q`
- `pytest tests/test_hybrid_memory_eviction.py::test_hybrid_memory_eviction -q`
- `pytest tests/test_convert_model_cli.py::test_convert_model_marble -q`


------
https://chatgpt.com/codex/tasks/task_e_688c72f99fb483279d3930c156cbaa22