### PR TITLE
Add streaming BitTensorDataset step with async batching

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -536,14 +536,16 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
            enqueueing.  On CPU-only systems the tensors are yielded directly.  This
            uniform interface lets downstream steps simply call `.to(current_device)` to
            guarantee correct placement while minimising unnecessary copies.
-   - [ ] Implement Offer a specialised step that consumes the new streaming `BitTensorDataset` with CPU/GPU support.
-       - [ ] Create step class wrapping BitTensorDataset iterator.
-       - [ ] Implement asynchronous data fetching compatible with CPU and GPU tensors.
-       - [ ] Integrate step into pipeline execution engine.
-   - [ ] Add tests validating Offer a specialised step that consumes the new streaming `BitTensorDataset`.
-       - [ ] Unit test streaming step with synthetic dataset.
-       - [ ] Stress test behaviour under variable stream rates.
-       - [ ] Verify GPU execution matches CPU results.
+  - [ ] Implement Offer a specialised step that consumes the new streaming `BitTensorDataset` with CPU/GPU support.
+      - [x] Create step class wrapping BitTensorDataset iterator.
+      - [x] Implement asynchronous data fetching compatible with CPU and GPU tensors.
+      - [ ] Integrate step into pipeline execution engine.
+          - [ ] Expose factory function in `marble_interface`.
+          - [ ] Auto-consume streams in `Pipeline.execute`.
+  - [ ] Add tests validating Offer a specialised step that consumes the new streaming `BitTensorDataset`.
+      - [x] Unit test streaming step with synthetic dataset.
+      - [ ] Stress test behaviour under variable stream rates.
+      - [ ] Verify GPU execution matches CPU results.
    - [ ] Document Offer a specialised step that consumes the new streaming `BitTensorDataset` in README and TUTORIAL.
        - [ ] Explain configuration and usage in README.
        - [ ] Add tutorial section showing streaming dataset pipeline.

--- a/streaming_dataset_step.py
+++ b/streaming_dataset_step.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import torch
+
+from bit_tensor_dataset import BitTensorDataset
+
+
+class StreamingDatasetStep:
+    """Asynchronously yield batches from a :class:`BitTensorDataset`.
+
+    The step prefetches data batches in a background task using an
+    :class:`asyncio.Queue`. Each batch is moved to the requested device
+    (CPU or GPU) before being enqueued. Downstream consumers call
+    :meth:`next_batch` to obtain dictionaries containing ``"inputs"`` and
+    ``"targets"`` tensors. When the dataset is exhausted ``None`` is
+    returned and :meth:`is_finished` starts returning ``True``.
+
+    Parameters
+    ----------
+    dataset:
+        Source :class:`BitTensorDataset` to stream from.
+    batch_size:
+        Number of samples per batch.
+    prefetch:
+        Maximum number of prefetched batches awaiting consumption.
+    device:
+        Target device. ``None`` selects ``"cuda"`` when available otherwise
+        ``"cpu"``.
+    """
+
+    def __init__(
+        self,
+        dataset: BitTensorDataset,
+        *,
+        batch_size: int = 1,
+        prefetch: int = 2,
+        device: str | torch.device | None = None,
+    ) -> None:
+        self.dataset = dataset
+        self.batch_size = int(batch_size)
+        if self.batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        self.device = (
+            torch.device("cuda")
+            if device is None and torch.cuda.is_available()
+            else torch.device(device or "cpu")
+        )
+        self._queue: asyncio.Queue[dict[str, torch.Tensor] | None] = asyncio.Queue(
+            maxsize=prefetch
+        )
+        self._producer: asyncio.Task | None = None
+        self._finished = False
+
+    def _start(self) -> None:
+        if self._producer is None:
+            self._producer = asyncio.create_task(self._produce())
+
+    async def _produce(self) -> None:
+        try:
+            iterator = iter(self.dataset)
+            while True:
+                inputs: list[torch.Tensor] = []
+                targets: list[torch.Tensor] = []
+                try:
+                    for _ in range(self.batch_size):
+                        inp, tgt = next(iterator)
+                        if self.device.type != inp.device.type:
+                            inp = inp.to(self.device, non_blocking=True)
+                            tgt = tgt.to(self.device, non_blocking=True)
+                        inputs.append(inp)
+                        targets.append(tgt)
+                except StopIteration:
+                    if inputs:
+                        batch = {
+                            "inputs": torch.stack(inputs),
+                            "targets": torch.stack(targets),
+                        }
+                        await self._queue.put(batch)
+                    break
+                batch = {
+                    "inputs": torch.stack(inputs),
+                    "targets": torch.stack(targets),
+                }
+                await self._queue.put(batch)
+        finally:
+            self._finished = True
+            await self._queue.put(None)
+
+    async def next_batch(self) -> dict[str, torch.Tensor] | None:
+        """Return next batch as a dictionary or ``None`` when done."""
+
+        self._start()
+        batch = await self._queue.get()
+        self._queue.task_done()
+        return batch
+
+    def is_finished(self) -> bool:
+        """Return ``True`` when all data has been consumed."""
+
+        return self._finished and self._queue.empty()
+
+    async def __aiter__(self) -> AsyncIterator[dict[str, torch.Tensor]]:
+        while True:
+            batch = await self.next_batch()
+            if batch is None:
+                break
+            yield batch
+
+    def close(self) -> None:
+        """Cancel background producer if still running."""
+
+        if self._producer is not None:
+            self._producer.cancel()
+            self._producer = None

--- a/tests/test_streaming_dataset_step.py
+++ b/tests/test_streaming_dataset_step.py
@@ -1,0 +1,32 @@
+import asyncio
+
+import torch
+
+from bit_tensor_dataset import BitTensorDataset
+from streaming_dataset_step import StreamingDatasetStep
+
+
+def _consume(step: StreamingDatasetStep):
+    async def _run():
+        batches = []
+        while True:
+            batch = await step.next_batch()
+            if batch is None:
+                break
+            batches.append(batch)
+        return batches
+
+    return asyncio.run(_run())
+
+
+def test_streaming_dataset_step_cpu():
+    ds = BitTensorDataset([(i, i) for i in range(5)], device="cpu")
+    step = StreamingDatasetStep(ds, batch_size=2, prefetch=2, device="cpu")
+    batches = _consume(step)
+    inputs = torch.cat([b["inputs"] for b in batches])
+    targets = torch.cat([b["targets"] for b in batches])
+    decoded_inp = [ds.tensor_to_object(t) for t in inputs]
+    decoded_tgt = [ds.tensor_to_object(t) for t in targets]
+    assert decoded_inp == list(range(5))
+    assert decoded_tgt == list(range(5))
+    assert step.is_finished()


### PR DESCRIPTION
## Summary
- implement `StreamingDatasetStep` class that asynchronously queues dataset batches and moves them to CPU/GPU as needed
- cover streaming step with a unit test verifying ordered batch emission and completion signals
- update TODO to reflect completed substeps and outline integration tasks

## Testing
- `pytest tests/test_streaming_dataset_step.py`


------
https://chatgpt.com/codex/tasks/task_e_68903c4d478483278e953a4646bfa809