### PR TITLE
docs: detail automatic model export step

### DIFF
--- a/ARCHITECTURE_OVERVIEW.md
+++ b/ARCHITECTURE_OVERVIEW.md
@@ -98,6 +98,16 @@ Input -> DataLoader.encode -> Brain.train/dynamic_wander ->
 Core/Neuronenblitz -> DataLoader.decode -> Output
 ```
 
+## Automatic Model Export Step
+
+`Pipeline.execute` appends an `export_model` plugin after all user-defined
+steps when an ``export_path`` is supplied. This final plugin serializes the
+trained MARBLE core to disk—either as JSON or, when ``export_format="onnx"``
+is specified, as an ONNX graph. The export runs on the same device selected
+for the pipeline, seamlessly handling CPU or GPU execution and creating the
+target directory if needed. The destination file path is returned as the
+last pipeline result so subsequent tooling can consume it.
+
 ## Future Extensions
 Future work could extend the compression layer to support streaming
 data sources, integrate JAX based automatic differentiation for

--- a/README.md
+++ b/README.md
@@ -362,7 +362,8 @@ pipe.execute(cache_dir="cache")  # loads from disk
 the `export_path` argument. The pipeline appends an `export_model` step that
 writes the MARBLE core to the given location in JSON format by default. Set
 `export_format="onnx"` to export an ONNX graph instead. Both modes operate on
-CPU and GPU transparently.
+CPU and GPU transparently, running on the same device as earlier steps and
+returning the destination path as the final pipeline result.
 
 ```python
 from pipeline import Pipeline

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -309,7 +309,7 @@ pipe.execute(cache_dir="cache")  # second run loads from disk
    bar on desktop layouts and textual percentages on mobile. If no updates
    appear, ensure JavaScript is enabled and the page URL includes the
    ``device`` query parameter.
-9. **Export the trained model automatically** by providing `export_path` when executing a pipeline. The final step serializes the core to disk:
+9. **Export the trained model automatically** by providing `export_path` when executing a pipeline. The final step serializes the core to disk on the currently active device (CPU or GPU):
    ```python
    from pipeline import Pipeline
    from marble_core import Core


### PR DESCRIPTION
## Summary
- Document automatic export plugin in architectural overview
- Clarify that automatic model export runs on the pipeline's device and returns the path
- Tutorial now notes export occurs on CPU or GPU depending on availability

## Testing
- `pytest tests/test_pipeline_export.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890aba99e2c83279885d094af28eab1