### PR TITLE
Add pipeline step plugin architecture

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -368,25 +368,25 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
         - [ ] Test export features on desktop layout.
         - [ ] Test export features on mobile layout.
         - [ ] Assert metric panels render correctly in both views.
-171. [ ] Offer a plugin system so users can register custom pipeline steps easily.
-   - [ ] Draft plugin interface and lifecycle expectations.
-       - [ ] Outline core lifecycle phases (initialise, execute, teardown).
-       - [ ] Specify required methods and expected inputs/outputs.
-   - [ ] Implement registry and dynamic loader for third-party plugins.
-       - [ ] Create registry mapping identifiers to plugin classes.
-       - [ ] Implement loader scanning entry points or directories.
-   - [ ] Support CPU and GPU execution contexts within plugins.
-       - [ ] Detect available device and select execution target.
-       - [ ] Route tensors and operations to the appropriate device.
-   - [ ] Ship an example plugin demonstrating registration and usage.
-       - [ ] Build minimal plugin exercising the interface.
-       - [ ] Provide instructions to register and invoke the sample.
-   - [ ] Add unit and integration tests for plugin discovery and execution.
-       - [ ] Test registry registration and lookup behaviour.
-       - [ ] Execute example plugin on CPU and GPU to verify paths.
-   - [ ] Document plugin architecture and example workflow in README and TUTORIAL.
-       - [ ] Add architecture overview section to README.
-       - [ ] Extend tutorial with step-by-step plugin creation guide.
+171. [x] Offer a plugin system so users can register custom pipeline steps easily.
+   - [x] Draft plugin interface and lifecycle expectations.
+       - [x] Outline core lifecycle phases (initialise, execute, teardown).
+       - [x] Specify required methods and expected inputs/outputs.
+   - [x] Implement registry and dynamic loader for third-party plugins.
+       - [x] Create registry mapping identifiers to plugin classes.
+       - [x] Implement loader scanning entry points or directories.
+   - [x] Support CPU and GPU execution contexts within plugins.
+       - [x] Detect available device and select execution target.
+       - [x] Route tensors and operations to the appropriate device.
+   - [x] Ship an example plugin demonstrating registration and usage.
+       - [x] Build minimal plugin exercising the interface.
+       - [x] Provide instructions to register and invoke the sample.
+   - [x] Add unit and integration tests for plugin discovery and execution.
+       - [x] Test registry registration and lookup behaviour.
+       - [x] Execute example plugin on CPU and GPU to verify paths.
+   - [x] Document plugin architecture and example workflow in README and TUTORIAL.
+       - [x] Add architecture overview section to README.
+       - [x] Extend tutorial with step-by-step plugin creation guide.
 172. [ ] Manage dependencies between steps automatically to maintain correct order.
    - [ ] Design dependency graph representation for pipeline steps.
        - [ ] Choose data structure to model nodes and edges.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1835,6 +1835,50 @@ The new *Global Workspace* plugin is loaded in the same way. Add
 `n_plugin.activate("global_workspace")` to share broadcast messages between
 plugins and components.
 
+### Project 31 – Pipeline Step Plugin
+
+**Goal:** Create a custom pipeline step using the plugin architecture.
+
+1. **Write the plugin class** in ``plugins/double_step.py``:
+   ```python
+   from pipeline_plugins import PipelinePlugin, register_plugin
+   import torch
+
+   class DoubleStep(PipelinePlugin):
+       def __init__(self, factor: float = 2.0):
+           self.factor = factor
+
+       def initialise(self, device, marble=None):
+           self.device = device
+
+       def execute(self, device, marble=None):
+           return torch.ones(1, device=device) * self.factor
+
+       def teardown(self):
+           pass
+
+   def register(reg):
+       reg("double_step", DoubleStep)
+   ```
+2. **Load the plugin** before running a pipeline:
+   ```python
+   from pipeline_plugins import load_pipeline_plugins
+
+   load_pipeline_plugins("plugins")
+   ```
+3. **Add a pipeline step** referencing the plugin:
+   ```python
+   from pipeline import Pipeline
+
+   pipe = Pipeline([
+       {"plugin": "double_step", "params": {"factor": 4}}
+   ])
+   print(pipe.execute()[0])  # tensor([4.])
+   ```
+4. **GPU support** is automatic.  If CUDA is available the ``device`` passed to
+   ``initialise`` and ``execute`` will be ``"cuda"``; otherwise it defaults to
+   ``"cpu"``.
+
 ### Using Attention Codelets
 
 1. Define a codelet that returns an ``AttentionProposal``:

