### PR TITLE
Integrate prompt memory into inference

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1325,8 +1325,8 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
         - [x] Add methods for retrieval and composite prompt generation.
         - [x] Provide serialization for stored pairs.
     - [ ] Modify inference to use `prompt + input` as composite query.
-        - [ ] Concatenate prompts with new inputs before inference.
-        - [ ] Handle empty or oversized prompt caches gracefully.
+        - [x] Concatenate prompts with new inputs before inference.
+        - [x] Handle empty or oversized prompt caches gracefully.
     - [ ] Add GUI control for toggling prompt injection.
         - [ ] Create Streamlit toggle linked to inference pipeline.
         - [ ] Persist user preference between sessions.
@@ -1335,7 +1335,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
         - [x] Include timestamps for chronological retrieval.
     - [ ] Write tests for prompt cache behavior.
         - [x] Verify FIFO eviction policy.
-        - [ ] Test inference output when prompts are applied.
+        - [x] Test inference output when prompts are applied.
 
 327. [ ] Add YAML config editor in Streamlit.
     - [ ] Add new "Config Editor" tab using `st_ace` with YAML syntax.

--- a/tests/test_prompt_memory.py
+++ b/tests/test_prompt_memory.py
@@ -32,3 +32,16 @@ def test_timestamps_persist(tmp_path):
     loaded_records = loaded.get_records()
     assert [(r["input"], r["output"]) for r in loaded_records] == [("x", "1"), ("y", "2")]
     assert "timestamp" in loaded_records[0]
+
+
+def test_composite_with_handles_limits():
+    mem = PromptMemory(max_size=3)
+    mem.add("a", "1")
+    mem.add("b", "2")
+    composite = mem.composite_with("c", max_chars=50)
+    assert "Input: a" in composite and "Input: b" in composite and composite.endswith("Input: c")
+    # Create long strings to trigger truncation of oldest pair
+    mem.add("x" * 40, "y" * 40)
+    composite2 = mem.composite_with("end", max_chars=80)
+    assert "x" * 40 not in composite2  # oldest removed to fit size
+    assert composite2.endswith("end")


### PR DESCRIPTION
## Summary
- extend `PromptMemory` with `composite_with` to merge recent prompt/response pairs with new inputs while limiting length
- allow `InferenceServer` to accept text queries, compose them with optional `PromptMemory`, and record resulting pairs
- test prompt memory concatenation limits and web API prompt memory handling
- update TODO checklist for prompt memory inference integration

## Testing
- `pytest tests/test_prompt_memory.py`
- `pytest tests/test_web_api.py`


------
https://chatgpt.com/codex/tasks/task_e_688fde0c49ac8327b63a275089f4e06c