### PR TITLE
Add pipeline step dependency resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,24 @@ registered with ``HighLevelPipeline.register_data_args`` to support custom
 features. Arbitrary steps from any module may be chained without limitation,
 allowing any number or combination of MARBLE features and options to be expressed
 through a single ``HighLevelPipeline`` instance.
+### Step dependencies
+
+Steps may include a unique ``name`` and a list of dependencies in
+``depends_on``. MARBLE constructs a directed graph and orders steps with a
+topological sort. Cycles raise a ``ValueError`` describing the loop.
+
+```python
+from pipeline import Pipeline
+
+p = Pipeline()
+p.add_step("prepare_data", module="marble_interface", name="prep")
+p.add_step("train_model", module="marble_interface", name="train", depends_on=["prep"])
+p.execute()
+```
+
+Here ``train_model`` runs after ``prepare_data`` regardless of insertion
+order. Unknown-step errors typically indicate a misspelled dependency or
+missing ``name``.
 Multiple MARBLE systems can be created in one session. Use the *Active Instance*
 selector in the sidebar to switch between them, duplicate a system for
 comparison or delete instances you no longer need.

--- a/TODO.md
+++ b/TODO.md
@@ -387,22 +387,22 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [x] Document plugin architecture and example workflow in README and TUTORIAL.
        - [x] Add architecture overview section to README.
        - [x] Extend tutorial with step-by-step plugin creation guide.
-172. [ ] Manage dependencies between steps automatically to maintain correct order.
-   - [ ] Design dependency graph representation for pipeline steps.
-       - [ ] Choose data structure to model nodes and edges.
-       - [ ] Document semantics of dependencies and allowed patterns.
-   - [ ] Implement topological sorting with cycle detection and clear errors.
-       - [ ] Implement sorting algorithm with cycle checks.
-       - [ ] Raise descriptive error messages when cycles are found.
-   - [ ] Ensure resolved ordering executes correctly on CPU and GPU.
-       - [ ] Run sample pipelines on CPU and validate outputs.
-       - [ ] Run sample pipelines on GPU to confirm parity.
-   - [ ] Add unit and integration tests for dependency management.
-       - [ ] Test graph construction and sorting logic in isolation.
-       - [ ] Create integration tests covering complex dependency chains.
-   - [ ] Document dependency configuration and troubleshooting in README and TUTORIAL.
-       - [ ] Provide examples of declaring step dependencies.
-       - [ ] Include troubleshooting tips for cycle and ordering issues.
+172. [x] Manage dependencies between steps automatically to maintain correct order.
+   - [x] Design dependency graph representation for pipeline steps.
+       - [x] Choose data structure to model nodes and edges.
+       - [x] Document semantics of dependencies and allowed patterns.
+   - [x] Implement topological sorting with cycle detection and clear errors.
+       - [x] Implement sorting algorithm with cycle checks.
+       - [x] Raise descriptive error messages when cycles are found.
+   - [x] Ensure resolved ordering executes correctly on CPU and GPU.
+       - [x] Run sample pipelines on CPU and validate outputs.
+       - [x] Run sample pipelines on GPU to confirm parity.
+   - [x] Add unit and integration tests for dependency management.
+       - [x] Test graph construction and sorting logic in isolation.
+       - [x] Create integration tests covering complex dependency chains.
+   - [x] Document dependency configuration and troubleshooting in README and TUTORIAL.
+       - [x] Provide examples of declaring step dependencies.
+       - [x] Include troubleshooting tips for cycle and ordering issues.
 173. [ ] Allow branching paths in a pipeline to explore alternative experiment flows.
    - [ ] Design branch step abstraction and merge semantics.
        - [ ] Define API for creating branch and merge nodes.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1726,13 +1726,31 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
    needed. Custom callables may be added as steps and any MARBLE instance returned
    (even inside tuples or dictionaries) becomes the active system for the
    following operations.
-   - Set ``pipeline.async_enabled: true`` in ``config.yaml`` or pass
-     ``async_enabled=True`` to ``HighLevelPipeline`` to overlap data loading and
-     computation using ``asyncio``.
-   - Provide ``pipeline.cache_dir`` to enable on-disk caching of step outputs.
-     The metrics dashboard tracks ``cache_hit`` and ``cache_miss`` so you can
-     verify reuse. Clear the cache with ``HighLevelPipeline.clear_cache()`` when
-     disk space runs low.
+    - Set ``pipeline.async_enabled: true`` in ``config.yaml`` or pass
+      ``async_enabled=True`` to ``HighLevelPipeline`` to overlap data loading and
+      computation using ``asyncio``.
+    - Provide ``pipeline.cache_dir`` to enable on-disk caching of step outputs.
+      The metrics dashboard tracks ``cache_hit`` and ``cache_miss`` so you can
+      verify reuse. Clear the cache with ``HighLevelPipeline.clear_cache()`` when
+      disk space runs low.
+    - Assign each step a unique ``name`` and declare prerequisites with
+      ``depends_on``. MARBLE resolves the ordering automatically using a
+      topological sort. Cycles produce a ``ValueError`` describing the loop.
+
+      ```python
+      from pipeline import Pipeline
+
+      pipe = Pipeline()
+      pipe.add_step("load_data", module="marble_interface", name="load")
+      pipe.add_step("train", module="marble_interface", name="train", depends_on=["load"])
+      pipe.execute()
+      ```
+
+      Troubleshooting:
+
+      - ``Dependency cycle detected`` indicates a loop in the graph.
+      - ``depends on unknown step`` means a dependency name was misspelled or
+        the referenced step lacks a ``name``.
 12. **View the core graph** on the *Visualization* tab. Press **Generate Graph**
    to see an interactive display of neurons and synapses.
 13. **Inspect synaptic weights** on the *Weight Heatmap* tab. Set a maximum

