### PR TITLE
Add activation flags, graph export, and workspace metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ The lightweight ``DatasetCacheServer`` shares preprocessed dataset files between
 nodes to avoid repeated downloads. Memory usage during these workflows can be
 tracked using ``memory_manager.MemoryManager`` while
 ``metrics_dashboard.MetricsDashboard`` provides live charts of loss, VRAM
-consumption and other metrics.
+consumption and other metrics. When the Global Workspace plugin is active, the
+dashboard also visualises the workspace queue length to monitor cognitive load.
 
 ### Remote Inference API
 
@@ -536,7 +537,13 @@ For a quick overview without producing an output file you can use ``--summary``
 to print the neuron and synapse counts. ``--summary-output`` writes the same
 information to a JSON file. The ``--summary-plot`` option saves a bar chart of
 neuron and synapse counts per layer, and ``--summary-csv`` exports the counts
-to a CSV file for further analysis.
+to a CSV file for further analysis. ``--summary-graph`` exports an interactive
+HTML visualisation of the converted graph using Plotly.
+
+Neurons created via the converter or the low-level graph builder now expose an
+``activation_flag`` in their ``params`` dictionary. Runtime evaluators can set
+or inspect this boolean flag to enable conditional message passing, allowing
+modules to skip expensive activations for neurons marked as inactive.
 
 ```python
 from pytorch_to_marble import convert_model

--- a/TODO.md
+++ b/TODO.md
@@ -996,10 +996,10 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
     - [ ] Integrate version info with pipeline loader.
     - [ ] Add tests for version switching.
 314. [ ] Integrate with the Global Workspace to monitor overall system state.
-    - [ ] Expose pipeline metrics to Global Workspace.
-    - [ ] Add callbacks pushing state updates.
-    - [ ] Visualize workspace status in metrics dashboard.
-    - [ ] Test Global Workspace integration path.
+    - [x] Expose pipeline metrics to Global Workspace.
+    - [x] Add callbacks pushing state updates.
+    - [x] Visualize workspace status in metrics dashboard.
+    - [x] Test Global Workspace integration path.
 315. [ ] Provide cross-device tensor synchronization to minimize latency during distributed training.
     - [ ] Implement diff-based synchronization protocol.
     - [ ] Add background sync service coordinating devices.

--- a/converttodo.md
+++ b/converttodo.md
@@ -153,10 +153,10 @@
 - [x] Support `.json` or `.marble` output based on extension
 
 ### 9. Graph visualization and inspection
-- [ ] Visualize generated MARBLE graph structure
-  - [ ] Integrate graph visualization library (e.g., pyvis or plotly).
-  - [ ] Save rendered graphs to HTML for inspection.
-  - [ ] Add tests verifying graph export.
+- [x] Visualize generated MARBLE graph structure
+  - [x] Integrate graph visualization library (e.g., pyvis or plotly).
+  - [x] Save rendered graphs to HTML for inspection.
+  - [x] Add tests verifying graph export.
 - [x] Display neuron and synapse counts per layer
   - [x] Implement summarizer that tallies counts per layer.
   - [x] Provide CLI option to print or save counts.
@@ -195,11 +195,11 @@
 - [ ] Graph construction utilities bridging to dynamic message passing
   - [x] Helper to spawn neurons for input/output dimensions
   - [x] Helper to connect neurons with weighted synapses
-    - [ ] Activation flag storage for message passing
-      - [ ] Add boolean flag field to neuron metadata.
-      - [ ] Propagate activation flags through graph builder.
-      - [ ] Document usage for runtime evaluators.
-      - [ ] Add tests verifying flag presence.
+    - [x] Activation flag storage for message passing
+      - [x] Add boolean flag field to neuron metadata.
+      - [x] Propagate activation flags through graph builder.
+      - [x] Document usage for runtime evaluators.
+      - [x] Add tests verifying flag presence.
 - [ ] torch.fx integration for arbitrary models
   - [ ] Trace custom layers and call registered converters
   - [ ] Allow decorators to register new converters

--- a/marble_base.py
+++ b/marble_base.py
@@ -142,6 +142,7 @@ class MetricsVisualizer:
             "cpu_usage": [],
             "cache_hit": [],
             "cache_miss": [],
+            "workspace_queue": [],
         }
         self.fig_width = fig_width
         self.fig_height = fig_height

--- a/marble_core.py
+++ b/marble_core.py
@@ -509,6 +509,9 @@ class Neuron:
             raise InvalidNeuronParamsError("rep_size must be positive")
         self.representation = np.zeros(rep_size, dtype=float)
         self.params = {}
+        # Flag used during message passing to indicate active neurons.
+        # Stored in params so converters and builders can toggle it.
+        self.params["activation_flag"] = False
         self.value_history = []
         self.initialize_params()
         self.validate_params()

--- a/marble_graph_builder.py
+++ b/marble_graph_builder.py
@@ -5,7 +5,9 @@ from typing import List, Iterable, Optional, Sequence
 from marble_core import Core, Neuron, Synapse
 
 
-def add_neuron_group(core: Core, count: int, activation: Optional[str] = None) -> List[int]:
+def add_neuron_group(
+    core: Core, count: int, activation: Optional[str] = None, activation_flag: bool = False
+) -> List[int]:
     """Add ``count`` neurons to ``core``.
 
     Parameters
@@ -16,6 +18,8 @@ def add_neuron_group(core: Core, count: int, activation: Optional[str] = None) -
         Number of neurons to create.
     activation : Optional[str]
         Optional activation type to store in neuron metadata.
+    activation_flag : bool
+        Whether to mark neurons as active for message passing.
 
     Returns
     -------
@@ -28,6 +32,7 @@ def add_neuron_group(core: Core, count: int, activation: Optional[str] = None) -
         neuron = Neuron(nid, value=0.0, tier="vram")
         if activation is not None:
             neuron.params["activation"] = activation
+        neuron.params["activation_flag"] = activation_flag
         core.neurons.append(neuron)
         ids.append(nid)
     return ids
@@ -40,6 +45,7 @@ def add_fully_connected_layer(
     weights: Optional[Sequence[Sequence[float]]] = None,
     bias: Optional[Sequence[float]] = None,
     activation: Optional[str] = None,
+    activation_flag: bool = False,
 ) -> List[int]:
     """Create a fully connected layer.
 
@@ -57,13 +63,17 @@ def add_fully_connected_layer(
         Bias values for each output neuron.
     activation : Optional[str]
         Optional activation flag to assign to output neurons.
+    activation_flag : bool
+        Whether to mark output neurons as active.
 
     Returns
     -------
     List[int]
         IDs of output neurons.
     """
-    out_ids = add_neuron_group(core, out_dim, activation=activation)
+    out_ids = add_neuron_group(
+        core, out_dim, activation=activation, activation_flag=activation_flag
+    )
 
     if weights is None:
         weights = [[0.0 for _ in inputs] for _ in range(out_dim)]
@@ -94,6 +104,7 @@ def linear_layer(
     weights: Optional[Sequence[Sequence[float]]] = None,
     bias: Optional[Sequence[float]] = None,
     activation: Optional[str] = None,
+    activation_flag: bool = False,
 ) -> tuple[List[int], List[int]]:
     """Create a fully connected layer with freshly allocated neurons.
 
@@ -119,7 +130,13 @@ def linear_layer(
     """
     inputs = add_neuron_group(core, in_dim)
     outputs = add_fully_connected_layer(
-        core, inputs, out_dim, weights=weights, bias=bias, activation=activation
+        core,
+        inputs,
+        out_dim,
+        weights=weights,
+        bias=bias,
+        activation=activation,
+        activation_flag=activation_flag,
     )
     return inputs, outputs
 

--- a/metrics_dashboard.py
+++ b/metrics_dashboard.py
@@ -110,6 +110,12 @@ class MetricsDashboard:
             fig.add_scatter(
                 y=self.smooth(metrics["cache_miss"]), mode="lines", name="Cache Miss"
             )
+        if "workspace_queue" in selected and metrics.get("workspace_queue"):
+            fig.add_scatter(
+                y=self.smooth(metrics["workspace_queue"]),
+                mode="lines",
+                name="WorkspaceQueue",
+            )
         fig.update_layout(xaxis_title="Updates", yaxis_title="Value")
         return fig
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,6 +58,7 @@ markdown-it-py==3.0.0
 MarkupSafe==2.1.5
 matplotlib==3.10.3
 matplotlib-inline==0.1.7
+mdformat==0.7.22
 mdurl==0.1.2
 mpmath==1.3.0
 msgpack==1.0.8
@@ -141,4 +142,3 @@ widgetsnbextension==4.0.14
 xxhash==3.5.0
 yarl==1.20.1
 zipp==3.23.0
-mdformat==0.7.22

--- a/tests/test_convert_model_graph_html.py
+++ b/tests/test_convert_model_graph_html.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+import subprocess
+
+import torch
+
+
+def _small_model() -> torch.nn.Module:
+    # Use only built-in layers so loading via torch.load works in subprocess
+    return torch.nn.Sequential(torch.nn.Linear(2, 1))
+
+
+def test_convert_model_summary_graph(tmp_path):
+    model = _small_model()
+    model_path = tmp_path / "model.pt"
+    torch.save(model, model_path)
+    html_path = tmp_path / "summary.html"
+    script = Path(__file__).resolve().parent.parent / "convert_model.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--pytorch",
+            str(model_path),
+            "--summary",
+            "--summary-graph",
+            str(html_path),
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 0
+    assert html_path.exists()
+    assert html_path.stat().st_size > 0

--- a/tests/test_global_workspace_metrics.py
+++ b/tests/test_global_workspace_metrics.py
@@ -1,0 +1,17 @@
+import importlib
+
+from marble_base import MetricsVisualizer
+import global_workspace
+from metrics_dashboard import MetricsDashboard
+
+
+def test_workspace_metric_updates():
+    importlib.reload(global_workspace)
+    mv = MetricsVisualizer()
+    gw = global_workspace.activate(capacity=2, metrics=mv)
+    gw.publish("source", "msg")
+    assert mv.metrics["workspace_queue"][-1] == 1
+    dash = MetricsDashboard(mv)
+    fig = dash._build_figure(["workspace_queue"])
+    # Should produce a trace for workspace queue
+    assert any(trace.name == "WorkspaceQueue" for trace in fig.data)

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -15,10 +15,18 @@ from tests.test_core_functions import minimal_params
 
 def test_add_neuron_group_activation():
     core = Core(minimal_params(), formula="0", formula_num_neurons=0)
-    ids = add_neuron_group(core, 3, activation="relu")
+    ids = add_neuron_group(core, 3, activation="relu", activation_flag=True)
     assert len(ids) == 3
     for nid in ids:
         assert core.neurons[nid].params["activation"] == "relu"
+        assert core.neurons[nid].params["activation_flag"] is True
+
+
+def test_activation_flag_default():
+    core = Core(minimal_params(), formula="0", formula_num_neurons=0)
+    ids = add_neuron_group(core, 2)
+    for nid in ids:
+        assert core.neurons[nid].params["activation_flag"] is False
 
 
 def test_add_fully_connected_layer_bias_weights():


### PR DESCRIPTION
## Summary
- Store `activation_flag` in neuron metadata and propagate through graph builder
- Export MARBLE graphs to interactive Plotly HTML via new `--summary-graph` option
- Surface Global Workspace queue metrics in metrics dashboard and tests

## Testing
- `pytest tests/test_graph_builder.py`
- `pytest tests/test_convert_model_graph_html.py`
- `pytest tests/test_global_workspace_metrics.py`
- `pytest tests/test_global_workspace_plugin.py`
- `pytest tests/test_metrics_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_688f898a820c8327b082e65d54a1428e