### PR TITLE
feat: bias wandering using episodic memory

### DIFF
--- a/marble_neuronenblitz/README.md
+++ b/marble_neuronenblitz/README.md
@@ -4,7 +4,7 @@ This package contains the implementation of the adaptive learning system used by
 
 - `core.py` – main `Neuronenblitz` class with dynamic wandering and synaptic plasticity logic.
 - `learning.py` – reinforcement learning helpers used by `Neuronenblitz` and the high level agents.
-- `memory.py` – utilities for managing memory gate strengths and eligibility traces.
+- `memory.py` – utilities for managing memory gate strengths, episodic path replay, and eligibility traces.
 - `__init__.py` – exports commonly used functions and the core class.
 
 These modules can be imported individually, allowing advanced users to extend or replace specific functionality.

--- a/marble_neuronenblitz/core.py
+++ b/marble_neuronenblitz/core.py
@@ -1117,6 +1117,9 @@ class Neuronenblitz:
                     ),
                 )
             )
+            entry_neuron, initial_path, depth_limit = _memory.bias_with_episodic_memory(
+                self, entry_neuron, initial_path, depth_limit
+            )
             if self.beam_width > 1:
                 final_neuron, final_path = self._beam_wander(entry_neuron, depth_limit)
             else:

--- a/marble_neuronenblitz/memory.py
+++ b/marble_neuronenblitz/memory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import random
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
@@ -14,3 +15,65 @@ def decay_memory_gates(nb: "Neuronenblitz") -> None:
         nb.memory_gates[syn] *= nb.memory_gate_decay
         if nb.memory_gates[syn] < 1e-6:
             del nb.memory_gates[syn]
+
+
+def bias_with_episodic_memory(
+    nb: "Neuronenblitz", entry, path, depth_remaining
+):
+    """Follow a stored episodic path to bias wandering.
+
+    With probability ``nb.episodic_memory_prob`` a previously successful path
+    stored in ``nb.episodic_memory`` is replayed for up to
+    ``nb.episodic_sim_length`` steps.  Each traversed synapse applies the same
+    side effects as during normal wandering and the remaining depth is
+    decreased accordingly.
+
+    Parameters
+    ----------
+    nb:
+        ``Neuronenblitz`` instance.
+    entry:
+        Starting neuron for the wander.
+    path:
+        Current path as a list of ``(neuron, synapse)`` tuples where the first
+        synapse is ``None``.
+    depth_remaining:
+        Number of wandering steps still allowed.
+
+    Returns
+    -------
+    tuple
+        ``(current_neuron, path, depth_remaining)`` reflecting the state after
+        any episodic replay.
+    """
+
+    if nb.episodic_memory and random.random() < nb.episodic_memory_prob:
+        mem_path = random.choice(list(nb.episodic_memory))
+        steps = mem_path[: nb.episodic_sim_length]
+        current = entry
+        for syn in steps:
+            if depth_remaining <= 0:
+                break
+            next_neuron = nb.core.neurons[syn.target]
+            w = (
+                syn.effective_weight(nb.last_context, nb.global_phase)
+                if hasattr(syn, "effective_weight")
+                else syn.weight
+            )
+            transmitted = nb.combine_fn(current.value, w)
+            if hasattr(syn, "apply_side_effects"):
+                syn.apply_side_effects(nb.core, current.value)
+            if hasattr(syn, "update_echo"):
+                syn.update_echo(current.value, nb.core.synapse_echo_decay)
+            if nb.synaptic_fatigue_enabled and hasattr(syn, "update_fatigue"):
+                syn.update_fatigue(nb.fatigue_increase, nb.fatigue_decay)
+            syn.visit_count += 1
+            if hasattr(next_neuron, "process"):
+                next_neuron.value = next_neuron.process(transmitted)
+            else:
+                next_neuron.value = transmitted
+            path.append((next_neuron, syn))
+            current = next_neuron
+            depth_remaining -= 1
+        return current, path, depth_remaining
+    return entry, path, depth_remaining

--- a/neuronenblitztodo.md
+++ b/neuronenblitztodo.md
@@ -7,7 +7,7 @@ This document lists 100 concrete ideas for enhancing the `Neuronenblitz` algorit
 3. Integrate gradient-based path scoring to accelerate learning. (Completed with optional RMS gradient scoring)
 4. Employ soft actor-critic for reinforcement-driven wandering.
 5. Add memory-gated attention to modulate path selection.
-6. Use episodic memory to bias wandering toward past successes.
+6. Use episodic memory to bias wandering toward past successes. (Completed with episodic replay bias)
 7. Apply meta-learning to adjust plasticity thresholds dynamically.
 8. Integrate unsupervised contrastive losses into wander updates.
 9. Add hierarchical wandering to explore coarse-to-fine routes.

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -1,6 +1,6 @@
 from marble_core import Core
 from marble_neuronenblitz import Neuronenblitz
-from marble_neuronenblitz.memory import decay_memory_gates
+from marble_neuronenblitz.memory import bias_with_episodic_memory, decay_memory_gates
 from tests.test_core_functions import minimal_params
 
 
@@ -11,3 +11,25 @@ def test_decay_memory_gates():
     nb.memory_gates[syn] = 1.0
     decay_memory_gates(nb)
     assert syn not in nb.memory_gates or nb.memory_gates[syn] < 1.0
+
+
+def test_bias_with_episodic_memory_follows_path():
+    core = Core(minimal_params())
+    nb = Neuronenblitz(
+        core,
+        episodic_memory_prob=1.0,
+        episodic_sim_length=1,
+        split_probability=0.0,
+        alternative_connection_prob=0.0,
+        backtrack_probability=0.0,
+        backtrack_enabled=False,
+    )
+    syn = core.add_synapse(0, 1, weight=1.0)
+    nb.episodic_memory.append([syn])
+    entry = core.neurons[0]
+    entry.value = 1.0
+    current, path, remaining = bias_with_episodic_memory(
+        nb, entry, [(entry, None)], 1
+    )
+    assert path[-1][1] == syn
+    assert remaining == 0

--- a/tests/test_neuronenblitz_enhancements.py
+++ b/tests/test_neuronenblitz_enhancements.py
@@ -974,6 +974,24 @@ def test_curiosity_strength_biases_toward_novel_synapse():
     assert choices.count(syn_new) > choices.count(syn_old)
 
 
+def test_episodic_memory_biases_wandering():
+    random.seed(0)
+    np.random.seed(0)
+    core, syn = create_simple_core()
+    nb = Neuronenblitz(
+        core,
+        episodic_memory_prob=1.0,
+        episodic_sim_length=1,
+        split_probability=0.0,
+        alternative_connection_prob=0.0,
+        backtrack_probability=0.0,
+        backtrack_enabled=False,
+    )
+    nb.episodic_memory.append([syn])
+    _, path = nb.dynamic_wander(1.0)
+    assert path[0] == syn
+
+
 def test_depth_clip_scaling_reduces_update_for_deep_paths():
     random.seed(0)
     core, syn = create_simple_core()


### PR DESCRIPTION
## Summary
- introduce episodic replay to bias wandering toward previously successful paths
- document memory module and mark TODO entry
- add tests covering episodic memory bias

## Testing
- `pytest tests/test_memory_module.py`
- `pytest tests/test_neuronenblitz_enhancements.py`


------
https://chatgpt.com/codex/tasks/task_e_688f2acda6bc8327b6ba6e31811438f5