### PR TITLE
Expand TODO tasks into actionable substeps

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1034,32 +1034,82 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
     - [x] Create backend abstraction layer (`tensor_backend.py`) with functions like `matmul`, `sigmoid`, and `relu`.
     - [x] Implement NumPy and JAX backend versions.
     - [ ] Refactor Mandelbrot seed generation (`core/init_seed.py`) to use backend functions.
+        - [ ] Replace direct NumPy operations with backend wrappers.
+        - [ ] Ensure random seeds are produced via the selected backend.
+        - [ ] Add unit tests confirming identical seeds across backends.
     - [ ] Update message passing (`core/message_passing.py`) to rely on the abstraction.
+        - [ ] Swap low-level tensor ops for backend calls.
+        - [ ] Enable runtime selection of NumPy or JAX paths.
+        - [ ] Verify message delivery equivalence with tests.
     - [x] Add `core.backend` to `config.yaml` with fallback to NumPy and document in `yaml-manual.txt` and `CONFIGURABLE_PARAMETERS.md`.
     - [x] Test Mandelbrot output consistency across backends.
 
 320. [ ] Introduce parallel Neuronenblitz workers.
     - [ ] Refactor `Neuronenblitz.train_example()` to be stateless and reentrant.
+        - [ ] Remove global state dependencies.
+        - [ ] Guard internal structures for thread safety.
+        - [ ] Document reentrant assumptions in docstrings.
     - [ ] Implement `train_in_parallel()` using `concurrent.futures.ThreadPoolExecutor`.
+        - [ ] Create worker wrapper around `train_example`.
+        - [ ] Manage executor lifecycle and exception handling.
+        - [ ] Aggregate gradients and metrics from workers.
     - [ ] Add `neuronenblitz.parallel_wanderers` to config with default 1 and document it.
+        - [ ] Add parameter to `config.yaml` and CLI.
+        - [ ] Describe usage in `yaml-manual.txt` and `CONFIGURABLE_PARAMETERS.md`.
+        - [ ] Provide defaults and edge-case guidance.
     - [ ] Log worker-level metrics like average path length and divergence.
+        - [ ] Record metrics within each worker loop.
+        - [ ] Aggregate and report per-worker summaries.
     - [ ] Benchmark speedup on multi-core CPUs.
+        - [ ] Design benchmark comparing single vs multi-worker.
+        - [ ] Capture wall-clock time and throughput.
+        - [ ] Summarize findings in docs.
     - [ ] Write tests for parallel wanderers.
+        - [ ] Ensure deterministic results with one worker.
+        - [ ] Validate scaling behavior with multiple workers.
 
 321. [ ] Add quantization and sparse tensor support.
     - [ ] Implement `QuantizedTensor` class with `.to_dense()` and `.to_bits()`.
+        - [ ] Define bit-packing strategy for tensors.
+        - [ ] Implement conversion methods for CPU and GPU.
+        - [ ] Provide serialization helpers.
     - [ ] Add optional quantization in `DataCompressor` using `core.quantization_bits` and document parameter.
+        - [ ] Integrate `QuantizedTensor` into compression pipeline.
+        - [ ] Add configuration option for bit width.
+        - [ ] Update docs outlining trade-offs.
     - [ ] Use `scipy.sparse` for large synapse matrices.
+        - [ ] Convert eligible matrices to sparse format.
+        - [ ] Provide utilities to switch between dense and sparse.
+        - [ ] Benchmark memory savings.
     - [ ] Validate lossless forward pass for common operations.
+        - [ ] Compare quantized and dense outputs on sample layers.
+        - [ ] Track numerical error and performance.
     - [ ] Add CLI flag `--quantize` for toggling quantization.
+        - [ ] Parse flag and map to configuration value.
+        - [ ] Document usage in CLI help and README.
     - [ ] Write unit tests verifying quantization correctness.
+        - [ ] Test bit conversion round-trips.
+        - [ ] Validate sparse and dense paths produce same results.
 
 322. [ ] Implement causal attention and gating.
     - [ ] Add `core.attention_causal` to configuration and document it.
+        - [ ] Insert parameter into `config.yaml` with default setting.
+        - [ ] Extend `yaml-manual.txt` and `CONFIGURABLE_PARAMETERS.md`.
+        - [ ] Provide CLI flag to toggle causal attention.
     - [ ] Modify attention mechanism to mask future tokens (`mask[i, j] = j > i`).
+        - [ ] Implement mask generation routine.
+        - [ ] Ensure masking works on CPU and GPU backends.
+        - [ ] Benchmark overhead introduced by masking.
     - [ ] Implement `gating_layer` using sine or chaotic modulation.
