### PR TITLE
Implement prompt memory cache with persistence

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1320,8 +1320,10 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 
 326. [ ] Create in-context learning prompt system.
     - [ ] Add `PromptMemory` to cache recent `(input, output)` pairs.
-        - [ ] Implement bounded queue with eviction policy.
-        - [ ] Provide serialization for stored pairs.
+        - [x] Define `PromptMemory` class skeleton.
+        - [x] Implement bounded queue with eviction policy.
+        - [x] Add methods for retrieval and composite prompt generation.
+        - [x] Provide serialization for stored pairs.
     - [ ] Modify inference to use `prompt + input` as composite query.
         - [ ] Concatenate prompts with new inputs before inference.
         - [ ] Handle empty or oversized prompt caches gracefully.
@@ -1330,9 +1332,9 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
         - [ ] Persist user preference between sessions.
     - [ ] Store prompts persistently with timestamps.
         - [ ] Save prompt memory to disk on shutdown.
-        - [ ] Include timestamps for chronological retrieval.
+        - [x] Include timestamps for chronological retrieval.
     - [ ] Write tests for prompt cache behavior.
-        - [ ] Verify FIFO eviction policy.
+        - [x] Verify FIFO eviction policy.
         - [ ] Test inference output when prompts are applied.
 
 327. [ ] Add YAML config editor in Streamlit.

--- a/prompt_memory.py
+++ b/prompt_memory.py
@@ -1,0 +1,63 @@
+import json
+from collections import deque
+from time import time
+from typing import Deque, Dict, List, Tuple
+
+
+class PromptMemory:
+    """Caches recent (input, output) pairs for in-context learning.
+
+    Parameters
+    ----------
+    max_size: int
+        Maximum number of pairs to keep. Oldest pairs are evicted first.
+    """
+
+    def __init__(self, max_size: int = 10):
+        self.max_size = max_size
+        self._data: Deque[Dict[str, str]] = deque(maxlen=max_size)
+
+    def add(self, inp: str, out: str) -> None:
+        """Add a new `(input, output)` pair to the memory."""
+        self._data.append({"input": inp, "output": out, "timestamp": time()})
+
+    def get_pairs(self) -> List[Tuple[str, str]]:
+        """Return stored `(input, output)` pairs ignoring timestamps."""
+        return [(item["input"], item["output"]) for item in list(self._data)]
+
+    def get_records(self) -> List[Dict[str, str]]:
+        """Return full records including timestamps."""
+        return list(self._data)
+
+    def get_prompt(self) -> str:
+        """Concatenate stored pairs into a prompt string."""
+        segments = []
+        for pair in self._data:
+            segments.append(f"Input: {pair['input']}\nOutput: {pair['output']}")
+        return "\n".join(segments)
+
+    def serialize(self, path: str) -> None:
+        """Save stored pairs to ``path`` in JSON format."""
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(list(self._data), f)
+
+    @classmethod
+    def load(cls, path: str, max_size: int = 10) -> "PromptMemory":
+        """Load stored pairs from ``path``.
+
+        Parameters
+        ----------
+        path: str
+            JSON file previously produced by :meth:`serialize`.
+        max_size: int
+            Maximum number of pairs to keep in the loaded memory.
+        """
+        memory = cls(max_size=max_size)
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data: List[Dict[str, str]] = json.load(f)
+            for pair in data[-max_size:]:
+                memory._data.append(pair)
+        except FileNotFoundError:
+            pass
+        return memory

--- a/tests/test_prompt_memory.py
+++ b/tests/test_prompt_memory.py
@@ -1,0 +1,34 @@
+import json
+from prompt_memory import PromptMemory
+
+
+def test_fifo_eviction(tmp_path):
+    memory = PromptMemory(max_size=2)
+    memory.add("in1", "out1")
+    memory.add("in2", "out2")
+    memory.add("in3", "out3")
+    assert memory.get_pairs() == [("in2", "out2"), ("in3", "out3")]
+
+
+def test_serialization_round_trip(tmp_path):
+    path = tmp_path / "mem.json"
+    memory = PromptMemory(max_size=3)
+    memory.add("a", "1")
+    memory.add("b", "2")
+    memory.serialize(path)
+    loaded = PromptMemory.load(path, max_size=3)
+    assert loaded.get_pairs() == [("a", "1"), ("b", "2")]
+
+
+def test_timestamps_persist(tmp_path):
+    path = tmp_path / "mem.json"
+    memory = PromptMemory(max_size=2)
+    memory.add("x", "1")
+    memory.add("y", "2")
+    records = memory.get_records()
+    assert records[0]["timestamp"] <= records[1]["timestamp"]
+    memory.serialize(path)
+    loaded = PromptMemory.load(path, max_size=2)
+    loaded_records = loaded.get_records()
+    assert [(r["input"], r["output"]) for r in loaded_records] == [("x", "1"), ("y", "2")]
+    assert "timestamp" in loaded_records[0]


### PR DESCRIPTION
## Summary
- build `PromptMemory` utility for caching recent input/output pairs with timestamped records
- persist prompt memories to JSON and reload them for chronological retrieval
- add comprehensive tests for FIFO eviction, serialization, and timestamp persistence
- expand TODO entry for the in-context prompt system with finer substeps

## Testing
- `pytest tests/test_prompt_memory.py::test_fifo_eviction -q`
- `pytest tests/test_prompt_memory.py::test_serialization_round_trip -q`
- `pytest tests/test_prompt_memory.py::test_timestamps_persist -q`


------
https://chatgpt.com/codex/tasks/task_e_688fdc50f50c8327b56a98e75d2e1c4d