--- a/examples/plugins/double_step.py
+++ b/examples/plugins/double_step.py
@@ -1,0 +1,30 @@
+"""Example pipeline plugin that scales a tensor by a constant factor."""
+
+from __future__ import annotations
+
+import torch
+
+from pipeline_plugins import PipelinePlugin, register_plugin
+
+
+class DoubleStep(PipelinePlugin):
+    """Multiply a tensor of ones by ``factor`` on the selected device."""
+
+    def __init__(self, factor: float = 2.0) -> None:
+        super().__init__(factor=factor)
+        self.factor = factor
+        self.device: torch.device | None = None
+
+    def initialise(self, device: torch.device, marble=None) -> None:
+        self.device = device
+
+    def execute(self, device: torch.device, marble=None):
+        tensor = torch.ones(1, device=device)
+        return tensor * self.factor
+
+    def teardown(self) -> None:
+        self.device = None
+
+
+def register(register_func) -> None:
+    register_func("double_step", DoubleStep)

--- a/tests/test_pipeline_step_plugin.py
+++ b/tests/test_pipeline_step_plugin.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import torch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from pipeline import Pipeline
+from pipeline_plugins import PLUGIN_REGISTRY, load_pipeline_plugins
+
+
+def test_registry_and_lookup(tmp_path):
+    plugin_code = (
+        "from pipeline_plugins import PipelinePlugin, register_plugin\n"
+        "import torch\n"
+        "class TmpPlugin(PipelinePlugin):\n"
+        "    def initialise(self, device, marble=None):\n        \tself.device = device\n"
+        "    def execute(self, device, marble=None):\n        \treturn torch.ones(1, device=device)\n"
+        "    def teardown(self):\n        \tpass\n"
+        "def register(reg):\n    \treg('tmp', TmpPlugin)\n"
+    )
+    plugin_file = tmp_path / "tmp_plugin.py"
+    plugin_file.write_text(plugin_code)
+    load_pipeline_plugins([str(tmp_path)])
+    assert "tmp" in PLUGIN_REGISTRY
+
+
+def test_pipeline_plugin_execution(tmp_path):
+    plugin_code = (
+        "from pipeline_plugins import PipelinePlugin, register_plugin\n"
+        "import torch\n"
+        "class P(PipelinePlugin):\n"
+        "    def __init__(self, factor=2):\n        \tself.factor = factor\n"
+        "    def initialise(self, device, marble=None):\n        \tself.device = device\n"
+        "    def execute(self, device, marble=None):\n        \treturn torch.ones(1, device=device) * self.factor\n"
+        "    def teardown(self):\n        \tpass\n"
+        "def register(reg):\n    \treg('mult', P)\n"
+    )
+    plugin_file = tmp_path / "mult_plugin.py"
+    plugin_file.write_text(plugin_code)
+    load_pipeline_plugins([str(tmp_path)])
+
+    pipe = Pipeline([{ "plugin": "mult", "params": {"factor": 3}}])
+    result = pipe.execute()[0]
+    assert torch.allclose(result, torch.tensor([3.], device=result.device))
+    assert result.device.type in {"cpu", "cuda"}


### PR DESCRIPTION
## Summary
- implement extensible pipeline step plugin framework with lifecycle hooks and CPU/GPU routing
- integrate plugin execution into Pipeline and provide example DoubleStep plugin
- document plugin architecture and creation tutorial, update TODO and tests

## Testing
- `pytest tests/test_pipeline_step_plugin.py -q`
- `pytest tests/test_pipeline_class.py -q`
- `pytest tests/test_plugin_system.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689059125b588327842f149949419130