+        - [ ] Prototype gating function and parameter ranges.
+        - [ ] Integrate gating into attention pipeline.
+        - [ ] Expose gating parameters in configuration.
     - [ ] Visualize mask and gate effects on message propagation.
+        - [ ] Create plotting utilities for masks and gates.
+        - [ ] Add Streamlit view to display visuals.
     - [ ] Add tests for causal attention and gating behavior.
+        - [ ] Verify masks prevent future token access.
+        - [ ] Check gating outputs remain within expected bounds.
 
 323. [x] Build streaming tokenizer and data loader.
     - [x] Refactor tokenizer interface to yield `tokenize(line)` instead of whole corpus.
@@ -1070,62 +1120,147 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 
 324. [ ] Enhance Theory of Mind module.
     - [ ] Add `agent_id` and `belief_state` fields to input.
+        - [ ] Extend input schemas and validation.
+        - [ ] Update serialization/deserialization logic.
     - [ ] Encode beliefs as key-value memory slots in a new `ToMModule`.
+        - [ ] Define memory slot structure and capacity.
+        - [ ] Integrate module into existing pipeline.
     - [ ] Add multi-hop attention over belief states.
+        - [ ] Implement attention layers supporting multiple hops.
+        - [ ] Tune hop count for efficiency.
     - [ ] Log belief mismatches during evaluation.
+        - [ ] Define mismatch metric and thresholds.
+        - [ ] Store mismatches for post-run analysis.
     - [ ] Write tests for belief encoding and attention.
+        - [ ] Unit test memory slot creation and retrieval.
+        - [ ] Validate attention selects correct belief states.
 
 325. [ ] Implement self-distillation over time.
     - [ ] Save `logits.pkl` after each epoch.
+        - [ ] Hook training loop to capture logits.
+        - [ ] Serialize logits with epoch metadata.
     - [ ] Add `self_distill_loss = KL(current_logits, previous_logits)` to the loss function with weight `meta_learning.distill_alpha`.
+        - [ ] Implement KL divergence term.
+        - [ ] Introduce `distill_alpha` parameter in config and docs.
     - [ ] Visualize alignment of predictions over time.
+        - [ ] Plot KL divergence per epoch.
+        - [ ] Display visualization in Streamlit dashboard.
     - [ ] Document distillation parameter in YAML manual and tutorial.
+        - [ ] Describe purpose and recommended ranges.
+        - [ ] Add tutorial section with example usage.
     - [ ] Add tests for self-distillation loss.
+        - [ ] Unit test loss calculation with synthetic logits.
+        - [ ] Ensure training uses previous epoch logits when available.
 
 326. [ ] Create in-context learning prompt system.
     - [ ] Add `PromptMemory` to cache recent `(input, output)` pairs.
+        - [ ] Implement bounded queue with eviction policy.
+        - [ ] Provide serialization for stored pairs.
     - [ ] Modify inference to use `prompt + input` as composite query.
+        - [ ] Concatenate prompts with new inputs before inference.
+        - [ ] Handle empty or oversized prompt caches gracefully.
     - [ ] Add GUI control for toggling prompt injection.
+        - [ ] Create Streamlit toggle linked to inference pipeline.
+        - [ ] Persist user preference between sessions.
     - [ ] Store prompts persistently with timestamps.
+        - [ ] Save prompt memory to disk on shutdown.
+        - [ ] Include timestamps for chronological retrieval.
     - [ ] Write tests for prompt cache behavior.
+        - [ ] Verify FIFO eviction policy.
+        - [ ] Test inference output when prompts are applied.
 
 327. [ ] Add YAML config editor in Streamlit.
     - [ ] Add new "Config Editor" tab using `st_ace` with YAML syntax.
+        - [ ] Preload existing configuration into editor.
+        - [ ] Provide syntax highlighting and line numbers.
     - [ ] Validate YAML with schema on submit and save edits to `config.yaml` with backup timestamp.
+        - [ ] Run schema validation and surface errors in UI.
+        - [ ] Save validated YAML and create timestamped backup file.
     - [ ] Update GUI tests for the editor tab.
+        - [ ] Simulate editing and saving a valid config.
+        - [ ] Confirm invalid YAML triggers error messages.
 
 328. [ ] Integrate hyperparameter optimisation via Optuna.
     - [ ] Add `scripts/optimize.py` with Optuna study and objective function training one epoch.
+        - [ ] Define search space and objective returning validation loss.
+        - [ ] Allow resuming existing studies.
     - [ ] Log trials to `optuna_db.sqlite3`.
