### PR TITLE
docs: expand coverage for new modules

### DIFF
--- a/ARCHITECTURE_OVERVIEW.md
+++ b/ARCHITECTURE_OVERVIEW.md
@@ -44,7 +44,9 @@ downloads. ``distributed_training.DistributedTrainer`` wraps PyTorch's process
 group API to synchronise weights across multiple workers. A
 ``metrics_dashboard.MetricsDashboard`` instance renders live charts in a browser
 and the minimalist ``memory_manager.MemoryManager`` tracks upcoming allocations
-to avoid oversubscription.
+to avoid oversubscription. The ``experiment_tracker`` module logs metrics to
+external services such as Weights & Biases via ``WandbTracker`` so long-running
+experiments remain reproducible.
 
 ``system_metrics`` exposes lightweight functions to query CPU, RAM and GPU
 utilisation, while ``usage_profiler.UsageProfiler`` records these values to CSV

--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -284,6 +284,19 @@ Each entry is listed under its section heading.
 - threshold
 - consolidation_interval
 
+## cwfl
+- num_basis
+- bandwidth
+- reg_lambda
+- learning_rate
+
+## harmonic
+- base_frequency
+- decay
+
+## fractal
+- target_dimension
+
 ## hybrid_memory
 - vector_store_path
 - symbolic_store_path

--- a/README.md
+++ b/README.md
@@ -405,6 +405,34 @@ When tuning a new task consider the following workflow:
 
 Documenting the parameters of each run with the new experiment tracker makes it easy to compare results later.
 
+## Experiment Tracking
+
+The `experiment_tracker` module provides a simple abstraction for logging metrics
+to external services. The included `WandbTracker` sends results to
+[Weights & Biases](https://wandb.ai) and can be extended for other backends.
+Call `tracker.log_metrics({"loss": value}, step)` during training and invoke
+`tracker.finish()` once the run ends.
+
+## Dataset Versioning and Replication
+
+Datasets can be tracked over time with `dataset_versioning`. The
+`create_version` function writes a diff between two data states, while
+`apply_version` restores a previous snapshot. To distribute datasets across
+workers use `dataset_replication.replicate_dataset` to push files to remote
+HTTP endpoints before training begins.
+
+## System Metrics and Profiling
+
+`system_metrics.profile_resource_usage` returns the current CPU, RAM and GPU
+utilisation. For longer runs `usage_profiler.UsageProfiler` records these
+metrics at regular intervals and writes them to CSV for later inspection.
+
+## HTTP Inference API
+
+`web_api.InferenceServer` exposes a trained brain through a minimal Flask
+application. Sending a JSON payload to `/infer` returns the decoded output so
+other services can integrate MARBLE predictions.
+
 ## Troubleshooting
 If training diverges or produces NaNs:
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -32,6 +32,18 @@ not covered by the test suite and some optional features may be unavailable.
 * **Attention codelets have no effect** – Verify that `attention_codelets.enabled` is `true` and that at least one codelet has been registered. Call `attention_codelets.run_cycle()` during training to broadcast proposals.
 * **Remote hardware tier unavailable** – Ensure `remote_hardware.tier_plugin` points to a valid module and that the remote service is reachable from the network.
 
+## Experiment Tracker Issues
+* **Weights & Biases login failures** – Ensure the `WANDB_API_KEY` environment
+  variable is set or run `wandb login` before training.
+* **Missing metrics** – Call `tracker.log_metrics` during training and invoke
+  `tracker.finish()` at shutdown to flush pending logs.
+
+## Dataset Versioning Issues
+* **Version diff not applied** – Verify the path passed to `apply_version`
+  contains the saved version files.
+* **Replication targets unreachable** – Confirm all URLs given to
+  `dataset_replication.replicate_dataset` are accessible from the current host.
+
 ## Networking Issues
 * **Dataset cache server not reachable** – Start `DatasetCacheServer` on the host machine and set `dataset.cache_url` correctly in `config.yaml`.
 * **Distributed training hangs** – Verify all workers can connect to the master address and that `init_distributed` uses a unique port.

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -30,12 +30,15 @@ This document lists the main classes and functions intended for external use.
 - `highlevel_pipeline.HighLevelPipeline`
 - `dataset_loader.load_dataset`
 - `dataset_loader.prefetch_dataset`
+- `dataset_loader.export_dataset`
 - `dataset_versioning.create_version`
 - `dataset_versioning.apply_version`
 - `dataset_replication.replicate_dataset`
+- `graph_streaming.stream_graph_chunks`
 - `pipeline.Pipeline`
 - `model_quantization.quantize_core_weights`
 - `experiment_tracker.ExperimentTracker`
+- `experiment_tracker.WandbTracker`
 - `system_metrics.profile_resource_usage`
 - `usage_profiler.UsageProfiler`
 - `web_api.InferenceServer`


### PR DESCRIPTION
## Summary
- document experiment tracking, dataset tools, profiling utilities, and HTTP inference in README
- highlight experiment tracker in architecture overview
- enumerate memory system, CWFL, harmonic, and fractal config parameters
- add troubleshooting guidance for experiment tracking and dataset versioning
- include new helpers in public API list

## Testing
- `pre-commit run --files README.md ARCHITECTURE_OVERVIEW.md CONFIGURABLE_PARAMETERS.md TROUBLESHOOTING.md docs/public_api.md`


------
https://chatgpt.com/codex/tasks/task_e_688e843491ac8327908c2570d5de48ce