### PR TITLE
Improve core ↔ neuronenblitz linkage

### DIFF
--- a/marble_core.py
+++ b/marble_core.py
@@ -1744,9 +1744,32 @@ class Core:
         manual wiring by the caller.
         """
 
+        # Detach any existing Neuronenblitz instance from this core
+        if self.neuronenblitz is not None and self.neuronenblitz is not nb:
+            old_nb = self.neuronenblitz
+            self.neuronenblitz = None
+            if getattr(old_nb, "core", None) is self:
+                old_nb.core = None
+
+        # Ensure the incoming instance is detached from its previous core
+        if getattr(nb, "core", None) not in (None, self):
+            old_core = nb.core
+            nb.core = None
+            if getattr(old_core, "neuronenblitz", None) is nb:
+                old_core.neuronenblitz = None
+
         self.neuronenblitz = nb
         if getattr(nb, "core", None) is not self:
             nb.core = self
+
+    def detach_neuronenblitz(self) -> None:
+        """Detach any connected Neuronenblitz instance."""
+
+        if self.neuronenblitz is not None:
+            nb = self.neuronenblitz
+            self.neuronenblitz = None
+            if getattr(nb, "core", None) is self:
+                nb.core = None
 
     def _init_weight(self, fan_in: int = 1, fan_out: int = 1) -> float:
         """Return an initial synapse weight based on configuration."""

--- a/tests/test_core_neuronenblitz_integration.py
+++ b/tests/test_core_neuronenblitz_integration.py
@@ -33,3 +33,17 @@ def test_attach_core_switch():
     nb.attach_core(core2)
     assert nb.core is core2
     assert core2.neuronenblitz is nb
+    assert core1.neuronenblitz is None
+
+
+def test_detach_methods():
+    random.seed(0)
+    core = Core(tiny_params())
+    nb = Neuronenblitz(core)
+    core.detach_neuronenblitz()
+    assert core.neuronenblitz is None
+    assert nb.core is None
+    nb.attach_core(core)
+    nb.detach_core()
+    assert core.neuronenblitz is None
+    assert nb.core is None


### PR DESCRIPTION
## Summary
- add robust attach/detach cycle for core and Neuronenblitz
- clear previous references when switching cores or NB instances
- test bidirectional attach/detach behaviour

## Testing
- `pytest tests/test_core_neuronenblitz_integration.py -q`
- `pytest tests/test_neuronenblitz_reset.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e8b25b92c8327894514452b8ff4c3