+        - [ ] Configure SQLite storage backend.
+        - [ ] Expose path via CLI option.
     - [ ] Add Streamlit tab to visualize optimization history and best config.
+        - [ ] Plot trial scores and parameter importances.
+        - [ ] Provide download of best config.
     - [ ] Document usage in tutorials and manuals.
+        - [ ] Include setup and run instructions.
+        - [ ] Describe interpretation of optimization charts.
     - [ ] Add tests for optimization script.
+        - [ ] Use tiny dataset to run a short study.
+        - [ ] Assert database and result files are created.
 
 329. [ ] Implement live neuron graph visualisation.
     - [ ] Export graph as `{"nodes": [...], "edges": [...]}` in core.
+        - [ ] Gather neuron and synapse metadata into structured dicts.
+        - [ ] Support incremental updates for dynamic graphs.
     - [ ] Add `/graph` API endpoint.
+        - [ ] Implement endpoint returning serialized graph JSON.
+        - [ ] Secure endpoint with optional authentication.
     - [ ] Render graph with `plotly.graph_objects.Sankey` or `pyvis.network` and add sliders for filtering.
+        - [ ] Build reusable visualization component.
+        - [ ] Provide sliders for weight and degree thresholds.
     - [ ] Update GUI tests for graph visualization.
+        - [ ] Confirm endpoint availability in tests.
+        - [ ] Validate sliders adjust visible graph elements.
 
 330. [ ] Introduce multi-agent MARBLE.
     - [ ] Define `MARBLEAgent` wrapper with its own config and brain.
+        - [ ] Encapsulate brain initialization and lifecycle methods.
+        - [ ] Allow per-agent configuration loading.
     - [ ] Implement `MessageBus` for agent-to-agent communication.
+        - [ ] Design protocol for broadcasting and direct messages.
+        - [ ] Ensure thread-safe message queues.
     - [ ] Simulate cooperative or competitive RL environments.
+        - [ ] Provide sample environment harnesses.
+        - [ ] Support reward sharing and competition modes.
     - [ ] Log inter-agent influence and conversation.
+        - [ ] Record message histories and effect metrics.
+        - [ ] Visualize interactions in dashboard.
     - [ ] Add tests for multi-agent interactions.
+        - [ ] Unit test message exchange between two agents.
+        - [ ] Validate environment simulations run without deadlocks.
 
 331. [ ] Add evolutionary learning module.
     - [ ] Create `EvolutionTrainer` class.
+        - [ ] Implement mutation, evaluation, and selection hooks.
+        - [ ] Support parallel evaluation of candidates.
     - [ ] Generate `N` config mutations, train each for a few steps, and evaluate fitness.
+        - [ ] Define mutation operators for numeric and categorical params.
+        - [ ] Collect fitness metrics after partial training.
     - [ ] Select top `M` configurations and mutate again.
+        - [ ] Rank configurations by fitness.
+        - [ ] Produce next-generation configs via mutation.
     - [ ] Log evolution tree and best lineage.
+        - [ ] Track parent-child relationships.
+        - [ ] Serialize lineage to JSON and graphs.
     - [ ] Add tests for evolutionary training.
+        - [ ] Unit test mutation and selection logic.
+        - [ ] Integration test over multiple generations.
 
 332. [ ] Document new configuration parameters and tutorials.
     - [ ] Update `yaml-manual.txt` with detailed explanations and examples.
+        - [ ] Describe new parameters and their ranges.
+        - [ ] Include practical usage examples.
     - [ ] Add entries to `CONFIGURABLE_PARAMETERS.md`.
+        - [ ] List default values and descriptions.
+        - [ ] Cross-reference related parameters.
     - [ ] Extend `TUTORIAL.md` with projects for new features (e.g., self-distillation).
+        - [ ] Create step-by-step project showcasing feature.
+        - [ ] Link to dataset download and preparation code.
 
 333. [ ] Add unit tests and verify CUDA fallbacks.
     - [ ] Write tests for quantization correctness, parallel wanderers, and prompt cache behavior.
+        - [ ] Cover QuantizedTensor round-trip accuracy.
+        - [ ] Ensure parallel wanderers yield consistent results.
+        - [ ] Test prompt cache operations under load.
     - [ ] Verify CUDA fallbacks for all new modules.
+        - [ ] Run tests forcing CPU execution.
+        - [ ] Document any GPU-only limitations.

--- a/converttodo.md
+++ b/converttodo.md
@@ -62,35 +62,71 @@
   - [x] Converter for ``LSTM``
   - [x] Converter for ``GRU``
   - [x] Unit tests with tiny sequences
