### PR TITLE
feat: add interactive pipeline debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,32 @@ pipe.register_pre_hook("n", pre_scale)
 pipe.execute()
 ```
 
+### Interactive Step Debugging
+
+For exploratory development you can inspect the inputs and outputs of every
+pipeline step interactively. Call
+``Pipeline.enable_interactive_debugging`` to register hooks that capture step
+parameters and result summaries including tensor shapes, dtypes and the CPU/GPU
+device in use. When ``interactive=True`` (the default) the debugger drops into
+``pdb`` before and after each step so you can examine state and experiment
+interactively. Passing ``interactive=False`` records the information without
+halting execution which is ideal for automated scripts and tests.
+
+```python
+import torch
+from pipeline import Pipeline
+
+def add_value(tensor: torch.Tensor, value: float, device: str) -> torch.Tensor:
+    return tensor.to(device) + value
+
+pipe = Pipeline()
+pipe.add_step("add_value", module="__main__", params={"tensor": torch.ones(2), "value": 5})
+debugger = pipe.enable_interactive_debugging()  # set interactive=False to avoid pdb
+pipe.execute()
+print(debugger.inputs)
+print(debugger.outputs)
+```
+
 ### Caching Step Results
 
 ``Pipeline.execute`` accepts a ``cache_dir`` argument that persists each step's

--- a/TODO.md
+++ b/TODO.md
@@ -564,11 +564,17 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [ ] Implement Limit GPU memory usage per step through concurrency controls with CPU/GPU support.
    - [ ] Add tests validating Limit GPU memory usage per step through concurrency controls.
    - [ ] Document Limit GPU memory usage per step through concurrency controls in README and TUTORIAL.
-184. [ ] Debug steps interactively by inspecting their inputs and outputs.
-   - [ ] Outline design for Debug steps interactively by inspecting their inputs and outputs.
-   - [ ] Implement Debug steps interactively by inspecting their inputs and outputs with CPU/GPU support.
-   - [ ] Add tests validating Debug steps interactively by inspecting their inputs and outputs.
-   - [ ] Document Debug steps interactively by inspecting their inputs and outputs in README and TUTORIAL.
+184. [x] Debug steps interactively by inspecting their inputs and outputs.
+   - [x] Outline design for Debug steps interactively by inspecting their inputs and outputs.
+       - Introduce an ``InteractiveDebugger`` using pre and post hooks to capture
+         step parameters and result summaries.
+       - Summaries report tensor shape, dtype and CPU/GPU device without moving
+         data between devices.
+       - Expose ``Pipeline.enable_interactive_debugging`` helper registering the
+         hooks and optionally dropping into ``pdb`` before and after each step.
+   - [x] Implement Debug steps interactively by inspecting their inputs and outputs with CPU/GPU support.
+   - [x] Add tests validating Debug steps interactively by inspecting their inputs and outputs.
+   - [x] Document Debug steps interactively by inspecting their inputs and outputs in README and TUTORIAL.
 185. [x] Export trained models automatically as a final pipeline step.
    - [x] Outline design for Export trained models automatically as a final pipeline step.
    - [x] Implement Export trained models automatically as a final pipeline step with CPU/GPU support.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -195,6 +195,32 @@ print(pipe.execute()[0])  # tensor([7., 13.])
 Avoid side effects inside hooks and promptly release any GPU tensors to prevent
 memory leaks.
 
+### Interactive Step Debugging
+
+During experimentation it can be helpful to pause after each pipeline step and
+inspect what was passed in and what came out. ``Pipeline.enable_interactive_debugging``
+registers hooks that capture this information and, by default, drop you into
+``pdb`` before and after every step so you can explore the state interactively.
+
+```python
+import torch
+from pipeline import Pipeline
+
+def add_value(tensor: torch.Tensor, value: float, device: str) -> torch.Tensor:
+    return tensor.to(device) + value
+
+pipe = Pipeline()
+pipe.add_step(
+    "add_value",
+    module="__main__",
+    params={"tensor": torch.ones(2), "value": 5},
+)
+debugger = pipe.enable_interactive_debugging(interactive=False)  # set True for pdb
+pipe.execute()
+print(debugger.inputs[pipe.steps[0]["name"]])
+print(debugger.outputs[pipe.steps[0]["name"]])
+```
+
 ### Caching Step Results
 
 When experimenting it is useful to skip recomputation. Supply a directory via

--- a/tests/test_interactive_debug.py
+++ b/tests/test_interactive_debug.py
@@ -1,0 +1,39 @@
+import pytest
+import torch
+
+from pipeline import Pipeline
+
+
+def add_value(tensor: torch.Tensor, value: float, device: str) -> torch.Tensor:
+    return tensor.to(device) + value
+
+
+def test_interactive_debug_cpu():
+    pipe = Pipeline()
+    pipe.add_step(
+        "add_value",
+        module="tests.test_interactive_debug",
+        params={"tensor": torch.ones(2), "value": 5, "device": "cpu"},
+    )
+    debugger = pipe.enable_interactive_debugging(interactive=False)
+    result = pipe.execute()[0]
+    name = pipe.steps[0]["name"]
+    assert debugger.inputs[name]["params"]["tensor"]["device"] == "cpu"
+    assert debugger.outputs[name]["device"] == result.device.type
+    assert torch.allclose(result, torch.tensor([6.0, 6.0], device=result.device))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_interactive_debug_gpu():
+    pipe = Pipeline()
+    pipe.add_step(
+        "add_value",
+        module="tests.test_interactive_debug",
+        params={"tensor": torch.ones(2), "value": 5, "device": "cuda"},
+    )
+    debugger = pipe.enable_interactive_debugging(interactive=False)
+    result = pipe.execute()[0]
+    name = pipe.steps[0]["name"]
+    assert debugger.inputs[name]["params"]["tensor"]["device"] == "cpu"
+    assert debugger.outputs[name]["device"] == "cuda"
+    assert result.device.type == "cuda"


### PR DESCRIPTION
## Summary
- add `InteractiveDebugger` to inspect step inputs and outputs
- document interactive debugging in README and TUTORIAL
- cover interactive debugging with tests on CPU and GPU

## Testing
- `pre-commit run --files tests/test_interactive_debug.py pipeline.py README.md TUTORIAL.md TODO.md`
- `pytest tests/test_interactive_debug.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6890a19076408327b72ea8289fc64ef5