### PR TITLE
Add config sync docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ python cli.py --config config.yaml --sync-config /mnt/nodeA/config.yaml /mnt/nod
 
 Pass ``--sync-src`` to specify an alternative source file.
 
+For continuous synchronisation you can start ``ConfigSyncService`` which watches
+the source config for changes and propagates updates automatically:
+
+```python
+from config_sync_service import ConfigSyncService
+
+svc = ConfigSyncService('config.yaml', ['/mnt/nodeA/cfg.yaml', '/mnt/nodeB/cfg.yaml'])
+svc.start()
+```
+Use ``svc.stop()`` to terminate the watcher.
+
 ### Remote Inference API
 
 MARBLE can be exposed through a lightweight HTTP API. Launch the server with:

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -310,6 +310,21 @@ Remote offloading demonstrates **RemoteBrainServer**, **RemoteBrainClient** and 
 This project highlights how MARBLE can integrate with external services through
 a minimal web API.
 
+## Project 3c – Config Synchronisation (Medium)
+
+**Goal:** Keep configuration files consistent across multiple machines.
+
+1. **Start the watcher** on the main node:
+   ```python
+   from config_sync_service import ConfigSyncService
+   svc = ConfigSyncService('config.yaml', ['/mnt/nodeA/cfg.yaml', '/mnt/nodeB/cfg.yaml'])
+   svc.start()
+   ```
+2. **Edit `config.yaml`** as usual. Updates propagate automatically to each path
+   listed when the file changes.
+3. **Stop the service** with `svc.stop()` once synchronisation is no longer required.
+
+
 ## Project 4 – Autograd and PyTorch Challenge (Advanced)
 
 **Goal:** Combine MARBLE with a PyTorch model and compare results.


### PR DESCRIPTION
## Summary
- document ConfigSyncService usage in README
- add tutorial project for config synchronization

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_688d4897fcec8327ab88207b9f076b36