### PR TITLE
feat: add sync interval config

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -21,6 +21,9 @@ Each entry is listed under its section heading.
 - async_enabled
 - cache_dir
 
+## sync
+- interval_ms
+
 ## core
 - xmin
 - xmax

--- a/TODO.md
+++ b/TODO.md
@@ -1010,8 +1010,8 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
         - [ ] Spawn a lightweight worker thread per device to exchange deltas.
         - [ ] Aggregate metrics to detect and resync stale devices.
     - [ ] Tune synchronization interval via configuration.
-        - [ ] Add `sync.interval_ms` to configuration and CLI flags.
-        - [ ] Provide recommended ranges in YAML manual and parameters list.
+        - [x] Add `sync.interval_ms` to configuration and CLI flags.
+        - [x] Provide recommended ranges in YAML manual and parameters list.
     - [ ] Add tests measuring latency reduction.
         - [ ] Simulate a two-device setup with dummy tensors.
         - [ ] Verify synchronization reduces transfer volume and wall-clock time.

--- a/cli.py
+++ b/cli.py
@@ -36,6 +36,11 @@ def main() -> None:
     parser.add_argument("--min-lr", type=float, help="Minimum learning rate")
     parser.add_argument("--max-lr", type=float, help="Maximum learning rate")
     parser.add_argument(
+        "--sync-interval-ms",
+        type=int,
+        help="Milliseconds between cross-device tensor synchronizations",
+    )
+    parser.add_argument(
         "--pipeline",
         help="Path to a pipeline JSON file to execute after initialization",
     )
@@ -81,7 +86,7 @@ def main() -> None:
         sync_config(src, args.sync_config)
         return
 
-    overrides: dict[str, dict] = {"neuronenblitz": {}, "brain": {}}
+    overrides: dict[str, dict] = {"neuronenblitz": {}, "brain": {}, "sync": {}}
     if args.lr_scheduler:
         overrides["neuronenblitz"]["lr_scheduler"] = args.lr_scheduler
     if args.scheduler_steps is not None:
@@ -92,6 +97,8 @@ def main() -> None:
         overrides["neuronenblitz"]["min_learning_rate"] = args.min_lr
     if args.max_lr is not None:
         overrides["neuronenblitz"]["max_learning_rate"] = args.max_lr
+    if args.sync_interval_ms is not None:
+        overrides["sync"]["interval_ms"] = args.sync_interval_ms
     if args.early_stopping_patience is not None:
         overrides["brain"]["early_stopping_patience"] = args.early_stopping_patience
     if args.early_stopping_delta is not None:
@@ -99,6 +106,7 @@ def main() -> None:
     marble = create_marble_from_config(args.config, overrides=overrides)
     if args.grid_search:
         import yaml
+
         from hyperparameter_search import grid_search
 
         with open(args.grid_search, "r", encoding="utf-8") as f:

--- a/config.yaml
+++ b/config.yaml
@@ -20,6 +20,9 @@ pipeline:
   cache_dir: null       # Directory for cached step outputs; defaults to pipeline_cache_gpu or pipeline_cache_cpu
 
 
+sync:
+  interval_ms: 1000     # Interval in milliseconds between cross-device tensor synchronization cycles
+
 # =====
 # Core
 # =====

--- a/config_schema.py
+++ b/config_schema.py
@@ -74,6 +74,12 @@ CONFIG_SCHEMA = {
                 "tokenizer_vocab_size": {"type": "integer", "minimum": 1},
             },
         },
+        "sync": {
+            "type": "object",
+            "properties": {
+                "interval_ms": {"type": "integer", "minimum": 1},
+            },
+        },
         "plugins": {
             "type": ["array", "string"],
             "items": {"type": "string"},

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,3 +89,21 @@ def test_cli_grid_search(tmp_path):
     )
     assert result.returncode == 0
     assert b"dropout_probability" in result.stdout
+
+
+def test_cli_sync_interval_override(tmp_path):
+    cfg = Path(tmp_path) / "cfg.yaml"
+    import yaml
+
+    cfg.write_text(yaml.safe_dump({"core": minimal_params()}))
+    result = subprocess.run(
+        [
+            sys.executable,
+            "cli.py",
+            "--config",
+            str(cfg),
+            "--sync-interval-ms",
+            "2000",
+        ]
+    )
+    assert result.returncode == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,11 +6,7 @@ import jsonschema
 import pytest
 import yaml
 
-from config_loader import (
-    create_marble_from_config,
-    load_config,
-    validate_global_config,
-)
+from config_loader import create_marble_from_config, load_config, validate_global_config
 from marble_main import MARBLE
 from remote_offload import RemoteBrainClient
 from torrent_offload import BrainTorrentClient
@@ -47,6 +43,7 @@ def test_load_config_defaults():
     assert cfg["network"]["remote_client"]["max_retries"] == 3
     assert cfg["network"]["torrent_client"]["client_id"] == "main"
     assert cfg["network"]["torrent_client"]["buffer_size"] == 10
+    assert cfg["sync"]["interval_ms"] == 1000
     assert cfg["brain"]["initial_neurogenesis_factor"] == 1.0
     assert cfg["brain"]["offload_enabled"] is False
     assert cfg["brain"]["torrent_offload_enabled"] is False

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -49,6 +49,13 @@ pipeline:
     available or ``pipeline_cache_cpu`` otherwise. Use ``HighLevelPipeline.clear_cache()``
     to remove cached files when space is needed.
 
+sync:
+  interval_ms: Number of milliseconds between background tensor synchronization cycles
+    across devices in distributed training. Lower values (100–500) keep model
+    parameters closely aligned but increase communication overhead. Higher values
+    (1000–10000) reduce network usage at the cost of more stale updates. Must be
+    a positive integer. Defaults to ``1000``.
+
 core:
   xmin: Minimum X coordinate for the Mandelbrot seed. Defines the left boundary
     of the complex plane used when initializing neuron values.


### PR DESCRIPTION
## Summary
- add `sync.interval_ms` config option with CLI override
- document synchronization interval parameter across manuals and parameter lists
- test sync interval defaults and CLI flag handling

## Testing
- `pytest tests/test_config.py`
- `pytest tests/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_688f9461d2708327bd67c483078d3f30