### PR TITLE
feat: add weighted prioritized replay

### DIFF
--- a/neuronenblitztodo.md
+++ b/neuronenblitztodo.md
@@ -2,7 +2,7 @@
 
 This document lists 100 concrete ideas for enhancing the `Neuronenblitz` algorithm. Each item focuses on improving exploration, learning efficiency or structural adaptability beyond simply adding new parameters.
 
-1. Implement prioritized experience replay for wander results.
+1. Implement prioritized experience replay for wander results. (Completed with importance-sampling weights)
 2. Introduce adaptive exploration schedules based on entropy.
 3. Integrate gradient-based path scoring to accelerate learning.
 4. Employ soft actor-critic for reinforcement-driven wandering.


### PR DESCRIPTION
## Summary
- add prioritized replay sampling that returns importance weights
- scale training updates with importance-sampling weights
- verify weighted replay through unit tests and document improvement plan

## Testing
- `pytest tests/test_neuronenblitz_enhancements.py`
- `pytest tests/test_neuronenblitz_new_features.py`
- `pytest tests/test_neuronenblitz_package.py`
- `pytest tests/test_neuronenblitz_reset.py`
- `pytest tests/test_neuronenblitz_serialization.py`
- `pytest tests/test_core_neuronenblitz_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_688f0c28fa8c8327bc2ecc2b59bde092