### PR TITLE
Implement dataset async loading and pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ appending new training samples using the current vocabulary and device
 configuration.
 ``BitTensorDataset.add_stream_pair`` can ingest audio or video streams directly
 from a URL, converting the downloaded bytes into dataset pairs on the fly.
+``BitTensorDataset.add_stream_pair_async`` offers the same functionality using
+``aiohttp`` so multiple streams can be fetched concurrently within an async
+pipeline. Invalid or corrupted pairs can be removed at any time with
+``BitTensorDataset.prune_invalid`` which accepts a callback to check decoded
+objects.
 
 Datasets can now be cached on disk using ``BitTensorDataset.cached`` to avoid
 re-encoding pairs on subsequent runs. Deterministic splitting into training,

--- a/TODO.md
+++ b/TODO.md
@@ -246,8 +246,8 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [x] Add migration tests for old checkpoints without embedded tokenizers.
    - [x] Document tokenizer training workflow in more detail.
 
-117. [ ] Add asynchronous streaming loader in `BitTensorDataset` integrating with the remote offload service.
-118. [ ] Introduce pluggable compression modules so the pipeline can swap algorithms transparently.
+117. [x] Add asynchronous streaming loader in `BitTensorDataset` integrating with the remote offload service.
+118. [x] Introduce pluggable compression modules so the pipeline can swap algorithms transparently.
 119. [ ] Implement encryption of stored objects using Marble Core cryptographic utilities.
 120. [x] Provide deduplication to avoid storing identical bit streams across datasets.
 121. [x] Add index generation for constant-time retrieval integrated with the memory pool.
@@ -261,7 +261,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 129. [ ] Stream data directly from compressed archives without extraction.
 130. [ ] Add a bit-level augmentation pipeline for flipping and noisy bits.
 131. [x] Verify data integrity with checksums relying on marble core utilities.
-132. [ ] Automatically prune invalid or corrupted entries with callback hooks.
+132. [x] Automatically prune invalid or corrupted entries with callback hooks.
 133. [x] Cache encoded bitstreams on disk for fast reload between runs.
 134. [ ] Coordinate dataset memory usage with Marble Core's `MemoryPool`.
 135. [ ] Execute transformations asynchronously during idle GPU cycles.


### PR DESCRIPTION
## Summary
- add asynchronous stream loading and invalid entry pruning to BitTensorDataset
- support pluggable compression algorithms
- document new dataset features
- mark TODO items as complete
- add tests for async loader and prune function

## Testing
- `pytest -q tests/test_bit_tensor_dataset.py`
- `pytest -q tests/test_dataset_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_688cbaa992188327a3906397f29ff902