### PR TITLE
feat: unify core-neuronenblitz linking

### DIFF
--- a/marble_core.py
+++ b/marble_core.py
@@ -1746,17 +1746,23 @@ class Core:
 
         # Detach any existing Neuronenblitz instance from this core
         if self.neuronenblitz is not None and self.neuronenblitz is not nb:
-            old_nb = self.neuronenblitz
-            self.neuronenblitz = None
-            if getattr(old_nb, "core", None) is self:
-                old_nb.core = None
+            if hasattr(self.neuronenblitz, "detach_core"):
+                self.neuronenblitz.detach_core()
+            else:
+                old_nb = self.neuronenblitz
+                self.neuronenblitz = None
+                if getattr(old_nb, "core", None) is self:
+                    old_nb.core = None
 
         # Ensure the incoming instance is detached from its previous core
         if getattr(nb, "core", None) not in (None, self):
-            old_core = nb.core
-            nb.core = None
-            if getattr(old_core, "neuronenblitz", None) is nb:
-                old_core.neuronenblitz = None
+            if hasattr(nb, "detach_core"):
+                nb.detach_core()
+            else:
+                old_core = nb.core
+                nb.core = None
+                if getattr(old_core, "neuronenblitz", None) is nb:
+                    old_core.neuronenblitz = None
 
         self.neuronenblitz = nb
         if getattr(nb, "core", None) is not self:
@@ -1768,7 +1774,9 @@ class Core:
         if self.neuronenblitz is not None:
             nb = self.neuronenblitz
             self.neuronenblitz = None
-            if getattr(nb, "core", None) is self:
+            if hasattr(nb, "detach_core"):
+                nb.detach_core()
+            elif getattr(nb, "core", None) is self:
                 nb.core = None
 
     def _init_weight(self, fan_in: int = 1, fan_out: int = 1) -> float:

--- a/marble_neuronenblitz/core.py
+++ b/marble_neuronenblitz/core.py
@@ -377,21 +377,21 @@ class Neuronenblitz:
         """
 
         if self.core is not None and self.core is not core:
-            old_core = self.core
-            self.core = None
-            if getattr(old_core, "neuronenblitz", None) is self:
-                old_core.neuronenblitz = None
+            self.detach_core()
 
         if getattr(core, "neuronenblitz", None) not in (None, self):
-            existing = core.neuronenblitz
-            core.neuronenblitz = None
-            if getattr(existing, "core", None) is core:
-                existing.core = None
+            if hasattr(core, "detach_neuronenblitz"):
+                core.detach_neuronenblitz()
+            else:
+                existing = core.neuronenblitz
+                if getattr(existing, "core", None) is core:
+                    existing.core = None
+                core.neuronenblitz = None
 
-        self.core = core
         if hasattr(core, "attach_neuronenblitz"):
             core.attach_neuronenblitz(self)
         else:  # pragma: no cover - legacy path
+            self.core = core
             setattr(core, "neuronenblitz", self)
 
     def detach_core(self) -> None:

--- a/tests/test_core_neuronenblitz_integration.py
+++ b/tests/test_core_neuronenblitz_integration.py
@@ -47,3 +47,16 @@ def test_detach_methods():
     nb.detach_core()
     assert core.neuronenblitz is None
     assert nb.core is None
+
+
+def test_core_attach_neuronenblitz_switch():
+    random.seed(0)
+    core1 = Core(tiny_params())
+    nb1 = Neuronenblitz(core1)
+    core2 = Core(tiny_params())
+    nb2 = Neuronenblitz(core2)
+    core1.attach_neuronenblitz(nb2)
+    assert core1.neuronenblitz is nb2
+    assert nb2.core is core1
+    assert core2.neuronenblitz is None
+    assert nb1.core is None


### PR DESCRIPTION
## Summary
- ensure Core and Neuronenblitz consistently detach prior links before new attachments
- add integration test for attaching/detaching Neuronenblitz from Core

## Testing
- `pytest tests/test_core_neuronenblitz_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e8d2ce0988327b8f74c76d614e4ef