### PR TITLE
Implement dataset TODO features

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -255,13 +255,13 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 123. [x] Integrate GPU-accelerated encoding and decoding using core operations.
 124. [x] Enable background prefetching and caching to support asynchronous pipelines.
     - [x] Add `prefetch_dataset` helper running downloads in a background thread.
-    - [ ] Integrate the prefetch queue with pipeline execution so steps can await availability.
+    - [x] Integrate the prefetch queue with pipeline execution so steps can await availability.
 125. [x] Implement dataset merging with conflict resolution logic.
 126. [x] Support deterministic splitting into train, validation and test sets via hashing.
 127. [ ] Offer dataset versioning with reversible diffs to update existing sets.
 128. [ ] Provide an interactive dataset browser in the Streamlit GUI for manual review.
 129. [x] Stream data directly from compressed archives without extraction.
-130. [ ] Add a bit-level augmentation pipeline for flipping and noisy bits.
+130. [x] Add a bit-level augmentation pipeline for flipping and noisy bits.
 131. [x] Verify data integrity with checksums relying on marble core utilities.
 132. [x] Automatically prune invalid or corrupted entries with callback hooks.
 133. [x] Cache encoded bitstreams on disk for fast reload between runs.
@@ -272,11 +272,11 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 138. [ ] Manage encryption keys through pipeline configuration files.
 139. [ ] Adapt vocabulary dynamically when new words appear during training.
 140. [x] Audit data integrity through checksums and object hashes.
-141. [ ] Provide a plugin system for custom object encoders and decoders.
-142. [ ] Support memory-mapped files so huge datasets fit into RAM.
+141. [x] Provide a plugin system for custom object encoders and decoders.
+142. [x] Support memory-mapped files so huge datasets fit into RAM.
 143. [ ] Track modification history with the ability to revert changes.
 144. [ ] Offer undo and redo commands for interactive dataset editing.
-145. [ ] Fetch missing remote files automatically when constructing datasets.
+145. [x] Fetch missing remote files automatically when constructing datasets.
 146. [ ] Enable sample-level transformations such as image rotations or text cleanup.
 147. [ ] Lazily decode objects so they are materialised only when accessed.
 148. [ ] Select compression algorithms through a pluggable interface.
@@ -291,7 +291,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 157. [ ] Replicate datasets across nodes with progress notifications.
 158. [ ] Summarise datasets in pipeline descriptions for easier debugging.
 159. [ ] Notify the memory manager about upcoming dataset allocations.
-160. [ ] Add an API to append data incrementally with vocabulary updates.
+160. [x] Add an API to append data incrementally with vocabulary updates.
 161. [ ] Register debugging hooks for inspecting individual samples in the pipeline.
 162. [ ] Provide approximate nearest neighbour search over bit tensors for retrieval.
 163. [ ] Attach hierarchical tags or labels alongside each stored pair.

--- a/pipeline.py
+++ b/pipeline.py
@@ -5,6 +5,8 @@ import inspect
 import json
 from typing import Any
 
+from dataset_loader import wait_for_prefetch
+
 import marble_interface
 
 
@@ -33,6 +35,7 @@ class Pipeline:
     def execute(self, marble: Any | None = None) -> list[Any]:
         results: list[Any] = []
         for step in self.steps:
+            wait_for_prefetch()
             module_name = step.get("module")
             func_name = step["func"]
             params = step.get("params", {})

--- a/tests/test_dataloader_plugin.py
+++ b/tests/test_dataloader_plugin.py
@@ -1,0 +1,26 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from marble_core import DataLoader
+
+class Custom:
+    def __init__(self, value: str):
+        self.value = value
+
+
+def _encode(obj: Custom) -> bytes:
+    return obj.value.encode("utf-8")
+
+
+def _decode(data: bytes) -> Custom:
+    return Custom(data.decode("utf-8"))
+
+
+DataLoader.register_plugin(Custom, _encode, _decode)
+
+def test_custom_plugin_roundtrip():
+    dl = DataLoader()
+    obj = Custom("hello")
+    tensor = dl.encode(obj)
+    out = dl.decode(tensor)
+    assert isinstance(out, Custom)
+    assert out.value == "hello"

--- a/tests/test_prefetch_integration.py
+++ b/tests/test_prefetch_integration.py
@@ -1,0 +1,47 @@
+import os, sys
+import http.server
+import socketserver
+import threading
+import pandas as pd
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from dataset_loader import load_dataset, prefetch_dataset
+from pipeline import Pipeline
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, files=None, **kwargs):
+        self.files = files or {}
+        super().__init__(*args, **kwargs)
+
+    def do_GET(self):
+        if self.path in self.files:
+            content = self.files[self.path]
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+def test_prefetch_pipeline(tmp_path):
+    files = {
+        "/input.txt": b"hello",
+        "/target.txt": b"world",
+    }
+    dataset_csv = "input,target\nhttp://localhost:{port}/input.txt,http://localhost:{port}/target.txt\n"
+    with socketserver.TCPServer(("localhost", 0), lambda *a, **k: Handler(*a, files=files, **k)) as httpd:
+        port = httpd.server_address[1]
+        dataset_content = dataset_csv.format(port=port).encode()
+        files["/data.csv"] = dataset_content
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        url = f"http://localhost:{port}/data.csv"
+        prefetch_dataset(url, cache_dir=tmp_path)
+        pipe = Pipeline([
+            {"func": "load_dataset", "module": "dataset_loader", "params": {"source": url, "cache_dir": str(tmp_path)}}
+        ])
+        result = pipe.execute()
+        httpd.shutdown()
+        thread.join()
+    assert result[0] == [(b"hello", b"world")]


### PR DESCRIPTION
## Summary
- integrate prefetch queue with Pipeline execution
- add custom encoder/decoder plugin system for DataLoader
- support bit-level augmentation and vocab updates in BitTensorDataset
- enable memory-mapped dataset loading
- fetch remote files referenced inside datasets automatically
- add tests for new functionality
- mark completed TODO items

## Testing
- `pytest tests/test_dataloader_plugin.py -q`
- `pytest tests/test_bit_tensor_dataset.py::test_bit_augmentation -q`
- `pytest tests/test_bit_tensor_dataset.py::test_append_pairs_rebuild_vocab -q`
- `pytest tests/test_bit_tensor_dataset.py::test_load_memory_mapped -q`
- `pytest tests/test_prefetch_integration.py -q`
- `pytest tests/test_pipeline_class.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688cfcac09348327a7c1f9d386eb276a