### PR TITLE
Add averaging strategy for parallel Neuronenblitz wanderers

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -141,6 +141,7 @@ Each entry is listed under its section heading.
 - max_learning_rate
 - top_k_paths
 - parallel_wanderers
+- parallel_update_strategy
 - beam_width
 - wander_cache_ttl
 - wander_anomaly_threshold

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -178,13 +178,14 @@ URL or loading routine changes.
 4. **Run inference concurrently** with `marble.brain.dynamic_wander(sample)` to test the partially trained network while training is still running.
 5. **Tune caching** using the ``wander_cache_ttl`` parameter in ``config.yaml`` to control how long ``dynamic_wander`` results remain valid. Increasing the value reuses paths more aggressively while ``0`` disables expiry.
 6. **Speed up wandering** by enabling ``subpath_cache_size`` and ``subpath_cache_ttl`` under ``neuronenblitz``. This stores frequently used path prefixes so subsequent runs can recombine them without recomputing every step.
-7. **Bias exploration** toward informative routes by adjusting ``gradient_path_score_scale``. Set ``use_gradient_path_scoring: true`` to factor gradient magnitude into path selection. Enabling ``rms_gradient_path_scoring`` switches the metric from the sum of absolute last gradients to the root-mean-square of RMSProp statistics, favoring paths that consistently produce strong updates.
-8. **Experiment with evolutionary functions** to mutate or prune synapses:
+7. **Average parallel wanderers** by setting ``parallel_wanderers`` above ``1`` and ``parallel_update_strategy: average`` in ``config.yaml``. Each wanderer explores independently and their weight updates are averaged, producing smoother training dynamics.
+8. **Bias exploration** toward informative routes by adjusting ``gradient_path_score_scale``. Set ``use_gradient_path_scoring: true`` to factor gradient magnitude into path selection. Enabling ``rms_gradient_path_scoring`` switches the metric from the sum of absolute last gradients to the root-mean-square of RMSProp statistics, favoring paths that consistently produce strong updates.
+9. **Experiment with evolutionary functions** to mutate or prune synapses:
    ```python
    mutated, pruned = marble.brain.evolve(mutation_rate=0.02, prune_threshold=0.05)
    ```
    Mutations add noise to synapses while pruning removes the least useful ones.
-7. **Enable dreaming** by setting `dream_enabled: true` in `config.yaml`. Parameters like `dream_num_cycles` and `dream_interval` determine how often memory consolidation happens in the background.
+10. **Enable dreaming** by setting `dream_enabled: true` in `config.yaml`. Parameters like `dream_num_cycles` and `dream_interval` determine how often memory consolidation happens in the background.
 
 **Complete Example**
 ```python

--- a/config.yaml
+++ b/config.yaml
@@ -147,6 +147,7 @@ neuronenblitz:
   max_learning_rate: 0.1
   top_k_paths: 5
   parallel_wanderers: 1
+  parallel_update_strategy: best
   beam_width: 1
   wander_cache_ttl: 300
   wander_anomaly_threshold: 3.0

--- a/neuronenblitztodo.md
+++ b/neuronenblitztodo.md
@@ -45,7 +45,7 @@ This document lists 100 concrete ideas for enhancing the `Neuronenblitz` algorit
 41. Use cross-modal embeddings for richer neuron representations.
 42. Employ mutual information maximization between wander paths.
 43. Introduce cyclical wandering phases inspired by biological sleep.
-44. Apply dynamic weight averaging across parallel wanderers.
+44. Apply dynamic weight averaging across parallel wanderers. (Completed with averaging strategy)
 45. Use discrete variational autoencoders for route encoding.
 46. Introduce feature-wise modulation for neuromodulatory signals.
 47. Apply an attention-based critic for reinforcement learning loops.

--- a/tests/test_parallel_wander.py
+++ b/tests/test_parallel_wander.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import random
@@ -6,6 +7,15 @@ import numpy as np
 from marble_core import Core
 from marble_neuronenblitz import Neuronenblitz
 from tests.test_core_functions import minimal_params
+
+
+calls: list[tuple[int, float]] = []
+orig_apply_weight_updates = Neuronenblitz.apply_weight_updates_and_attention
+
+
+def record_apply_weight_updates(nb, path, error):
+    calls.append((len(path), error))
+    return orig_apply_weight_updates(nb, path, error)
 
 
 def test_parallel_wander_train_example():
@@ -21,3 +31,30 @@ def test_parallel_wander_train_example():
     assert isinstance(err, float)
     assert path
     assert len(core.synapses) > before
+
+
+def test_parallel_average_applies_updates(monkeypatch):
+    random.seed(0)
+    np.random.seed(0)
+    params = minimal_params()
+    params["plasticity_threshold"] = 0.0
+    core = Core(params)
+    nb = Neuronenblitz(
+        core,
+        parallel_wanderers=2,
+        plasticity_threshold=0.0,
+        parallel_update_strategy="average",
+    )
+    global calls
+    calls = []
+    monkeypatch.setattr(
+        Neuronenblitz, "apply_weight_updates_and_attention", record_apply_weight_updates
+    )
+    out, err, path = nb.train_example(0.5, 0.2)
+    monkeypatch.setattr(
+        Neuronenblitz, "apply_weight_updates_and_attention", orig_apply_weight_updates
+    )
+    assert len(calls) == 2
+    assert isinstance(out, float)
+    assert isinstance(err, float)
+    assert path

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -333,10 +333,14 @@ neuronenblitz:
   parallel_wanderers: How many ``dynamic_wander`` processes to run in parallel
     for each training example. Setting this above ``1`` launches multiple
     temporary Neuronenblitz copies that explore the graph concurrently in
-    separate OS processes.  After all processes finish, only the wanderer that
-    achieves the greatest loss reduction, path speed improvement and model size
-    decrease is replayed in the main process to apply its weight updates and
-    structural plasticity.
+    separate OS processes. After all processes finish, their results are
+    combined according to ``parallel_update_strategy``.
+  parallel_update_strategy: Method for merging results from parallel wanderers.
+    ``best`` (default) replays only the wanderer that achieves the greatest
+    loss reduction, shortest path and smallest predicted model size. ``average``
+    averages the errors from all wanderers and applies each path's weight
+    updates scaled by ``1 / parallel_wanderers``. Use ``average`` to smooth
+    learning when running many wanderers.
   beam_width: Number of candidate paths retained at each depth during the
     beam search variant of ``dynamic_wander``. Wider beams explore more options
     but increase computation time. A value of ``1`` disables beam search and


### PR DESCRIPTION
## Summary
- allow Neuronenblitz to average weight updates from parallel wanderers via new `parallel_update_strategy` option
- document and expose `parallel_update_strategy` in configuration, manual, and tutorial
- test that averaging strategy applies updates from every wanderer

## Testing
- `pytest tests/test_parallel_wander.py`
- `pytest tests/test_neuronenblitz_enhancements.py`


------
https://chatgpt.com/codex/tasks/task_e_688f30d3ee248327879e49efee9fcb4b