### PR TITLE
feat(gui): add pipeline step visualisation

### DIFF
--- a/streamlit_playground.py
+++ b/streamlit_playground.py
@@ -38,6 +38,7 @@ import streamlit as st
 import streamlit.components.v1 as components
 import torch
 import yaml
+from bit_tensor_dataset import BitTensorDataset
 from PIL import Image
 
 from huggingface_utils import (
@@ -2158,8 +2159,20 @@ def run_playground() -> None:
                 st.plotly_chart(fig, use_container_width=True)
             with st.expander("Step Visualisation"):
                 for i, step in enumerate(st.session_state["pipeline"]):
-                    st.markdown(f"**Step {i+1}:**")
-                    st.json(step)
+                    module = step.get("module") or "marble_interface"
+                    st.markdown(
+                        f"**Step {i+1}:** `{module}.{step['func']}`"
+                    )
+                    params = step.get("params", {})
+                    if params:
+                        st.write("Parameters:")
+                        st.json(params)
+                        for name, value in params.items():
+                            if isinstance(value, BitTensorDataset):
+                                st.write(f"Dataset `{name}` summary:")
+                                st.json(value.summary())
+                    else:
+                        st.write("Parameters: none")
             if st.button("Run Pipeline") and st.session_state["pipeline"]:
                 res = execute_function_sequence(st.session_state["pipeline"], marble)
                 for out in res:

--- a/tests/test_streamlit_gui.py
+++ b/tests/test_streamlit_gui.py
@@ -475,8 +475,15 @@ def test_pipeline_tab_graph_and_clear():
 def test_pipeline_step_visualisation():
     at = _setup_advanced_playground()
     pipe_tab = next(t for t in at.tabs if t.label == "Pipeline")
-    expanders = [e.label for e in pipe_tab.expander]
-    assert "Step Visualisation" in expanders
+
+    add_expander = pipe_tab.expander[1]
+    add_expander.selectbox[0].set_value("increase_marble_representation")
+    add_expander.number_input[0].set_value(2)
+    at = add_expander.button[0].click().run(timeout=20)
+    pipe_tab = next(t for t in at.tabs if t.label == "Pipeline")
+
+    vis_exp = next(e for e in pipe_tab.expander if e.label == "Step Visualisation")
+    assert any("delta" in j.value for j in vis_exp.json)
 
 
 def test_lobe_manager_actions():


### PR DESCRIPTION
## Summary
- show pipeline step parameters and dataset summaries in Streamlit GUI
- test pipeline tab renders step visualisation with parameters

## Testing
- `pytest tests/test_streamlit_gui.py -q`
- `pytest tests/test_streamlit_playground.py -q`
- `pytest tests/test_streamlit_all_buttons.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68904fde663883278be9e66d20d13932