### PR TITLE
docs: sync markdown with latest features

### DIFF
--- a/ARCHITECTURE_OVERVIEW.md
+++ b/ARCHITECTURE_OVERVIEW.md
@@ -46,6 +46,13 @@ group API to synchronise weights across multiple workers. A
 and the minimalist ``memory_manager.MemoryManager`` tracks upcoming allocations
 to avoid oversubscription.
 
+``dataset_loader`` provides high level helpers for downloading, sharding and
+caching tabular datasets while tracking dependencies and memory usage. Datasets
+can be versioned with ``dataset_versioning`` which writes diffs for each change
+and later applies them to reproduce exact states. ``dataset_replication``
+pushes dataset files to multiple HTTP endpoints so distributed jobs start from
+identical inputs.
+
 ## Data Compression Pipeline
 The `DataLoader` converts arbitrary Python objects or arrays into binary
 representations using the `DataCompressor` and can optionally cache them via

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,14 +13,15 @@ This document outlines upcoming milestones for future Marble releases.
 - Expanded template library for neurons and synapses.
 - Docker images for streamlined deployment.
 
-## v0.6 – Q3 2025
+## v0.6 – Q3 2025 *(released)*
 - Remote offloading with compression.
 - Live metrics dashboard and memory manager.
 - Additional BitTensor pipelines for imitation and fractal learning.
 
 ## v0.7 – Q1 2026
-- Full GUI test coverage across all tabs.
-- Improved plugin discovery and configuration.
+- Dataset versioning and replication utilities.
+- Pipeline CLI for executing YAML-defined workflows.
+- Initial model quantization helpers.
 
 Further versions will refine the API and add more tutorials based on
 community feedback.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2077,3 +2077,32 @@ reconstructed with the correct Python type during decoding.
    core.predictive_coding = pc_activate(num_layers=2, latent_dim=4, learning_rate=0.001)
    ```
 
+## Project 38 – Dataset Versioning and Replication
+
+**Goal:** Track dataset changes and distribute files to remote workers.**
+
+1. **Load a dataset** using ``dataset_loader.load_dataset``:
+   ```python
+   from dataset_loader import load_dataset
+   pairs = load_dataset(
+       "https://raw.githubusercontent.com/mwaskom/seaborn-data/master/iris.csv",
+       input_col="sepal_length",
+       target_col="species",
+       limit=32,
+   )
+   ```
+2. **Create a version diff** so modifications can be reproduced later:
+   ```python
+   from dataset_versioning import create_version, apply_version
+   vid = create_version([], pairs, "versions")
+   restored = apply_version([], "versions", vid)
+   ```
+3. **Export and replicate the dataset** to additional machines:
+   ```python
+   from dataset_loader import export_dataset
+   from dataset_replication import replicate_dataset
+   export_dataset(restored, "iris_subset.csv")
+   replicate_dataset("iris_subset.csv", ["http://worker1:8000", "http://worker2:8000"])
+   ```
+Run ``python project38_dataset_tools.py`` to reproduce and distribute the dataset.
+

--- a/docs/distributed_training.md
+++ b/docs/distributed_training.md
@@ -15,6 +15,9 @@ altering the core learning logic. `DistributedTrainer` accepts a configurable
 `world_size` and `backend` (``gloo`` by default) allowing the same interface to
 scale from a single machine to a small cluster.
 
+Use ``dataset_replication.replicate_dataset`` to push training files to all
+machines before starting jobs so that each worker loads identical data shards.
+
 Workers require `init_distributed` to run before constructing `Core` instances.
 Set `MASTER_ADDR` and `MASTER_PORT` environment variables when launching across
 machines. Datasets can be synchronised by combining `DatasetCacheServer` with

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -28,5 +28,13 @@ This document lists the main classes and functions intended for external use.
 - `memory_manager.MemoryManager`
 - `config_sync_service.ConfigSyncService`
 - `highlevel_pipeline.HighLevelPipeline`
+- `dataset_loader.load_dataset`
+- `dataset_loader.prefetch_dataset`
+- `dataset_versioning.create_version`
+- `dataset_versioning.apply_version`
+- `dataset_replication.replicate_dataset`
+- `pipeline.Pipeline`
+- `model_quantization.quantize_core_weights`
+- `experiment_tracker.ExperimentTracker`
 
 These APIs are kept stable across minor versions. Internal helpers not listed here may change without notice.

--- a/docs/pytorch_conversion.md
+++ b/docs/pytorch_conversion.md
@@ -18,6 +18,15 @@ def convert_linear(layer, core, inputs):
 The registry dictionaries ``LAYER_CONVERTERS``, ``FUNCTION_CONVERTERS`` and
 ``METHOD_CONVERTERS`` hold these mappings. Custom layers can be supported by
 adding new entries using ``register_converter``.
+The shipped registry covers a wide range of core building blocks including:
+
+- Linear, Conv2d and the activations ReLU, Sigmoid, Tanh and GELU
+- Dropout, Flatten and Unflatten for shape manipulation
+- MaxPool2d, AvgPool2d and their adaptive and global variants
+- Embedding and EmbeddingBag layers with ``padding_idx`` and ``max_norm``
+- Recurrent modules RNN, LSTM and GRU
+- BatchNorm1d/2d, LayerNorm and GroupNorm
+- Sequential containers and ModuleList objects which expand recursively
 
 Pooling layers like ``MaxPool2d`` and ``AvgPool2d`` are handled by dedicated
 converters that create neurons with ``neuron_type`` set to ``"maxpool2d"`` or


### PR DESCRIPTION
## Summary
- document dataset versioning, replication and loader utilities
- add pipeline CLI usage, remote offload plugin info and expanded public API list
- refresh roadmap, architecture overview and tutorial with new dataset tools

## Testing
- `pre-commit run --files ARCHITECTURE_OVERVIEW.md README.md ROADMAP.md TUTORIAL.md docs/distributed_training.md docs/public_api.md docs/pytorch_conversion.md`

------
https://chatgpt.com/codex/tasks/task_e_688e3e279bac832797673bd5717fd1a7