### PR TITLE
Add CLI for checkpointing and resuming HighLevelPipeline

### DIFF
--- a/HIGHLEVEL_PIPELINE_TUTORIAL.md
+++ b/HIGHLEVEL_PIPELINE_TUTORIAL.md
@@ -391,3 +391,20 @@ PY
 
 These examples provide starting points for building your own workflows with
 `HighLevelPipeline`. Adjust epochs, learning rates and parameters as needed.
+
+## Saving and Resuming Pipelines
+
+Long running experiments can be checkpointed and later resumed without
+rebuilding the entire workflow. The `highlevel_pipeline_cli.py` script
+provides two commands:
+
+```bash
+# Execute pipeline JSON and create a checkpoint
+python highlevel_pipeline_cli.py checkpoint pipeline.json pipeline.chk --config config.yaml --device cpu
+
+# Resume from a saved checkpoint
+python highlevel_pipeline_cli.py resume pipeline.chk --config config.yaml --device cpu
+```
+
+Checkpoints store the pipeline steps and the `dataset_version` metadata so
+repeated runs continue with the exact same dataset revision.

--- a/highlevel_pipeline_cli.py
+++ b/highlevel_pipeline_cli.py
@@ -1,0 +1,66 @@
+import argparse
+import torch
+from config_loader import create_marble_from_config
+from highlevel_pipeline import HighLevelPipeline
+
+
+def _select_device(name: str) -> str:
+    if name == "gpu":
+        if torch.cuda.is_available():
+            return "cuda"
+        raise RuntimeError("GPU requested but CUDA is not available")
+    return "cpu"
+
+
+def _apply_device(pipeline: HighLevelPipeline, device: str) -> None:
+    # override device for datasets created during execution
+    pipeline.bit_dataset_params["device"] = device
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Utilities for HighLevelPipeline checkpoints"
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    chk = sub.add_parser(
+        "checkpoint", help="Execute pipeline and save a checkpoint afterwards"
+    )
+    chk.add_argument("pipeline", help="Path to pipeline JSON file")
+    chk.add_argument("checkpoint", help="Output checkpoint file")
+    chk.add_argument("--config", required=True, help="Path to MARBLE config YAML")
+    chk.add_argument(
+        "--device", choices=["cpu", "gpu"], default="cpu", help="Device to run on"
+    )
+    chk.add_argument(
+        "--dataset-version",
+        help="Optional dataset version metadata to store in the checkpoint",
+    )
+
+    res = sub.add_parser("resume", help="Resume pipeline from a checkpoint")
+    res.add_argument("checkpoint", help="Path to checkpoint file")
+    res.add_argument("--config", required=True, help="Path to MARBLE config YAML")
+    res.add_argument(
+        "--device", choices=["cpu", "gpu"], default="cpu", help="Device to run on"
+    )
+
+    args = parser.parse_args()
+    device = _select_device(args.device)
+    marble = create_marble_from_config(args.config)
+
+    if args.command == "checkpoint":
+        with open(args.pipeline, "r", encoding="utf-8") as f:
+            pipe = HighLevelPipeline.load_json(f)
+        if args.dataset_version:
+            pipe.dataset_version = args.dataset_version
+        _apply_device(pipe, device)
+        pipe.execute(marble)
+        pipe.save_checkpoint(args.checkpoint)
+    else:  # resume
+        pipe = HighLevelPipeline.load_checkpoint(args.checkpoint)
+        _apply_device(pipe, device)
+        pipe.execute(marble)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_highlevel_pipeline_cli.py
+++ b/tests/test_highlevel_pipeline_cli.py
@@ -1,0 +1,47 @@
+import subprocess
+import sys
+from highlevel_pipeline import HighLevelPipeline
+
+
+def test_cli_checkpoint_and_resume(tmp_path):
+    pipe = HighLevelPipeline(dataset_version="v42")
+    json_path = tmp_path / "pipe.json"
+    with open(json_path, "w", encoding="utf-8") as f:
+        f.write(pipe.to_json())
+    ckpt_path = tmp_path / "pipe.pkl"
+
+    subprocess.run(
+        [
+            sys.executable,
+            "highlevel_pipeline_cli.py",
+            "checkpoint",
+            str(json_path),
+            str(ckpt_path),
+            "--config",
+            "config.yaml",
+            "--dataset-version",
+            "v42",
+            "--device",
+            "cpu",
+        ],
+        check=True,
+    )
+
+    assert ckpt_path.exists()
+
+    subprocess.run(
+        [
+            sys.executable,
+            "highlevel_pipeline_cli.py",
+            "resume",
+            str(ckpt_path),
+            "--config",
+            "config.yaml",
+            "--device",
+            "cpu",
+        ],
+        check=True,
+    )
+
+    loaded = HighLevelPipeline.load_checkpoint(str(ckpt_path))
+    assert loaded.dataset_version == "v42"


### PR DESCRIPTION
## Summary
- add `highlevel_pipeline_cli.py` with `checkpoint` and `resume` commands
- document saving and resuming workflows in HighLevelPipeline tutorial
- test CLI checkpoint/resume flow including dataset version persistence

## Testing
- `pytest tests/test_highlevel_pipeline_checkpoint.py`
- `pytest tests/test_highlevel_pipeline_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68904d08de8c8327bd15ea939142e35a