### PR TITLE
Add deterministic parallel wanderer test

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1427,9 +1427,9 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
         - [x] Cover QuantizedTensor round-trip accuracy.
             - [x] Create quantized tensors with known values.
             - [x] Convert to float and back and assert equality.
-        - [ ] Ensure parallel wanderers yield consistent results.
-            - [ ] Set up small world simulation with multiple wanderers.
-            - [ ] Compare outputs and convergence metrics.
+        - [x] Ensure parallel wanderers yield consistent results.
+            - [x] Set up small world simulation with multiple wanderers.
+            - [x] Compare outputs and convergence metrics.
         - [ ] Test prompt cache operations under load.
             - [ ] Fill cache with synthetic prompts.
             - [ ] Measure latency and eviction behaviour.

--- a/tests/test_parallel_wander.py
+++ b/tests/test_parallel_wander.py
@@ -58,3 +58,25 @@ def test_parallel_average_applies_updates(monkeypatch):
     assert isinstance(out, float)
     assert isinstance(err, float)
     assert path
+
+
+def test_parallel_wander_consistency():
+    random.seed(0)
+    np.random.seed(0)
+    params_a = minimal_params()
+    params_a["plasticity_threshold"] = 0.0
+    core_a = Core(params_a)
+    nb_a = Neuronenblitz(core_a, parallel_wanderers=2, plasticity_threshold=0.0)
+    out_a, err_a, path_a = nb_a.train_example(0.5, 0.2)
+
+    random.seed(0)
+    np.random.seed(0)
+    params_b = minimal_params()
+    params_b["plasticity_threshold"] = 0.0
+    core_b = Core(params_b)
+    nb_b = Neuronenblitz(core_b, parallel_wanderers=2, plasticity_threshold=0.0)
+    out_b, err_b, path_b = nb_b.train_example(0.5, 0.2)
+
+    assert np.isclose(err_a, err_b)
+    assert np.isclose(out_a, out_b)
+    assert len(path_a) == len(path_b)


### PR DESCRIPTION
## Summary
- ensure parallel Neuronenblitz wanderers produce deterministic results with fixed seeds
- track TODO for parallel wanderer consistency as completed

## Testing
- `pytest tests/test_parallel_wander.py`

------
https://chatgpt.com/codex/tasks/task_e_688fd9ccd07c832784369d0d82a7abfb