### PR TITLE
Integrate streaming dataset step

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -539,13 +539,13 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
   - [ ] Implement Offer a specialised step that consumes the new streaming `BitTensorDataset` with CPU/GPU support.
       - [x] Create step class wrapping BitTensorDataset iterator.
       - [x] Implement asynchronous data fetching compatible with CPU and GPU tensors.
-      - [ ] Integrate step into pipeline execution engine.
-          - [ ] Expose factory function in `marble_interface`.
-          - [ ] Auto-consume streams in `Pipeline.execute`.
+      - [x] Integrate step into pipeline execution engine.
+          - [x] Expose factory function in `marble_interface`.
+          - [x] Auto-consume streams in `Pipeline.execute`.
   - [ ] Add tests validating Offer a specialised step that consumes the new streaming `BitTensorDataset`.
       - [x] Unit test streaming step with synthetic dataset.
-      - [ ] Stress test behaviour under variable stream rates.
-      - [ ] Verify GPU execution matches CPU results.
+      - [x] Stress test behaviour under variable stream rates.
+      - [x] Verify GPU execution matches CPU results.
    - [ ] Document Offer a specialised step that consumes the new streaming `BitTensorDataset` in README and TUTORIAL.
        - [ ] Explain configuration and usage in README.
        - [ ] Add tutorial section showing streaming dataset pipeline.

--- a/marble_interface.py
+++ b/marble_interface.py
@@ -11,6 +11,8 @@ import pandas as pd
 import torch
 from datasets import load_dataset
 
+from bit_tensor_dataset import BitTensorDataset
+from streaming_dataset_step import StreamingDatasetStep
 from huggingface_utils import hf_login
 from marble import DataLoader
 
@@ -312,6 +314,32 @@ def load_hf_dataset(
         if limit is not None and len(examples) >= limit:
             break
     return examples
+
+
+def streaming_dataset_step(
+    dataset: BitTensorDataset,
+    *,
+    batch_size: int = 1,
+    prefetch: int = 2,
+    device: str | torch.device | None = None,
+) -> StreamingDatasetStep:
+    """Return a :class:`StreamingDatasetStep` consuming ``dataset``.
+
+    Parameters
+    ----------
+    dataset:
+        Source :class:`BitTensorDataset` to stream.
+    batch_size:
+        Number of samples per emitted batch.
+    prefetch:
+        Maximum number of prefetched batches in the internal queue.
+    device:
+        Target device. ``None`` selects ``"cuda"`` when available otherwise ``"cpu"``.
+    """
+
+    return StreamingDatasetStep(
+        dataset, batch_size=batch_size, prefetch=prefetch, device=device
+    )
 
 
 def train_from_dataframe(marble: MARBLE, df: pd.DataFrame, epochs: int = 1) -> None:

--- a/tests/test_streaming_dataset_step.py
+++ b/tests/test_streaming_dataset_step.py
@@ -1,9 +1,13 @@
 import asyncio
+import time
 
+import pytest
 import torch
 
 from bit_tensor_dataset import BitTensorDataset
 from streaming_dataset_step import StreamingDatasetStep
+from pipeline import Pipeline
+import marble_interface
 
 
 def _consume(step: StreamingDatasetStep):
@@ -30,3 +34,64 @@ def test_streaming_dataset_step_cpu():
     assert decoded_inp == list(range(5))
     assert decoded_tgt == list(range(5))
     assert step.is_finished()
+
+
+def test_streaming_dataset_step_variable_rates():
+    ds = BitTensorDataset([(i, i) for i in range(20)], device="cpu")
+
+    class SlowDataset:
+        def __init__(self, base):
+            self.base = base
+
+        def __iter__(self):
+            for idx, pair in enumerate(iter(self.base)):
+                time.sleep(0.001 * (idx % 3))
+                yield pair
+
+    step = StreamingDatasetStep(SlowDataset(ds), batch_size=3, prefetch=2, device="cpu")
+
+    async def _run():
+        batches = []
+        while True:
+            batch = await step.next_batch()
+            if batch is None:
+                break
+            await asyncio.sleep(0.001 * (len(batches) % 2))
+            batches.append(batch)
+        return batches
+
+    batches = asyncio.run(_run())
+    inputs = torch.cat([b["inputs"] for b in batches])
+    decoded = [ds.tensor_to_object(t) for t in inputs]
+    assert decoded == list(range(20))
+    assert step.is_finished()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="cuda not available")
+def test_streaming_dataset_step_gpu():
+    ds = BitTensorDataset([(i, i) for i in range(5)], device="cpu")
+    cpu_step = StreamingDatasetStep(ds, batch_size=2, prefetch=2, device="cpu")
+    gpu_step = StreamingDatasetStep(ds, batch_size=2, prefetch=2, device="cuda")
+    cpu_batches = _consume(cpu_step)
+    gpu_batches = _consume(gpu_step)
+    cpu_inputs = torch.cat([b["inputs"] for b in cpu_batches])
+    gpu_inputs = torch.cat([b["inputs"] for b in gpu_batches]).to("cpu")
+    assert torch.equal(cpu_inputs, gpu_inputs)
+    decoded = [ds.tensor_to_object(t) for t in gpu_inputs]
+    assert decoded == list(range(5))
+
+
+def test_pipeline_auto_consumes_streaming_step():
+    ds = BitTensorDataset([(i, i) for i in range(4)], device="cpu")
+    pipe = Pipeline([
+        {
+            "func": "streaming_dataset_step",
+            "module": "marble_interface",
+            "params": {"dataset": ds, "batch_size": 2, "prefetch": 2, "device": "cpu"},
+        }
+    ])
+    result = pipe.execute()
+    batches = result[0]
+    inputs = torch.cat([b["inputs"] for b in batches])
+    decoded = [ds.tensor_to_object(t) for t in inputs]
+    assert decoded == list(range(4))


### PR DESCRIPTION
## Summary
- expose `streaming_dataset_step` factory in marble_interface
- auto-drain streaming steps in Pipeline.execute via asyncio
- add stress, GPU parity and pipeline integration tests for streaming dataset step

## Testing
- `pytest tests/test_streaming_dataset_step.py`
- `pytest tests/test_pipeline_class.py`
- `pytest tests/test_pipeline_summary.py`
- `pytest tests/test_prefetch_integration.py`
- `pytest tests/test_pipeline_utils.py`
- `pytest tests/test_marble_interface.py`


------
https://chatgpt.com/codex/tasks/task_e_68904872ef1483278c409f4f00c188ed