### PR TITLE
Add live stream support to BitTensorDataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ footprint for convenient logging. Datasets can be serialised to JSON with
 ``BitTensorDataset.add_pair`` and ``BitTensorDataset.extend`` allow dynamically
 appending new training samples using the current vocabulary and device
 configuration.
+``BitTensorDataset.add_stream_pair`` can ingest audio or video streams directly
+from a URL, converting the downloaded bytes into dataset pairs on the fly.
 
 Datasets can now be cached on disk using ``BitTensorDataset.cached`` to avoid
 re-encoding pairs on subsequent runs. Deterministic splitting into training,


### PR DESCRIPTION
## Summary
- enable streaming ingestion from URLs via `_read_stream` and `add_stream_pair`
- document stream support in README
- test `add_stream_pair` with a local HTTP server

## Testing
- `pytest tests/test_bit_tensor_dataset.py::test_add_stream_pair -q`
- `pytest tests/test_bit_tensor_dataset.py -q`
- `pytest tests/test_highlevel_pipeline.py -q`
- `pytest tests/test_autoencoder_pipeline.py -q`
- `pytest tests/test_diffusion_pairs_pipeline.py -q`
- `pytest tests/test_unified_pairs_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688c930429c083278dee8bc83174227e