### PR TITLE
Make RMS gradient path scoring configurable

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -198,6 +198,7 @@ Each entry is listed under its section heading.
 - structural_dropout_prob
 - gradient_path_score_scale
 - use_gradient_path_scoring
+- rms_gradient_path_scoring
 - activity_gate_exponent
 - subpath_cache_size
 - subpath_cache_ttl

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -178,7 +178,7 @@ URL or loading routine changes.
 4. **Run inference concurrently** with `marble.brain.dynamic_wander(sample)` to test the partially trained network while training is still running.
 5. **Tune caching** using the ``wander_cache_ttl`` parameter in ``config.yaml`` to control how long ``dynamic_wander`` results remain valid. Increasing the value reuses paths more aggressively while ``0`` disables expiry.
 6. **Speed up wandering** by enabling ``subpath_cache_size`` and ``subpath_cache_ttl`` under ``neuronenblitz``. This stores frequently used path prefixes so subsequent runs can recombine them without recomputing every step.
-7. **Bias exploration** toward informative routes by adjusting ``gradient_path_score_scale``. When ``use_gradient_path_scoring`` is true, wander paths that previously produced large gradient updates are preferred.
+7. **Bias exploration** toward informative routes by adjusting ``gradient_path_score_scale``. Set ``use_gradient_path_scoring: true`` to factor gradient magnitude into path selection. Enabling ``rms_gradient_path_scoring`` switches the metric from the sum of absolute last gradients to the root-mean-square of RMSProp statistics, favoring paths that consistently produce strong updates.
 8. **Experiment with evolutionary functions** to mutate or prune synapses:
    ```python
    mutated, pruned = marble.brain.evolve(mutation_rate=0.02, prune_threshold=0.05)

--- a/config.yaml
+++ b/config.yaml
@@ -206,6 +206,7 @@ neuronenblitz:
   structural_dropout_prob: 0.0
   gradient_path_score_scale: 1.0
   use_gradient_path_scoring: true
+  rms_gradient_path_scoring: false
   activity_gate_exponent: 1.0
   subpath_cache_size: 100
   subpath_cache_ttl: 300

--- a/neuronenblitztodo.md
+++ b/neuronenblitztodo.md
@@ -4,7 +4,7 @@ This document lists 100 concrete ideas for enhancing the `Neuronenblitz` algorit
 
 1. Implement prioritized experience replay for wander results. (Completed with importance-sampling weights)
 2. Introduce adaptive exploration schedules based on entropy. (Completed with entropy-driven epsilon adjustment)
-3. Integrate gradient-based path scoring to accelerate learning.
+3. Integrate gradient-based path scoring to accelerate learning. (Completed with optional RMS gradient scoring)
 4. Employ soft actor-critic for reinforcement-driven wandering.
 5. Add memory-gated attention to modulate path selection.
 6. Use episodic memory to bias wandering toward past successes.

--- a/tests/test_neuronenblitz_new_features.py
+++ b/tests/test_neuronenblitz_new_features.py
@@ -17,11 +17,12 @@ def simple_core_two_synapses():
     return core, s1, s2
 
 
-def test_gradient_path_scoring_prefers_higher_gradient():
+def test_gradient_path_scoring_prefers_higher_last_gradient():
     random.seed(0)
     np.random.seed(0)
     core, s1, s2 = simple_core_two_synapses()
-    nb = Neuronenblitz(core, use_gradient_path_scoring=True, gradient_path_score_scale=10.0,
+    nb = Neuronenblitz(core, use_gradient_path_scoring=True,
+                        gradient_path_score_scale=10.0,
                         split_probability=0.0, alternative_connection_prob=0.0,
                         backtrack_probability=0.0, backtrack_enabled=False)
     nb._prev_gradients[s1] = 0.1
@@ -29,7 +30,23 @@ def test_gradient_path_scoring_prefers_higher_gradient():
     res = [(core.neurons[1], [(core.neurons[0], s1), (core.neurons[1], None)]),
            (core.neurons[1], [(core.neurons[0], s2), (core.neurons[1], None)])]
     neuron, path = nb._merge_results(res)
-    # Path orientation now keeps the chosen synapse in the first tuple
+    assert path[0][1] is s2
+
+
+def test_rms_gradient_path_scoring_prefers_higher_rms():
+    random.seed(0)
+    np.random.seed(0)
+    core, s1, s2 = simple_core_two_synapses()
+    nb = Neuronenblitz(core, use_gradient_path_scoring=True,
+                        rms_gradient_path_scoring=True,
+                        gradient_path_score_scale=10.0,
+                        split_probability=0.0, alternative_connection_prob=0.0,
+                        backtrack_probability=0.0, backtrack_enabled=False)
+    nb._grad_sq[s1] = 0.1 ** 2
+    nb._grad_sq[s2] = 1.0 ** 2
+    res = [(core.neurons[1], [(core.neurons[0], s1), (core.neurons[1], None)]),
+           (core.neurons[1], [(core.neurons[0], s2), (core.neurons[1], None)])]
+    neuron, path = nb._merge_results(res)
     assert path[0][1] is s2
 
 

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -489,13 +489,23 @@ neuronenblitz:
   structural_dropout_prob: Probability that a qualified synapse is skipped
     during structural plasticity. Increasing this value reduces the frequency
     of structural changes.
-  gradient_path_score_scale: Multiplier applied to the cumulative gradient
-    magnitude of a wander path when selecting the best result. Higher values
-    bias exploration toward routes that recently produced strong weight
-    updates.
+  gradient_path_score_scale: Multiplier applied to the gradient magnitude of
+    a wander path when selecting the best result. When
+    ``rms_gradient_path_scoring`` is ``false`` the magnitude is computed as the
+    sum of absolute recent gradients stored in ``_prev_gradients``; when set to
+    ``true`` it becomes the root-mean-square of the RMSProp statistics in
+    ``_grad_sq``. Larger values bias exploration toward routes that have
+    produced strong updates.
   use_gradient_path_scoring: Set to ``true`` to enable gradient-based path
-    scoring in ``dynamic_wander``. When disabled only the final neuron value
+    scoring in ``dynamic_wander``. When ``false`` only the final neuron value
     determines which path is chosen.
+  rms_gradient_path_scoring: Chooses the statistic used for
+    ``compute_path_gradient_score``. The default ``false`` sums absolute values
+    of the most recent gradients, favoring paths with a single high spike. When
+    ``true`` the score uses the root-mean-square of the running squared
+    gradients from the RMSProp optimizer, emphasizing paths that maintain large
+    gradients over time. Toggle this to ``true`` when noisy gradients cause the
+    simple magnitude to be unstable.
   activity_gate_exponent: Exponent controlling how strongly synapse visit
     counts gate subsequent weight updates. ``1.0`` scales updates by
     ``1/(1+visits)`` while larger values produce steeper decay.


### PR DESCRIPTION
## Summary
- add `rms_gradient_path_scoring` flag so RMSProp-based path scoring can be toggled and remains off by default
- document the new configuration flag and its behavior in the YAML manual, default config and tutorial
- test both legacy and RMS gradient path scoring modes

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_neuronenblitz_new_features.py`
- `pytest tests/test_neuronenblitz_enhancements.py`
- `pytest tests/test_core_neuronenblitz_integration.py`
- `pytest tests/test_neuronenblitz_package.py`
- `pytest tests/test_neuronenblitz_reset.py`
- `pytest tests/test_neuronenblitz_serialization.py`


------
https://chatgpt.com/codex/tasks/task_e_688f123248908327bd7e41c3de725fde