### PR TITLE
feat: add step hooks

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -467,22 +467,22 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [x] Document multi-process setup and troubleshooting in README and TUTORIAL.
        - [x] Provide setup instructions and environment variables.
        - [x] Include guidance for debugging deadlocks or hangs.
-177. [ ] Add pre and post hooks for each step enabling custom behaviour.
-   - [ ] Define hook interfaces for actions before and after steps.
-       - [ ] Specify function signatures for pre and post hooks.
-       - [ ] Describe available context passed to hooks.
-   - [ ] Implement registration and ordered invocation of hooks in pipeline core.
-       - [ ] Provide API to register multiple hooks per step.
-       - [ ] Ensure hooks execute in deterministic order.
-   - [ ] Guarantee hooks operate correctly on CPU and GPU paths.
-       - [ ] Test hooks manipulating CPU tensors.
-       - [ ] Test hooks handling GPU tensors without leaks.
-   - [ ] Add tests covering hook execution and interaction with steps.
-       - [ ] Unit test hook registration and removal.
-       - [ ] Integration test hooks altering step behaviour.
-   - [ ] Document hook patterns with code samples in README and TUTORIAL.
-       - [ ] Include example demonstrating pre-processing hook.
-       - [ ] Highlight best practices for side-effect management.
+177. [x] Add pre and post hooks for each step enabling custom behaviour.
+   - [x] Define hook interfaces for actions before and after steps.
+       - [x] Specify function signatures for pre and post hooks.
+       - [x] Describe available context passed to hooks.
+   - [x] Implement registration and ordered invocation of hooks in pipeline core.
+       - [x] Provide API to register multiple hooks per step.
+       - [x] Ensure hooks execute in deterministic order.
+   - [x] Guarantee hooks operate correctly on CPU and GPU paths.
+       - [x] Test hooks manipulating CPU tensors.
+       - [x] Test hooks handling GPU tensors without leaks.
+   - [x] Add tests covering hook execution and interaction with steps.
+       - [x] Unit test hook registration and removal.
+       - [x] Integration test hooks altering step behaviour.
+   - [x] Document hook patterns with code samples in README and TUTORIAL.
+       - [x] Include example demonstrating pre-processing hook.
+       - [x] Highlight best practices for side-effect management.
 178. [ ] Provide templates to quickly generate common workflows.
    - [ ] Catalogue common workflow patterns for template generation.
        - [ ] Gather representative pipelines from existing projects.

--- a/tests/test_pipeline_hooks.py
+++ b/tests/test_pipeline_hooks.py
@@ -1,0 +1,88 @@
+import gc
+import torch
+import pytest
+
+from pipeline import Pipeline
+
+
+def double_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor * 2
+
+
+def test_hook_registration_and_removal():
+    pipe = Pipeline()
+    pipe.add_step(
+        "double_tensor",
+        module="tests.test_pipeline_hooks",
+        params={"tensor": torch.tensor([1, 2])},
+        name="double",
+    )
+    calls: list[str] = []
+
+    def pre(step, marble, device):
+        calls.append("pre")
+
+    pipe.register_pre_hook("double", pre)
+    pipe.remove_pre_hook("double", pre)
+    pipe.execute()
+    assert calls == []
+
+
+def test_pre_post_hooks_cpu():
+    pipe = Pipeline()
+    tensor = torch.tensor([1, 2])
+    pipe.add_step(
+        "double_tensor",
+        module="tests.test_pipeline_hooks",
+        params={"tensor": tensor},
+        name="double",
+    )
+
+    def pre(step, marble, device):
+        step["params"]["tensor"] = step["params"]["tensor"].to(device) * 3
+
+    def post(step, result, marble, device):
+        assert result.device.type == device.type
+        return result + 1
+
+    pipe.register_pre_hook("double", pre)
+    pipe.register_post_hook("double", post)
+    result = pipe.execute()[0]
+    expected = torch.tensor([7, 13])
+    assert torch.equal(result.cpu(), expected)
+
+
+def test_pre_post_hooks_gpu():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    device = torch.device("cuda")
+    pipe = Pipeline()
+    tensor = torch.tensor([1, 2], device=device)
+    pipe.add_step(
+        "double_tensor",
+        module="tests.test_pipeline_hooks",
+        params={"tensor": tensor},
+        name="double",
+    )
+
+    def pre(step, marble, dev):
+        assert dev.type == "cuda"
+        step["params"]["tensor"] = step["params"]["tensor"] * 3
+
+    def post(step, result, marble, dev):
+        assert result.device.type == "cuda"
+        return result + 1
+
+    pipe.register_pre_hook("double", pre)
+    pipe.register_post_hook("double", post)
+
+    before = torch.cuda.memory_allocated()
+    result = pipe.execute()[0]
+    torch.cuda.synchronize()
+    after = torch.cuda.memory_allocated()
+    assert torch.all(result == torch.tensor([7, 13], device=device))
+    assert after <= before + 1024
+    # clear any lingering refs
+    del result
+    gc.collect()
+    torch.cuda.empty_cache()


### PR DESCRIPTION
## Summary
- add pipeline pre and post hook protocols and deterministic registration
- expose hook APIs with CPU/GPU aware execution
- document hook usage with examples and update TODO

## Testing
- `pytest tests/test_pipeline_hooks.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689080c0961c8327aeb896e968cbd4a9