--- a/tests/dependency_steps.py
+++ b/tests/dependency_steps.py
@@ -1,0 +1,13 @@
+import torch
+
+
+def step_a(device: str = "cpu"):
+    return ("a", device, torch.tensor(1, device=device))
+
+
+def step_b(device: str = "cpu"):
+    return ("b", device, torch.tensor(2, device=device))
+
+
+def step_c(device: str = "cpu"):
+    return ("c", device, torch.tensor(3, device=device))

--- a/tests/test_dependency_graph.py
+++ b/tests/test_dependency_graph.py
@@ -1,0 +1,31 @@
+import pytest
+
+from pipeline import Pipeline
+
+
+def test_topological_sort_orders_steps():
+    p = Pipeline()
+    steps = [
+        {"name": "c", "depends_on": ["b"]},
+        {"name": "a"},
+        {"name": "b", "depends_on": ["a"]},
+    ]
+    ordered = p._topological_sort(steps)
+    assert [s["name"] for s in ordered] == ["a", "b", "c"]
+
+
+def test_cycle_detection_raises_error():
+    p = Pipeline()
+    steps = [
+        {"name": "a", "depends_on": ["b"]},
+        {"name": "b", "depends_on": ["a"]},
+    ]
+    with pytest.raises(ValueError, match="cycle"):
+        p._topological_sort(steps)
+
+
+def test_unknown_dependency_error():
+    p = Pipeline()
+    steps = [{"name": "a", "depends_on": ["missing"]}]
+    with pytest.raises(ValueError, match="unknown step"):
+        p._topological_sort(steps)

--- a/tests/test_pipeline_dependency_integration.py
+++ b/tests/test_pipeline_dependency_integration.py
@@ -1,0 +1,36 @@
+import pytest
+import torch
+
+from pipeline import Pipeline
+
+
+def test_pipeline_executes_in_dependency_order_cpu():
+    p = Pipeline()
+    p.add_step("step_c", module="tests.dependency_steps", name="c", depends_on=["b"])
+    p.add_step("step_a", module="tests.dependency_steps", name="a")
+    p.add_step("step_b", module="tests.dependency_steps", name="b", depends_on=["a"])
+    results = p.execute()
+    names = [r[0] for r in results]
+    devices = [r[1] for r in results]
+    assert names == ["a", "b", "c"]
+    expected_device = "cuda" if torch.cuda.is_available() else "cpu"
+    assert all(d == expected_device for d in devices)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_pipeline_executes_on_gpu():
+    p = Pipeline()
+    p.add_step("step_a", module="tests.dependency_steps", name="a")
+    p.add_step("step_b", module="tests.dependency_steps", name="b", depends_on=["a"])
+    results = p.execute()
+    devices = [r[1] for r in results]
+    assert all(d == "cuda" for d in devices)
+
+
+def test_cycle_detection_in_execute():
+    p = Pipeline()
+    p.add_step("step_a", module="tests.dependency_steps", name="a", depends_on=["c"])
+    p.add_step("step_b", module="tests.dependency_steps", name="b", depends_on=["a"])
+    p.add_step("step_c", module="tests.dependency_steps", name="c", depends_on=["b"])
+    with pytest.raises(ValueError, match="cycle"):
+        p.execute()


### PR DESCRIPTION
## Summary
- allow pipeline steps to declare unique names and depends_on relationships
- topologically sort steps with cycle detection and clear error messages
- document dependency configuration in README and Tutorial

## Testing
- `pre-commit run --files pipeline.py tests/dependency_steps.py tests/test_dependency_graph.py tests/test_pipeline_dependency_integration.py README.md TUTORIAL.md TODO.md`
- `pytest tests/test_dependency_graph.py -q`
- `pytest tests/test_pipeline_dependency_integration.py -q`
- `python - <<'PY'
from pipeline import Pipeline
p = Pipeline()
p.add_step("step_a", module="tests.dependency_steps", name="a")
p.add_step("step_b", module="tests.dependency_steps", name="b", depends_on=["a"])
print('CPU/GPU check: torch.cuda.is_available =', __import__('torch').cuda.is_available())
print('Results:', p.execute())
PY`
- `python - <<'PY'
import torch
from pipeline import Pipeline
if not torch.cuda.is_available():
    print('GPU not available, skipping GPU sample')
else:
    p = Pipeline()
    p.add_step('step_a', module='tests.dependency_steps', name='a')
    p.add_step('step_b', module='tests.dependency_steps', name='b', depends_on=['a'])
    print('GPU Results:', p.execute())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68905d556c208327bafbc2afe4db99fd