-  - [ ] Bidirectional and multi-layer support
-    - [ ] Map forward and backward weights for bidirectional RNNs.
-    - [ ] Handle stacked layers with appropriate parameter naming.
-    - [ ] Add tests converting multi-layer bidirectional models.
-  - [ ] Persistent hidden state mapping
-    - [ ] Serialize initial hidden states with layer metadata.
-    - [ ] Restore hidden states during MARBLE execution.
-    - [ ] Provide tests verifying state persistence across runs.
+    - [ ] Bidirectional and multi-layer support
+      - [ ] Map forward and backward weights for bidirectional RNNs.
+        - [ ] Align parameter ordering between PyTorch and MARBLE.
+        - [ ] Validate hidden state concatenation.
+      - [ ] Handle stacked layers with appropriate parameter naming.
+        - [ ] Prefix layer indices consistently.
+        - [ ] Ensure loading preserves original hierarchy.
+      - [ ] Add tests converting multi-layer bidirectional models.
+        - [ ] Build example network with two bidirectional layers.
+        - [ ] Compare outputs against PyTorch reference.
+    - [ ] Persistent hidden state mapping
+      - [ ] Serialize initial hidden states with layer metadata.
+        - [ ] Embed state tensors into converter output.
+        - [ ] Record correspondence to layer identifiers.
+      - [ ] Restore hidden states during MARBLE execution.
+        - [ ] Load serialized states into runtime structures.
+        - [ ] Verify shapes match original expectations.
+      - [ ] Provide tests verifying state persistence across runs.
+        - [ ] Save model, reload, and compare hidden states.
+        - [ ] Ensure no drift after multiple executions.
 - [x] Normalization layers (LayerNorm, GroupNorm)
   - [x] ``LayerNorm`` converter
   - [x] ``GroupNorm`` converter
   - [x] Unit tests for normalization
- - [ ] Transformer blocks
-  - [ ] Self-attention conversion
-    - [ ] Translate query, key, and value projections.
-    - [ ] Support multi-head attention weight splitting.
-    - [ ] Add unit tests for attention weight parity.
-  - [ ] Feed-forward sublayers
-    - [ ] Convert linear1 and linear2 layers with activation.
-    - [ ] Handle dropout placement within sublayer.
-    - [ ] Verify output numerically against PyTorch.
-  - [ ] Positional encoding handling
-    - [ ] Map sinusoidal and learned positional embeddings.
-    - [ ] Expose positional encoding choice via config.
-    - [ ] Add tests ensuring positions align after conversion.
-  - [ ] Integration tests on a small transformer
-    - [ ] Convert a tiny transformer model end-to-end.
-    - [ ] Compare MARBLE and PyTorch outputs for sample inputs.
-    - [ ] Document transformer conversion workflow.
+   - [ ] Transformer blocks
+    - [ ] Self-attention conversion
+      - [ ] Translate query, key, and value projections.
+        - [ ] Map weight matrices and biases separately.
+        - [ ] Ensure projection shapes align with head count.
+      - [ ] Support multi-head attention weight splitting.
+        - [ ] Split combined matrices into per-head chunks.
+        - [ ] Recombine outputs after attention.
+      - [ ] Add unit tests for attention weight parity.
+        - [ ] Verify numerical parity for single-head case.
+        - [ ] Extend tests to multi-head scenarios.
+    - [ ] Feed-forward sublayers
+      - [ ] Convert linear1 and linear2 layers with activation.
+        - [ ] Preserve activation type and placement.
+        - [ ] Translate weight and bias tensors.
+      - [ ] Handle dropout placement within sublayer.
+        - [ ] Detect dropout modules during tracing.
+        - [ ] Insert dropout nodes into MARBLE graph.
+      - [ ] Verify output numerically against PyTorch.
+        - [ ] Run random inputs through both models.
+        - [ ] Check differences within tolerance.
+    - [ ] Positional encoding handling
+      - [ ] Map sinusoidal and learned positional embeddings.
+        - [ ] Convert embedding tensors and scaling factors.
+        - [ ] Support optional padding tokens.
+      - [ ] Expose positional encoding choice via config.
+        - [ ] Add config parameter and CLI option.
+        - [ ] Document when to use each encoding type.
+      - [ ] Add tests ensuring positions align after conversion.
+        - [ ] Compare embedding indices between models.
+        - [ ] Validate sequence lengths remain unchanged.
+    - [ ] Integration tests on a small transformer
+      - [ ] Convert a tiny transformer model end-to-end.
+        - [ ] Trace model and run through converter.
+        - [ ] Load converted model into MARBLE runtime.
+      - [ ] Compare MARBLE and PyTorch outputs for sample inputs.
+        - [ ] Generate deterministic test inputs.
+        - [ ] Assert outputs differ within tolerance.
+      - [ ] Document transformer conversion workflow.
+        - [ ] Provide step-by-step guide in README.
+        - [ ] Include troubleshooting section.
 
 ### 2. High-level graph construction API
 - [x] Helper to add neuron groups with activations
