### PR TITLE
feat: link core and neuronenblitz bidirectionally

### DIFF
--- a/marble_neuronenblitz/core.py
+++ b/marble_neuronenblitz/core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import math
 import multiprocessing as mp
@@ -8,7 +9,6 @@ import random
 import threading
 from collections import deque
 from datetime import datetime, timezone
-import json
 
 import numpy as np
 
@@ -184,7 +184,7 @@ class Neuronenblitz:
         torrent_map=None,
         metrics_visualizer=None,
     ):
-        self.core = core
+        self.attach_core(core)
         self.backtrack_probability = backtrack_probability
         self.consolidation_probability = consolidation_probability
         self.consolidation_strength = consolidation_strength
@@ -359,6 +359,27 @@ class Neuronenblitz:
             n_plugin.register(self)
         except Exception:
             pass
+
+    def attach_core(self, core) -> None:
+        """Attach to ``core`` and register with it.
+
+        Parameters
+        ----------
+        core:
+            The :class:`~marble_core.Core` instance to connect with.
+
+        Notes
+        -----
+        Sets ``self.core`` and stores ``self`` on ``core`` via
+        :meth:`core.attach_neuronenblitz` when available. This creates a
+        bidirectional link so both objects can access each other directly.
+        """
+
+        self.core = core
+        if hasattr(core, "attach_neuronenblitz"):
+            core.attach_neuronenblitz(self)
+        else:  # pragma: no cover - legacy path
+            setattr(core, "neuronenblitz", self)
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,15 +3,18 @@ aiohappyeyeballs==2.6.1
 aiohttp==3.12.14
 aiosignal==1.4.0
 altair==5.5.0
+annoy==1.17.3
 asttokens==3.0.0
 attrs==25.3.0
 black==25.1.0
 blinker==1.9.0
 cachetools==5.5.2
+cattrs==25.1.1
 certifi==2025.7.14
 cfgv==3.4.0
 charset-normalizer==3.4.2
 click==8.2.1
+cloudpickle==3.1.1
 comm==0.2.2
 contourpy==1.3.2
 cycler==0.12.1
@@ -22,6 +25,7 @@ diffusers==0.34.0
 dill==0.3.8
 distlib==0.4.0
 docker-pycreds==0.4.0
+et_xmlfile==2.0.0
 executing==2.2.0
 filelock==3.13.1
 Flask==3.1.1
@@ -56,6 +60,7 @@ matplotlib==3.10.3
 matplotlib-inline==0.1.7
 mdurl==0.1.2
 mpmath==1.3.0
+msgpack==1.0.8
 multidict==6.6.3
 multiprocess==0.70.16
 mypy==1.16.1
@@ -65,6 +70,7 @@ nest-asyncio==1.6.0
 networkx==3.3
 nodeenv==1.9.1
 numpy==1.26.4
+openpyxl==3.1.2
 packaging==24.0
 pandas==2.3.1
 parso==0.8.4
@@ -93,6 +99,7 @@ PyYAML==6.0.2
 referencing==0.36.2
 regex==2024.11.6
 requests==2.32.4
+requests-cache==1.2.0
 retrying==1.4.0
 rich==13.9.4
 rpds-py==0.26.0
@@ -123,6 +130,7 @@ traitlets==5.14.3
 transformers==4.40.1
 typing_extensions==4.14.1
 tzdata==2025.2
+url-normalize==2.2.1
 urllib3==2.5.0
 virtualenv==20.32.0
 wandb==0.17.0
@@ -133,9 +141,3 @@ widgetsnbextension==4.0.14
 xxhash==3.5.0
 yarl==1.20.1
 zipp==3.23.0
-openpyxl==3.1.2
-et_xmlfile==2.0.0
-cloudpickle==3.1.1
-requests-cache==1.2.0
-annoy==1.17.3
-msgpack==1.0.8

--- a/tests/test_core_neuronenblitz_integration.py
+++ b/tests/test_core_neuronenblitz_integration.py
@@ -1,0 +1,35 @@
+import random
+
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+
+
+def tiny_params():
+    return {
+        "width": 2,
+        "height": 2,
+        "max_iter": 1,
+        "representation_size": 4,
+        "vram_limit_mb": 0.1,
+        "ram_limit_mb": 0.1,
+        "disk_limit_mb": 0.1,
+        "random_seed": 0,
+    }
+
+
+def test_bidirectional_attachment():
+    random.seed(0)
+    core = Core(tiny_params())
+    nb = Neuronenblitz(core)
+    assert core.neuronenblitz is nb
+    assert nb.core is core
+
+
+def test_attach_core_switch():
+    random.seed(0)
+    core1 = Core(tiny_params())
+    nb = Neuronenblitz(core1)
+    core2 = Core(tiny_params())
+    nb.attach_core(core2)
+    assert nb.core is core2
+    assert core2.neuronenblitz is nb


### PR DESCRIPTION
## Summary
- expose `Core.attach_neuronenblitz` to store and sync a Neuronenblitz instance
- add `Neuronenblitz.attach_core` and call it during initialization
- test bidirectional attachment between Core and Neuronenblitz

## Testing
- `pytest tests/test_core_neuronenblitz_integration.py -q`
- `pytest tests/test_core_functions.py -q`
- `pytest tests/test_neuronenblitz_reset.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e89174ccc8327bbaf4d8980ed53c6