### PR TITLE
feat: freeze low impact synapses

### DIFF
--- a/tests/test_neuronenblitz_enhancements.py
+++ b/tests/test_neuronenblitz_enhancements.py
@@ -168,6 +168,27 @@ def test_prune_low_potential_synapses():
     assert syn_main in core.synapses
 
 
+def test_freeze_low_impact_synapses():
+    random.seed(0)
+    np.random.seed(0)
+    core, syn_a = create_simple_core()
+    syn_b = core.add_synapse(0, 1, weight=1.0)
+    nb = Neuronenblitz(
+        core,
+        split_probability=0.0,
+        alternative_connection_prob=0.0,
+        backtrack_probability=0.0,
+        backtrack_enabled=False,
+    )
+    nb._prev_gradients[syn_a] = 1.0
+    nb._prev_gradients[syn_b] = 0.0
+    syn_a.visit_count = 10
+    syn_b.visit_count = 0
+    nb.freeze_low_impact_synapses()
+    assert syn_b.frozen
+    assert not syn_a.frozen
+
+
 def test_update_and_get_context():
     core, _ = create_simple_core()
     nb = Neuronenblitz(core)

--- a/tests/test_neuronenblitz_reset.py
+++ b/tests/test_neuronenblitz_reset.py
@@ -17,3 +17,20 @@ def test_reset_learning_state_clears_caches():
     assert nb.wander_cache
     nb.reset_learning_state()
     assert not nb.wander_cache
+
+
+def test_reset_unfreezes_synapses():
+    random.seed(0)
+    np.random.seed(0)
+    core = Core(minimal_params())
+    core.neurons = [Neuron(0, value=0.0), Neuron(1, value=0.0)]
+    syn = core.add_synapse(0, 1, weight=1.0, frozen=True)
+    nb = Neuronenblitz(
+        core,
+        split_probability=0.0,
+        alternative_connection_prob=0.0,
+        backtrack_probability=0.0,
+        backtrack_enabled=False,
+    )
+    nb.reset_learning_state()
+    assert not syn.frozen


### PR DESCRIPTION
## Summary
- dynamically freeze synapses with negligible gradients and activity
- unfreeze synapses on reset
- test low-impact freezing logic

## Testing
- `pytest tests/test_neuronenblitz_enhancements.py`
- `pytest tests/test_neuronenblitz_reset.py`


------
https://chatgpt.com/codex/tasks/task_e_688f09abd27483279f867995464a09e1