@@ -99,10 +135,16 @@
   - [x] ``linear_layer`` wrapper
   - [x] ``conv2d_layer`` wrapper
 - [x] Documentation for graph builder utilities
- - [ ] Examples demonstrating dynamic message passing setup
-  - [ ] Create example script building a dynamic message passing graph.
-  - [ ] Document example usage in README.
-  - [ ] Add unit test covering dynamic example conversion.
+   - [ ] Examples demonstrating dynamic message passing setup
+    - [ ] Create example script building a dynamic message passing graph.
+        - [ ] Showcase runtime addition and removal of edges.
+        - [ ] Include comments explaining each step.
+    - [ ] Document example usage in README.
+        - [ ] Provide command to run the example.
+        - [ ] Explain expected output and graph behavior.
+    - [ ] Add unit test covering dynamic example conversion.
+        - [ ] Verify script executes without errors.
+        - [ ] Assert generated graph matches expected structure.
 
 ### 3. Weight and activation handling
 - [x] Extract weights and biases from PyTorch layers
@@ -124,19 +166,31 @@
 - [x] Add `--summary` CLI flag to print dry-run stats
 - [x] Support saving summary to JSON via `--summary-output`
 ### 6. Validation utilities
-- [ ] Validate converted models by comparing PyTorch and MARBLE outputs
-    - [ ] Unit tests for small networks
-    - [ ] Integration test for a custom model
-    - [ ] CLI option to run validation automatically
-        - [ ] Add `--validate` flag to `convert_model.py`.
-        - [ ] Execute PyTorch vs MARBLE comparison when the flag is provided.
-        - [ ] Output a validation report highlighting layer mismatches.
-        - [ ] Document the validation flag in README and CLI help.
-- [ ] Numerical tolerances for output comparison
-    - [ ] Define default tolerance thresholds for floating point comparisons.
-    - [ ] Allow overriding tolerance via CLI and configuration.
-    - [ ] Document tolerance settings in README.
-    - [ ] Add tests covering tolerance edge cases.
+  - [ ] Validate converted models by comparing PyTorch and MARBLE outputs
+      - [ ] Unit tests for small networks
+        - [ ] Compare single-layer models across frameworks.
+        - [ ] Check parameter copying correctness.
+      - [ ] Integration test for a custom model
+        - [ ] Convert a moderate-size model end-to-end.
+        - [ ] Validate numerical equivalence on sample data.
+      - [ ] CLI option to run validation automatically
+          - [ ] Add `--validate` flag to `convert_model.py`.
+          - [ ] Execute PyTorch vs MARBLE comparison when the flag is provided.
+          - [ ] Output a validation report highlighting layer mismatches.
+          - [ ] Document the validation flag in README and CLI help.
+  - [ ] Numerical tolerances for output comparison
+      - [ ] Define default tolerance thresholds for floating point comparisons.
+        - [ ] Determine separate tolerances for CPU and GPU.
+        - [ ] Justify chosen defaults in docs.
+      - [ ] Allow overriding tolerance via CLI and configuration.
+        - [ ] Add `--tolerance` flag and config entry.
+        - [ ] Validate user-provided values.
+      - [ ] Document tolerance settings in README.
+        - [ ] Include examples illustrating effects of tolerance.
+        - [ ] Warn about overly strict values causing failures.
+      - [ ] Add tests covering tolerance edge cases.
+        - [ ] Test near-threshold differences.
+        - [ ] Confirm override works via CLI and config.
 
 ### 7. Additional tooling
 - [x] Support converting `.pt` files directly into `.marble` snapshots
@@ -161,10 +215,16 @@
   - [x] Implement summarizer that tallies counts per layer.
   - [x] Provide CLI option to print or save counts.
   - [x] Write unit tests for summarizer accuracy.
-- [ ] Interactive tool to inspect neuron parameters
-  - [ ] Build Streamlit viewer with filtering and search.
-  - [ ] Support selecting neurons to show detailed parameters.
-  - [ ] Add GUI tests for viewer components.
+  - [ ] Interactive tool to inspect neuron parameters
+    - [ ] Build Streamlit viewer with filtering and search.
+        - [ ] Implement sidebar controls for filtering by layer or type.
+        - [ ] Provide search box for neuron IDs.
+    - [ ] Support selecting neurons to show detailed parameters.
+        - [ ] Display weights, biases, and activation info.
+        - [ ] Allow exporting selected neuron data.
+    - [ ] Add GUI tests for viewer components.
+        - [ ] Simulate user interaction with filters and search.
+        - [ ] Ensure detail view renders without errors.
 
 ### 10. Error handling and logging
 - [x] Unsupported layers raise `"[layer type name] is not supported for conversion"`
