### PR TITLE
Add CSV export for conversion summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,8 @@ file. You can also call ``convert_model`` directly:
 For a quick overview without producing an output file you can use ``--summary``
 to print the neuron and synapse counts. ``--summary-output`` writes the same
 information to a JSON file. The ``--summary-plot`` option saves a bar chart of
-neuron and synapse counts per layer to an image file for visual inspection.
+neuron and synapse counts per layer, and ``--summary-csv`` exports the counts
+to a CSV file for further analysis.
 
 ```python
 from pytorch_to_marble import convert_model

--- a/converttodo.md
+++ b/converttodo.md
@@ -157,10 +157,10 @@
   - [ ] Integrate graph visualization library (e.g., pyvis or plotly).
   - [ ] Save rendered graphs to HTML for inspection.
   - [ ] Add tests verifying graph export.
-- [ ] Display neuron and synapse counts per layer
-  - [ ] Implement summarizer that tallies counts per layer.
-  - [ ] Provide CLI option to print or save counts.
-  - [ ] Write unit tests for summarizer accuracy.
+- [x] Display neuron and synapse counts per layer
+  - [x] Implement summarizer that tallies counts per layer.
+  - [x] Provide CLI option to print or save counts.
+  - [x] Write unit tests for summarizer accuracy.
 - [ ] Interactive tool to inspect neuron parameters
   - [ ] Build Streamlit viewer with filtering and search.
   - [ ] Support selecting neurons to show detailed parameters.
@@ -247,10 +247,10 @@
   - [ ] Add `--show-graph` option to converter CLI.
   - [ ] Render graph after conversion when flag is set.
   - [ ] Include tests verifying flag triggers visualization.
-- [ ] Save neuron and synapse counts per layer to .csv
-  - [ ] Implement exporter writing counts to CSV.
-  - [ ] Add CLI argument for output path.
-  - [ ] Test CSV output formatting.
+- [x] Save neuron and synapse counts per layer to .csv
+  - [x] Implement exporter writing counts to CSV.
+  - [x] Add CLI argument for output path.
+  - [x] Test CSV output formatting.
 - [ ] Interactive viewer to inspect weights
   - [ ] Develop Streamlit app to browse layer weights.
   - [ ] Provide search and filtering capabilities.

--- a/tests/test_convert_model_cli.py
+++ b/tests/test_convert_model_cli.py
@@ -79,6 +79,31 @@ def test_convert_model_summary_output(tmp_path):
     assert summary_path.exists()
 
 
+def test_convert_model_summary_csv(tmp_path):
+    model = SmallModel()
+    model_path = tmp_path / "model.pt"
+    torch.save(model, model_path)
+
+    csv_path = tmp_path / "summary.csv"
+    script = Path(__file__).resolve().parent.parent / "convert_model.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--pytorch",
+            str(model_path),
+            "--summary-csv",
+            str(csv_path),
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 0
+    assert csv_path.exists()
+    content = csv_path.read_text(encoding="utf-8").strip().splitlines()
+    assert content[0] == "layer,neurons,synapses"
+    assert len(content) >= 2
+
+
 def test_convert_model_config(tmp_path):
     model = SmallModel()
     model_path = tmp_path / "model.pt"


### PR DESCRIPTION
## Summary
- support exporting conversion summaries to CSV via new `--summary-csv` option
- document CSV export in README and mark converter TODOs as completed
- test CLI CSV output

## Testing
- `pytest tests/test_convert_model_cli.py`
- `pytest tests/test_convert_model_summary_plot.py`


------
https://chatgpt.com/codex/tasks/task_e_688f61c85d548327a721cd270cb3def0