### PR TITLE
Update documentation for new plugins

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -351,6 +351,7 @@ Each entry is listed under its section heading.
 - log_dir
 - csv_log_path
 - json_log_path
+- anomaly_std_threshold
 ## metrics_dashboard
 - enabled
 - host

--- a/ML_PARADIGMS_HANDBOOK.md
+++ b/ML_PARADIGMS_HANDBOOK.md
@@ -109,6 +109,16 @@ stored embeddings against the current dialogue context. Retrieved records prime
 the response and new information is written back after answering, allowing
 persistent recall across many turns.
 
+### Theory of Mind
+MARBLE can model the beliefs of other agents using a lightweight recurrent
+network. It predicts future actions and publishes them through the Global
+Workspace so other modules can react.
+
+### Predictive Coding
+Within components like `DiffusionCore` a hierarchical predictive coder learns to
+reconstruct activations across multiple layers. Prediction errors are used as
+additional learning signals.
+
 ### Unified Multi-Paradigm Learning
 All paradigms share the same core and a gating network decides which learning
 rule to emphasise for each batch. The decision depends on memory usage and
@@ -212,6 +222,16 @@ Whenever two active neurons exhibit low cosine similarity, the Core spawns a new
 neuron whose representation is \(\tanh(r_i \odot r_j)\). Synapses connect it to
 both parents so future activity can quickly activate the abstract blend.
 
+### Theory of Mind
+A recurrent network predicts actions of other agents and shares these forecasts
+through the Global Workspace. Reinforcement learners adjust their policies based
+on these predictions.
+
+### Predictive Coding
+Hierarchical predictive coding layers reconstruct activations from deeper
+modules. Their error signals augment standard gradients, improving stability in
+diffusion-based learners.
+
 ### Unified Multi-Paradigm Learning
 Context features such as recent validation loss and tier usage feed a small
 gating network. Its softmax output scales
@@ -311,6 +331,16 @@ During inference a cross-attention network ranks stored embeddings against the
 current context. The best matches retrieve their symbolic entries which are fed
 back into the model. After generating a reply the new information is embedded and
 written to disk for future recall.
+
+### Theory of Mind
+The optional plugin trains a recurrent network that predicts other agents' next
+actions. Predictions are published through the Global Workspace so Reinforcement
+Learning modules can plan accordingly.
+
+### Predictive Coding
+`DiffusionCore` can be configured with a stack of predictive coding layers. They
+attempt to reconstruct activations from deeper layers and propagate prediction
+errors as additional gradients.
 
 ### Unified Multi-Paradigm Learning
 All MARBLE paradigms can now operate under a single meta-controller. A gating

--- a/README.md
+++ b/README.md
@@ -282,6 +282,12 @@ The interface now includes a **Hybrid Memory** tab as well. This lets you
 initialize a vector store and symbolic memory, store new values, query for the
 closest matches and prune old entries directly from the playground.
 
+Additional plugins such as **Theory of Mind** and **Predictive Coding** can be
+activated through the YAML configuration. These modules allow MARBLE to model
+other agents' behaviour and build hierarchical predictions over time. Enable
+them by adding `theory_of_mind` or `predictive_coding` sections to
+`config.yaml` and calling the respective `activate` functions in your scripts.
+
 ## Possible MARBLE Backcronyms
 
 Below is a list of ideas explored when naming the project:

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -28,3 +28,4 @@ MARBLE uses modern type hint syntax. Run `scripts/convert_to_py38.py` on the sou
 ## Plugin Troubleshooting
 * **Global workspace messages not appearing** – Ensure `global_workspace.enabled` is `true` in your configuration and that the plugin is activated before other plugins.
 * **Attention codelets have no effect** – Verify that `attention_codelets.enabled` is `true` and that at least one codelet has been registered. Call `attention_codelets.run_cycle()` during training to broadcast proposals.
+* **Remote hardware tier unavailable** – Ensure `remote_hardware.tier_plugin` points to a valid module and that the remote service is reachable from the network.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2050,3 +2050,30 @@ reconstructed with the correct Python type during decoding.
    pipe.train(data, epochs=1)
    ```
 
+## Project 36 – Theory of Mind Predictions
+
+**Goal:** Train the theory of mind plugin to model agents.
+
+1. **Enable the plugin** by setting `theory_of_mind.enabled: true` in `config.yaml`.
+2. **Train** on small interaction traces:
+   ```python
+   from theory_of_mind import activate
+   from config_loader import load_config
+   cfg = load_config()
+   tom = activate(hidden_size=8, num_layers=1, prediction_horizon=1)
+   tom.train([(0, 1), (1, 0)], epochs=5)
+   ```
+
+## Project 37 – Predictive Coding Integration
+
+**Goal:** Use predictive coding inside DiffusionCore.
+
+1. **Activate predictive coding** by editing `config.yaml` under `predictive_coding`.
+2. **Add the module** when constructing DiffusionCore:
+   ```python
+   from diffusion_core import DiffusionCore
+   from predictive_coding import activate as pc_activate
+   core = DiffusionCore(rep_size=4, predictive_coding_params={"num_layers": 2})
+   core.predictive_coding = pc_activate(num_layers=2, latent_dim=4, learning_rate=0.001)
+   ```
+

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -14,5 +14,7 @@ This document lists the main classes and functions intended for external use.
 - `global_workspace.GlobalWorkspace.subscribe`
 - `attention_codelets.register_codelet`
 - `attention_codelets.run_cycle`
+- `theory_of_mind.activate`
+- `predictive_coding.activate`
 
 These APIs are kept stable across minor versions. Internal helpers not listed here may change without notice.

--- a/marble_neuronenblitz/README.md
+++ b/marble_neuronenblitz/README.md
@@ -8,3 +8,5 @@ This package contains the implementation of the adaptive learning system used by
 - `__init__.py` – exports commonly used functions and the core class.
 
 These modules can be imported individually, allowing advanced users to extend or replace specific functionality.
+
+Additional plugin modules implement context-aware attention, theory-of-mind reasoning and predictive coding. Activate them with the respective `activate` functions to augment the core algorithms.

--- a/project_template/README.md
+++ b/project_template/README.md
@@ -3,3 +3,12 @@
 This template provides a minimal starting point for new MARBLE-based projects.
 It contains a sample configuration file and a short script that trains a small
 model. Copy the entire directory and adapt the code as needed.
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the example trainer:
+   ```bash
+   python exampletrain.py --config config.yaml
+   ```


### PR DESCRIPTION
## Summary
- sync docs with new Theory of Mind and Predictive Coding plugins
- expand tutorial with additional projects
- list new YAML parameter and public APIs
- add remote hardware troubleshooting tips
- refresh project template and package overview

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_688d4b165fbc8327ab472f374c1ed15f