@@ -172,21 +232,38 @@
   - [x] Consistent error message for invalid Conv2d parameters
 
 ### 11. Dynamic graph support
-- [ ] Map PyTorch control flow to MARBLE dynamic topology
-  - [ ] Parse torch.fx conditional and loop nodes.
-  - [ ] Generate dynamic neuron groups for branches.
-  - [ ] Document limitations and edge cases.
-- [ ] Handle evolving neuron and synapse creation during inference
-  - [ ] Implement runtime graph mutation utilities.
-  - [ ] Ensure thread safety during dynamic updates.
-  - [ ] Add tests exercising dynamic growth.
-- [ ] Unit tests covering dynamic model conversion paths
-  - [ ] Create mock models with branching control flow.
-  - [ ] Verify converted graphs execute correctly.
-- [ ] Research torch.fx support for control flow constructs
-  - [ ] Survey existing torch.fx features for loops and conditionals.
-  - [ ] Prototype tracing of a model using control flow.
-  - [ ] Summarize findings in documentation.
+  - [ ] Map PyTorch control flow to MARBLE dynamic topology
+    - [ ] Parse torch.fx conditional and loop nodes.
+        - [ ] Identify node types representing branches and loops.
+        - [ ] Convert nodes into intermediate representation.
+    - [ ] Generate dynamic neuron groups for branches.
+        - [ ] Create separate groups for each branch path.
+        - [ ] Merge outputs using switch-like connections.
+    - [ ] Document limitations and edge cases.
+        - [ ] Note unsupported control-flow patterns.
+        - [ ] Provide workarounds where possible.
+  - [ ] Handle evolving neuron and synapse creation during inference
+    - [ ] Implement runtime graph mutation utilities.
+        - [ ] Support adding and removing nodes on the fly.
+        - [ ] Maintain consistency of references and indices.
+    - [ ] Ensure thread safety during dynamic updates.
+        - [ ] Guard mutations with locks or queues.
+        - [ ] Add checks for concurrent modification.
+    - [ ] Add tests exercising dynamic growth.
+        - [ ] Simulate incremental graph expansion during inference.
+        - [ ] Verify outputs remain stable.
+  - [ ] Unit tests covering dynamic model conversion paths
+    - [ ] Create mock models with branching control flow.
+        - [ ] Include nested loops and conditionals.
+    - [ ] Verify converted graphs execute correctly.
+        - [ ] Run forward passes and compare outputs.
+  - [ ] Research torch.fx support for control flow constructs
+    - [ ] Survey existing torch.fx features for loops and conditionals.
+        - [ ] Review documentation and open issues.
+    - [ ] Prototype tracing of a model using control flow.
+        - [ ] Evaluate limitations encountered.
+    - [ ] Summarize findings in documentation.
+        - [ ] Provide recommendations for future work.
 
 ### 12. Universal converter roadmap
 - [ ] Comprehensive layer mapping registry

--- a/neuronenblitztodo.md
+++ b/neuronenblitztodo.md
@@ -7,60 +7,150 @@ This document lists 100 concrete ideas for enhancing the `Neuronenblitz` algorit
 3. Integrate gradient-based path scoring to accelerate learning. (Completed with optional RMS gradient scoring)
 4. Employ soft actor-critic for reinforcement-driven wandering.
    - [ ] Implement actor and critic networks within wander policy.
+       - [ ] Define neural architectures for actor and critic.
+       - [ ] Integrate networks with wander policy update loop.
+       - [ ] Validate forward and backward passes on toy data.
    - [ ] Integrate entropy regularization into loss.
+       - [ ] Add entropy term to objective function.
+       - [ ] Tune regularization weight for stability.
+       - [ ] Document impact on exploration.
    - [ ] Add temperature parameter to config and docs.
+       - [ ] Introduce `sac.temperature` in configuration files.
+       - [ ] Explain parameter in YAML manual and tutorial.
    - [ ] Test wandering with SAC on small environment.
+       - [ ] Build minimal environment for SAC evaluation.
+       - [ ] Compare performance against baseline wanderer.
 5. Add memory-gated attention to modulate path selection.
    - [ ] Design gating mechanism using episodic memory cues.
