### PR TITLE
Add load test for PromptMemory and detail CUDA fallback tasks

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1432,13 +1432,19 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
         - [x] Ensure parallel wanderers yield consistent results.
             - [x] Set up small world simulation with multiple wanderers.
             - [x] Compare outputs and convergence metrics.
-        - [ ] Test prompt cache operations under load.
-            - [ ] Fill cache with synthetic prompts.
-            - [ ] Measure latency and eviction behaviour.
+        - [x] Test prompt cache operations under load.
+            - [x] Fill cache with synthetic prompts.
+            - [x] Measure latency and eviction behaviour.
     - [ ] Verify CUDA fallbacks for all new modules.
-        - [ ] Run tests forcing CPU execution.
-            - [ ] Set environment variable to disable CUDA.
-            - [ ] Execute each module's test suite.
+        - [ ] QuantizedTensor CPU path.
+            - [ ] Force CPU execution for quantized tensor tests.
+            - [ ] Confirm outputs match GPU path.
+        - [ ] Parallel wanderers CPU fallback.
+            - [ ] Disable CUDA and run wanderer tests.
+            - [ ] Document any discrepancies.
+        - [ ] PromptMemory CPU performance baseline.
+            - [ ] Run load tests with CUDA disabled.
+            - [ ] Compare timings with GPU-enabled runs.
         - [ ] Document any GPU-only limitations.
             - [ ] Record modules lacking CPU implementation.
             - [ ] Update README with limitation notes.

--- a/prompt_memory.py
+++ b/prompt_memory.py
@@ -17,6 +17,10 @@ class PromptMemory:
         self.max_size = max_size
         self._data: Deque[Dict[str, str]] = deque(maxlen=max_size)
 
+    def __len__(self) -> int:
+        """Return the number of stored records."""
+        return len(self._data)
+
     def add(self, inp: str, out: str) -> None:
         """Add a new `(input, output)` pair to the memory."""
         self._data.append({"input": inp, "output": out, "timestamp": time()})

--- a/tests/test_prompt_memory.py
+++ b/tests/test_prompt_memory.py
@@ -1,4 +1,5 @@
-import json
+import time
+
 from prompt_memory import PromptMemory
 
 
@@ -7,6 +8,7 @@ def test_fifo_eviction(tmp_path):
     memory.add("in1", "out1")
     memory.add("in2", "out2")
     memory.add("in3", "out3")
+    assert len(memory) == 2
     assert memory.get_pairs() == [("in2", "out2"), ("in3", "out3")]
 
 
@@ -30,7 +32,10 @@ def test_timestamps_persist(tmp_path):
     memory.serialize(path)
     loaded = PromptMemory.load(path, max_size=2)
     loaded_records = loaded.get_records()
-    assert [(r["input"], r["output"]) for r in loaded_records] == [("x", "1"), ("y", "2")]
+    assert [(r["input"], r["output"]) for r in loaded_records] == [
+        ("x", "1"),
+        ("y", "2"),
+    ]
     assert "timestamp" in loaded_records[0]
 
 
@@ -39,9 +44,34 @@ def test_composite_with_handles_limits():
     mem.add("a", "1")
     mem.add("b", "2")
     composite = mem.composite_with("c", max_chars=50)
-    assert "Input: a" in composite and "Input: b" in composite and composite.endswith("Input: c")
+    assert (
+        "Input: a" in composite
+        and "Input: b" in composite
+        and composite.endswith("Input: c")
+    )
     # Create long strings to trigger truncation of oldest pair
     mem.add("x" * 40, "y" * 40)
     composite2 = mem.composite_with("end", max_chars=80)
     assert "x" * 40 not in composite2  # oldest removed to fit size
     assert composite2.endswith("end")
+
+
+def test_load_latency_and_eviction():
+    mem = PromptMemory(max_size=1000)
+    start = time.time()
+    for i in range(5000):
+        mem.add(f"in{i}", f"out{i}")
+    elapsed = time.time() - start
+    avg_time = elapsed / 5000
+    # ensure average insertion time remains below 10ms
+    assert avg_time < 0.01
+    pairs = mem.get_pairs()
+    assert len(pairs) == 1000
+    assert pairs[0] == ("in4000", "out4000")
+    assert pairs[-1] == ("in4999", "out4999")
+    prompt_start = time.time()
+    prompt_text = mem.get_prompt()
+    prompt_elapsed = time.time() - prompt_start
+    # retrieving prompt should also remain fast
+    assert prompt_elapsed < 0.5
+    assert prompt_text.startswith("Input: in4000")


### PR DESCRIPTION
## Summary
- add __len__ to `PromptMemory` for quick record counts
- stress test `PromptMemory` under heavy load and measure latency/eviction
- break down CUDA fallback verification tasks in TODO roadmap

## Testing
- `pre-commit run --files prompt_memory.py tests/test_prompt_memory.py TODO.md`
- `pytest tests/test_prompt_memory.py`
- `pytest tests/test_web_api.py`


------
https://chatgpt.com/codex/tasks/task_e_689037e668488327b3302e698dc3f3e7