### PR TITLE
feat: export model at pipeline completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,25 @@ pipe.execute(cache_dir="cache")  # stores result
 pipe.execute(cache_dir="cache")  # loads from disk
 ```
 
+### Automatic Model Export
+
+`Pipeline.execute` can persist the trained model as a final step by supplying
+the `export_path` argument. The pipeline appends an `export_model` step that
+writes the MARBLE core to the given location in JSON format by default. Set
+`export_format="onnx"` to export an ONNX graph instead. Both modes operate on
+CPU and GPU transparently.
+
+```python
+from pipeline import Pipeline
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from tests.test_core_functions import minimal_params
+
+pipe = Pipeline()
+nb = Neuronenblitz(Core(minimal_params()))
+pipe.execute(marble=nb, export_path="core.json")
+```
+
 ### Automatic Neuronenblitz training loops
 
 When a pipeline step produces a dataset, MARBLE automatically constructs a

--- a/TODO.md
+++ b/TODO.md
@@ -569,11 +569,11 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [ ] Implement Debug steps interactively by inspecting their inputs and outputs with CPU/GPU support.
    - [ ] Add tests validating Debug steps interactively by inspecting their inputs and outputs.
    - [ ] Document Debug steps interactively by inspecting their inputs and outputs in README and TUTORIAL.
-185. [ ] Export trained models automatically as a final pipeline step.
-   - [ ] Outline design for Export trained models automatically as a final pipeline step.
-   - [ ] Implement Export trained models automatically as a final pipeline step with CPU/GPU support.
-   - [ ] Add tests validating Export trained models automatically as a final pipeline step.
-   - [ ] Document Export trained models automatically as a final pipeline step in README and TUTORIAL.
+185. [x] Export trained models automatically as a final pipeline step.
+   - [x] Outline design for Export trained models automatically as a final pipeline step.
+   - [x] Implement Export trained models automatically as a final pipeline step with CPU/GPU support.
+   - [x] Add tests validating Export trained models automatically as a final pipeline step.
+   - [x] Document Export trained models automatically as a final pipeline step in README and TUTORIAL.
 186. [ ] Log pipeline events to the remote experiment tracker.
    - [ ] Outline design for Log pipeline events to the remote experiment tracker.
    - [ ] Implement Log pipeline events to the remote experiment tracker with CPU/GPU support.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -283,9 +283,22 @@ pipe.execute(cache_dir="cache")  # second run loads from disk
    bar on desktop layouts and textual percentages on mobile. If no updates
    appear, ensure JavaScript is enabled and the page URL includes the
    ``device`` query parameter.
-9. **View metrics in your browser** by enabling `metrics_dashboard.enabled`. Set `window_size` to control the moving-average smoothing of the curves.
-10. **Gradually reduce regularization** by setting `dropout_probability` and `dropout_decay_rate` under `neuronenblitz`. A decay rate below `1.0` multiplies the current dropout value after each epoch.
-11. **Search hyperparameters** using `hyperparameter_search.grid_search` to try different learning rates or scheduler options:
+9. **Export the trained model automatically** by providing `export_path` when executing a pipeline. The final step serializes the core to disk:
+   ```python
+   from pipeline import Pipeline
+   from marble_core import Core
+   from marble_neuronenblitz import Neuronenblitz
+   from tests.test_core_functions import minimal_params
+
+   core = Core(minimal_params())
+   nb = Neuronenblitz(core)
+   pipe = Pipeline()
+   pipe.execute(marble=nb, export_path="core.json")
+   ```
+   Use `export_format="onnx"` to emit an ONNX graph instead of JSON.
+10. **View metrics in your browser** by enabling `metrics_dashboard.enabled`. Set `window_size` to control the moving-average smoothing of the curves.
+11. **Gradually reduce regularization** by setting `dropout_probability` and `dropout_decay_rate` under `neuronenblitz`. A decay rate below `1.0` multiplies the current dropout value after each epoch.
+12. **Search hyperparameters** using `hyperparameter_search.grid_search` to try different learning rates or scheduler options:
    ```python
    from hyperparameter_search import grid_search
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -271,6 +271,8 @@ class Pipeline:
         log_callback: Callable[[str], None] | None = None,
         debug_hook: Callable[[int, Any], None] | None = None,
         cache_dir: str | Path | None = None,
+        export_path: str | Path | None = None,
+        export_format: str = "json",
     ) -> list[Any]:
         results: list[Any] = []
         self._summaries = []
@@ -452,6 +454,13 @@ class Pipeline:
                     pass
             if summary:
                 self._summaries.append(summary)
+        if export_path is not None and marble is not None:
+            plugin_cls = pipeline_plugins.get_plugin("export_model")
+            exporter = plugin_cls(path=str(export_path), fmt=export_format)
+            exporter.initialise(device=device, marble=marble)
+            export_result = exporter.execute(device=device, marble=marble)
+            exporter.teardown()
+            results.append(export_result)
         return results
 
     def _execute_function(

--- a/tests/test_pipeline_export.py
+++ b/tests/test_pipeline_export.py
@@ -1,0 +1,15 @@
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from pipeline import Pipeline
+from tests.test_core_functions import minimal_params
+
+
+def test_automatic_export(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    pipe = Pipeline()
+    export_file = tmp_path / "model.json"
+    results = pipe.execute(marble=nb, export_path=str(export_file))
+    assert export_file.exists() and export_file.stat().st_size > 0
+    assert str(export_file) in results


### PR DESCRIPTION
## Summary
- add `export_model` pipeline plugin that saves the trained core in JSON or ONNX
- allow `Pipeline.execute` to append a final model export step via `export_path`
- document and test automatic model export

## Testing
- `pytest tests/test_pipeline_export.py -q`
- `pytest tests/test_pipeline_class.py -q`
- `pytest tests/test_pipeline_step_plugin.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68909c9fd7a08327a69f704056a3c394