### PR TITLE
feat: visualize conversion summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,8 @@ file. You can also call ``convert_model`` directly:
 
 For a quick overview without producing an output file you can use ``--summary``
 to print the neuron and synapse counts. ``--summary-output`` writes the same
-information to a JSON file.
+information to a JSON file. The ``--summary-plot`` option saves a bar chart of
+neuron and synapse counts per layer to an image file for visual inspection.
 
 ```python
 from pytorch_to_marble import convert_model

--- a/converttodo.md
+++ b/converttodo.md
@@ -98,7 +98,7 @@
 ### 5. Dry-run improvements
 - [x] Number of neurons and synapses created
 - [x] Per-layer mapping information
-- [ ] Visualize neuron and synapse counts
+- [x] Visualize neuron and synapse counts
 
 - [x] Add `--summary` CLI flag to print dry-run stats
 - [x] Support saving summary to JSON via `--summary-output`

--- a/tests/test_convert_model_summary_plot.py
+++ b/tests/test_convert_model_summary_plot.py
@@ -1,0 +1,36 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import torch
+
+
+class SmallModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc = torch.nn.Linear(2, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - simple pass-through
+        return self.fc(x)
+
+
+def test_convert_model_summary_plot(tmp_path):
+    model = SmallModel()
+    model_path = tmp_path / "model.pt"
+    torch.save(model, model_path)
+    plot_path = tmp_path / "summary.png"
+    script = Path(__file__).resolve().parent.parent / "convert_model.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--pytorch",
+            str(model_path),
+            "--summary-plot",
+            str(plot_path),
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 0
+    assert plot_path.exists()
+    assert plot_path.stat().st_size > 0


### PR DESCRIPTION
## Summary
- track synapse counts per layer during PyTorch model conversion and surface them in dry-run summaries
- add `--summary-plot` to `convert_model.py` to save bar charts of neuron and synapse counts, documenting the option
- mark "Visualize neuron and synapse counts" as completed in the converter TODO list

## Testing
- `pytest tests/test_pytorch_to_marble.py -q`
- `pytest tests/test_convert_model_cli.py -q`
- `pytest tests/test_convert_model_summary_plot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f37e3fee88327b2446e7f74341502