### PR TITLE
Auto Neuronenblitz training loops for dataset steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,29 @@ pipe.register_pre_hook("n", pre_scale)
 pipe.execute()
 ```
 
+### Automatic Neuronenblitz training loops
+
+When a pipeline step produces a dataset, MARBLE automatically constructs a
+training loop for an attached `Neuronenblitz` instance. Any step whose function
+or plugin name contains `dataset` is treated as a dataset producer. During
+execution the dataset is detected and a training loop runs without requiring an
+explicit training step.
+
+The loop selects the appropriate device and moves tensor inputs before invoking
+`Neuronenblitz.train`. CPU-only systems use the `cpu` device while GPU-enabled
+machines switch to `cuda`.
+
+```mermaid
+flowchart TD
+    A[Pipeline Step] -->|dataset step| B{Dataset?}
+    B -->|no| C[Next Step]
+    B -->|yes| D[Auto Train Loop]
+    D --> C
+```
+
+To customise epochs for a dataset step, supply `{"epochs": N}` in the step's
+`params` mapping.
+
 **Best practices:** keep hooks side-effect free and release references to large
 GPU tensors once finished to avoid memory leaks. When mutating ``step`` ensure
 subsequent runs account for the modified parameters.

--- a/TODO.md
+++ b/TODO.md
@@ -499,22 +499,22 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [x] Document available templates and usage instructions in README and TUTORIAL.
        - [x] Write step-by-step guide for using generator.
        - [x] Include troubleshooting for common template issues.
-179. [ ] Automatically build training loops for Neuronenblitz when dataset steps are present.
-   - [ ] Outline design for Automatically build training loops for Neuronenblitz when dataset steps are present.
-       - [ ] Identify dataset step types that trigger training loop creation.
-       - [ ] Specify how loops detect CPU vs GPU execution paths.
-       - [ ] Draft flowchart illustrating automatic loop insertion points.
-   - [ ] Implement Automatically build training loops for Neuronenblitz when dataset steps are present with CPU/GPU support.
-       - [ ] Detect dataset steps during pipeline compilation.
-       - [ ] Instantiate training loop objects bound to detected datasets.
-       - [ ] Ensure created loops respect available hardware and switch between CPU and GPU.
-   - [ ] Add tests validating Automatically build training loops for Neuronenblitz when dataset steps are present.
-       - [ ] Unit test dataset step detection logic.
-       - [ ] Integration test auto-generated loop running on sample CPU dataset.
-       - [ ] Integration test loop operating on GPU when available.
-   - [ ] Document Automatically build training loops for Neuronenblitz when dataset steps are present in README and TUTORIAL.
-       - [ ] Describe automatic loop creation mechanism in README.
-       - [ ] Provide tutorial example demonstrating dataset-driven loop generation.
+179. [x] Automatically build training loops for Neuronenblitz when dataset steps are present.
+   - [x] Outline design for Automatically build training loops for Neuronenblitz when dataset steps are present.
+       - [x] Identify dataset step types that trigger training loop creation.
+       - [x] Specify how loops detect CPU vs GPU execution paths.
+       - [x] Draft flowchart illustrating automatic loop insertion points.
+   - [x] Implement Automatically build training loops for Neuronenblitz when dataset steps are present with CPU/GPU support.
+       - [x] Detect dataset steps during pipeline compilation.
+       - [x] Instantiate training loop objects bound to detected datasets.
+       - [x] Ensure created loops respect available hardware and switch between CPU and GPU.
+   - [x] Add tests validating Automatically build training loops for Neuronenblitz when dataset steps are present.
+       - [x] Unit test dataset step detection logic.
+       - [x] Integration test auto-generated loop running on sample CPU dataset.
+       - [x] Integration test loop operating on GPU when available.
+   - [x] Document Automatically build training loops for Neuronenblitz when dataset steps are present in README and TUTORIAL.
+       - [x] Describe automatic loop creation mechanism in README.
+       - [x] Provide tutorial example demonstrating dataset-driven loop generation.
 180. [ ] Offer a specialised step that consumes the new streaming `BitTensorDataset`.
    - [x] Outline design for Offer a specialised step that consumes the new streaming `BitTensorDataset`.
        - [x] Define step interface for streaming dataset consumption.

--- a/tests/test_auto_nb_training_loop.py
+++ b/tests/test_auto_nb_training_loop.py
@@ -1,0 +1,57 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import torch
+import pytest
+
+from pipeline import Pipeline
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from synthetic_dataset import generate_linear_dataset
+from tests.test_core_functions import minimal_params
+
+
+def tensor_dataset():
+    return [
+        (torch.tensor(0.0), torch.tensor(0.0)),
+        (torch.tensor(1.0), torch.tensor(1.0)),
+    ]
+
+
+def test_dataset_step_detection():
+    pipe = Pipeline([
+        {"module": "synthetic_dataset", "func": "generate_linear_dataset"},
+        {"func": "noop"},
+    ])
+    idxs = pipe._dataset_step_indices()
+    assert idxs == [0]
+
+
+def test_auto_training_loop_cpu():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    steps = [
+        {
+            "module": "synthetic_dataset",
+            "func": "generate_linear_dataset",
+            "params": {"n_samples": 5},
+        }
+    ]
+    pipe = Pipeline(steps)
+    pipe.execute(marble=nb)
+    assert len(nb.get_training_history()) > 0
+
+
+def test_auto_training_loop_gpu():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    steps = [
+        {"module": "tests.test_auto_nb_training_loop", "func": "tensor_dataset"}
+    ]
+    pipe = Pipeline(steps)
+    pipe.execute(marble=nb)
+    assert len(nb.get_training_history()) > 0


### PR DESCRIPTION
## Summary
- detect dataset-producing steps in `Pipeline` and auto-train Neuronenblitz models with CPU/GPU awareness
- document automatic loop insertion with flowchart and tutorial example
- cover new behaviour with unit and integration tests

## Testing
- `pytest tests/test_pipeline_class.py`
- `pytest tests/test_streaming_dataset_step.py`
- `pytest tests/test_auto_nb_training_loop.py`


------
https://chatgpt.com/codex/tasks/task_e_68908f8880f88327a86110966212ada2