+       - [ ] Specify features retrieved from episodic memory.
+       - [ ] Formulate gating equation blending memory and context.
    - [ ] Inject gating weights into attention calculations.
+       - [ ] Modify attention module to accept gate values.
+       - [ ] Ensure gradients propagate through gating path.
    - [ ] Expose gate strength hyperparameter in config.
+       - [ ] Add `memory.gate_strength` to configs and docs.
+       - [ ] Provide reasonable default and tuning guidance.
    - [ ] Validate with ablation studies.
+       - [ ] Run experiments with and without gating.
+       - [ ] Report effects on path diversity and accuracy.
 6. Use episodic memory to bias wandering toward past successes. (Completed with episodic replay bias)
 7. Apply meta-learning to adjust plasticity thresholds dynamically.
    - [ ] Record plasticity outcomes over recent steps.
+       - [ ] Log success metrics for each plasticity event.
+       - [ ] Maintain rolling history buffer.
    - [ ] Train meta-learner to propose threshold updates.
+       - [ ] Choose lightweight model for meta-learning.
+       - [ ] Fit model on recorded outcomes to predict new thresholds.
    - [ ] Add config options for meta-learning rate and window size.
+       - [ ] Introduce parameters `meta.rate` and `meta.window`.
+       - [ ] Document recommended ranges and defaults.
    - [ ] Add tests verifying threshold adapts.
+       - [ ] Simulate scenarios where thresholds should change.
+       - [ ] Assert meta-learner adjusts values accordingly.
 8. Integrate unsupervised contrastive losses into wander updates.
    - [ ] Generate positive and negative wander path pairs.
+       - [ ] Sample similar paths as positives and random paths as negatives.
+       - [ ] Cache pairs for reuse during training.
    - [ ] Compute contrastive loss (e.g., NT-Xent).
+       - [ ] Implement loss function leveraging cosine similarity.
+       - [ ] Normalize embeddings before comparison.
    - [ ] Combine loss with existing wander objectives.
+       - [ ] Weight contrastive term relative to primary loss.
+       - [ ] Provide config knob for contrastive weight.
    - [ ] Evaluate improvement on representation quality.
+       - [ ] Measure embedding clustering metrics.
+       - [ ] Compare against baseline without contrastive loss.
 9. Add hierarchical wandering to explore coarse-to-fine routes.
    - [ ] Implement high-level planner producing subgoals.
+       - [ ] Define planner interface and data structures.
+       - [ ] Generate subgoals based on current graph state.
    - [ ] Enable low-level wanderers for each subgoal.
+       - [ ] Spawn dedicated wanderers conditioned on subgoal.
+       - [ ] Merge results back into global context.
    - [ ] Track hierarchy in metrics and logs.
+       - [ ] Record subgoal transitions and outcomes.
+       - [ ] Visualize hierarchical progress over time.
    - [ ] Test on tasks requiring multi-stage reasoning.
+       - [ ] Create multi-step benchmark task.
+       - [ ] Compare to flat wandering baseline.
 10. Use graph attention networks for context-aware message passing.
-   - [ ] Integrate GAT layers into core message propagation.
-   - [ ] Allow optional use via configuration.
-   - [ ] Benchmark against baseline propagation.
-   - [ ] Add tests for attention weights.
+    - [ ] Integrate GAT layers into core message propagation.
+        - [ ] Implement graph attention layer compatible with existing tensors.
+        - [ ] Replace or augment current message passing modules.
+    - [ ] Allow optional use via configuration.
+        - [ ] Add flag to enable or disable GAT usage.
+        - [ ] Document performance considerations.
+    - [ ] Benchmark against baseline propagation.
+        - [ ] Measure throughput and accuracy differences.
+        - [ ] Report results in documentation.
+    - [ ] Add tests for attention weights.
+        - [ ] Check weight normalization per node.
+        - [ ] Validate gradient flow through attention coefficients.
 11. Optimize wandering via Monte Carlo tree search strategies.
-   - [ ] Implement tree node structure for wander states.
-   - [ ] Apply UCT formula to select expansions.
-   - [ ] Integrate with existing wander loop.
-   - [ ] Compare performance to random wandering.
+    - [ ] Implement tree node structure for wander states.
+        - [ ] Define node fields for state, visits, and rewards.
+        - [ ] Manage expansion and backpropagation steps.
+    - [ ] Apply UCT formula to select expansions.
+        - [ ] Implement selection policy using UCT.
+        - [ ] Tune exploration constant.
+    - [ ] Integrate with existing wander loop.
+        - [ ] Insert MCTS selection into wander cycle.
+        - [ ] Handle node recycling to limit memory.
+    - [ ] Compare performance to random wandering.
+        - [ ] Benchmark on standard tasks.
+        - [ ] Analyze improvement in discovery rate.
 12. Leverage curiosity-driven exploration for unseen regions.
-   - [ ] Define intrinsic reward based on prediction error.
-   - [ ] Add curiosity module producing exploration bonuses.
-   - [ ] Expose bonus weight in config.
-   - [ ] Measure coverage improvement.
+    - [ ] Define intrinsic reward based on prediction error.
+        - [ ] Compute error between predicted and actual activations.
+        - [ ] Normalize reward to avoid scale issues.
+    - [ ] Add curiosity module producing exploration bonuses.
+        - [ ] Implement module that outputs bonus per state.
+        - [ ] Integrate bonus into wander reward function.
+    - [ ] Expose bonus weight in config.
+        - [ ] Add `curiosity.weight` parameter with docs.
+        - [ ] Provide tuning examples.
+    - [ ] Measure coverage improvement.
+        - [ ] Track number of novel states visited.
+        - [ ] Compare exploration metrics with baseline.
 13. Implement evolutionary algorithms to evolve wander heuristics.
-   - [ ] Represent heuristic parameters as genome.
-   - [ ] Implement selection, crossover, mutation.
-   - [ ] Evaluate population over wander tasks.
-   - [ ] Persist best heuristics to disk.
+    - [ ] Represent heuristic parameters as genome.
+        - [ ] Encode parameters into fixed-length vector.
+        - [ ] Define decoding back to heuristic settings.
+    - [ ] Implement selection, crossover, mutation.
+        - [ ] Choose selection strategy (e.g., tournament).
+        - [ ] Implement crossover and mutation operators.
+    - [ ] Evaluate population over wander tasks.
+        - [ ] Run each genome on set of tasks to compute fitness.
+        - [ ] Parallelize evaluations when possible.
+    - [ ] Persist best heuristics to disk.
+        - [ ] Save genome and metadata for top performers.
+        - [ ] Provide loader to reuse saved heuristics.
 14. Incorporate self-supervised prediction tasks during wandering.
-   - [ ] Predict future neuron activations as auxiliary task.
-   - [ ] Backpropagate prediction loss alongside main objective.
-   - [ ] Configure prediction horizon.
-   - [ ] Test improvement in model accuracy.
+    - [ ] Predict future neuron activations as auxiliary task.
+        - [ ] Add module to forecast next-step activations.
+        - [ ] Select loss function for prediction error.
+    - [ ] Backpropagate prediction loss alongside main objective.
+        - [ ] Combine losses with weighting factor.
+        - [ ] Ensure gradients do not dominate main objective.
+    - [ ] Configure prediction horizon.
+        - [ ] Add parameter controlling steps ahead to predict.
+        - [ ] Document trade-offs between horizon and accuracy.
+    - [ ] Test improvement in model accuracy.
+        - [ ] Compare with baseline without auxiliary task.
+        - [ ] Report metrics showing benefit.
 15. Add dynamic gating of synapse updates based on activity levels.
-   - [ ] Track synapse activation statistics.
-   - [ ] Apply gating function to scale weight updates.
-   - [ ] Provide config parameter for gating sensitivity.
-   - [ ] Ensure gating mechanism works on CPU and GPU.
+    - [ ] Track synapse activation statistics.
+        - [ ] Maintain moving averages of activations per synapse.
+        - [ ] Store statistics efficiently for large networks.
+    - [ ] Apply gating function to scale weight updates.
+        - [ ] Define gating formula using activation stats.
+        - [ ] Integrate gating into weight update routine.
+    - [ ] Provide config parameter for gating sensitivity.
+        - [ ] Introduce `gating.sensitivity` parameter with docs.
+        - [ ] Offer guidance on tuning ranges.
+    - [ ] Ensure gating mechanism works on CPU and GPU.
+        - [ ] Implement device-agnostic operations.
+        - [ ] Add tests for both execution paths.
 16. Exploit recurrent state embeddings for sequential tasks.
    - [x] Research approaches for recurrent state embeddings for sequential tasks.
      - Recurrent state embeddings can be derived from techniques such as


### PR DESCRIPTION
## Summary
- Split remaining JAX backend tasks into granular actions and added detailed plan for parallel Neuronenblitz workers
- Expanded Neuronenblitz improvement roadmap with concrete steps for SAC, memory-gated attention, and more
- Refined converter roadmap with specific tasks for bidirectional recurrent layers, transformer blocks, dynamic examples, and dynamic graph support

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_688f9f7404288327ad514d40ab2038d9