### PR TITLE
Integrate pipeline hyperparameter search

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,7 +688,7 @@ These heuristics work well across the provided examples but every dataset benefi
 When tuning a new task consider the following workflow:
 
 1. Start with the default configuration and run a short training job to verify that the loss decreases.
-2. Perform a coarse grid search over `learning_rate` and `lr_scheduler` settings using the helper functions in `hyperparameter_search.py`.
+2. Perform a coarse grid search over `learning_rate` and `lr_scheduler` settings using `Pipeline.hyperparameter_search` to evaluate each combination through the pipeline.
 3. Once a stable range is found, explore `representation_size` and `message_passing_alpha` which strongly influence capacity and convergence speed.
 4. Monitor GPU and CPU usage using the metrics dashboard to ensure batch size and dimensionality fit your hardware budget.
 5. Keep `gradient_clip_value` low (around `1.0`) when experimenting with very large learning rates or aggressive neurogenesis.

--- a/TODO.md
+++ b/TODO.md
@@ -600,11 +600,11 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [x] Implement Roll back to earlier step outputs when experiments go wrong with CPU/GPU support.
    - [x] Add tests validating Roll back to earlier step outputs when experiments go wrong.
    - [x] Document Roll back to earlier step outputs when experiments go wrong in README and TUTORIAL.
-190. [ ] Integrate hyperparameter search that plugs directly into the pipeline engine.
-   - [ ] Outline design for Integrate hyperparameter search that plugs directly into the pipeline engine.
-   - [ ] Implement Integrate hyperparameter search that plugs directly into the pipeline engine with CPU/GPU support.
-   - [ ] Add tests validating Integrate hyperparameter search that plugs directly into the pipeline engine.
-   - [ ] Document Integrate hyperparameter search that plugs directly into the pipeline engine in README and TUTORIAL.
+190. [x] Integrate hyperparameter search that plugs directly into the pipeline engine.
+   - [x] Outline design for Integrate hyperparameter search that plugs directly into the pipeline engine.
+   - [x] Implement Integrate hyperparameter search that plugs directly into the pipeline engine with CPU/GPU support.
+   - [x] Add tests validating Integrate hyperparameter search that plugs directly into the pipeline engine.
+   - [x] Document Integrate hyperparameter search that plugs directly into the pipeline engine in README and TUTORIAL.
 191. [ ] Schedule individual steps on remote hardware tiers seamlessly.
    - [ ] Outline design for Schedule individual steps on remote hardware tiers seamlessly.
    - [ ] Implement Schedule individual steps on remote hardware tiers seamlessly with CPU/GPU support.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -327,17 +327,17 @@ pipe.execute(cache_dir="cache")  # second run loads from disk
    Use `export_format="onnx"` to emit an ONNX graph instead of JSON.
 10. **View metrics in your browser** by enabling `metrics_dashboard.enabled`. Set `window_size` to control the moving-average smoothing of the curves.
 11. **Gradually reduce regularization** by setting `dropout_probability` and `dropout_decay_rate` under `neuronenblitz`. A decay rate below `1.0` multiplies the current dropout value after each epoch.
-12. **Search hyperparameters** using `hyperparameter_search.grid_search` to try different learning rates or scheduler options:
+12. **Search hyperparameters** directly through the pipeline using `Pipeline.hyperparameter_search`:
    ```python
-   from hyperparameter_search import grid_search
+   from pipeline import Pipeline
 
-   def train_with_params(params):
-       cfg['neuronenblitz'].update(params)
-       marble = MARBLE(cfg['core'])
-       marble.brain.train(train_examples, epochs=3, validation_examples=val_examples)
-       return marble.brain.validate(val_examples)
+   pipe = Pipeline()
+   pipe.add_step('train_step', params={'epochs': 3}, name='train')
+   def score(outputs):
+       return outputs[-1]  # assume last step returns validation loss
 
-   results = grid_search({'learning_rate': [0.001, 0.01], 'lr_scheduler': ['none', 'cyclic']}, train_with_params)
+   grid = {'train.epochs': [1, 2]}
+   results = pipe.hyperparameter_search(grid, score, marble=marble)
    print('Best params:', results[0])
    ```
 

--- a/cli.py
+++ b/cli.py
@@ -126,12 +126,23 @@ def main() -> None:
     if args.grid_search:
         import yaml
 
-        from hyperparameter_search import grid_search
-
         with open(args.grid_search, "r", encoding="utf-8") as f:
             param_grid = yaml.safe_load(f)
+        if args.pipeline:
+            from pipeline import Pipeline
 
-        results = grid_search(param_grid, lambda p: 0.0)
+            with open(args.pipeline, "r", encoding="utf-8") as f:
+                pipe = Pipeline.load_json(f)
+
+            def score_fn(outputs):
+                last = outputs[-1]
+                return float(last) if isinstance(last, (int, float)) else 0.0
+
+            results = pipe.hyperparameter_search(param_grid, score_fn, marble=marble)
+        else:
+            from hyperparameter_search import grid_search
+
+            results = grid_search(param_grid, lambda p: 0.0)
         print(results)
         return
     if args.no_early_stop:

--- a/tests/dummy_pipeline_module.py
+++ b/tests/dummy_pipeline_module.py
@@ -1,0 +1,5 @@
+import torch
+
+def scale_value(a: float, scale: float = 1.0, device: str = "cpu") -> float:
+    tensor = torch.tensor(a, device=device, dtype=torch.float32)
+    return float(tensor * scale)

--- a/tests/test_hyperparameter_search.py
+++ b/tests/test_hyperparameter_search.py
@@ -3,6 +3,7 @@ import sys, os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from hyperparameter_search import grid_search, random_search
+from pipeline import Pipeline
 
 
 def dummy_train(params):
@@ -26,3 +27,38 @@ def test_random_search_samples_requested_number():
     # best result should be close to dummy optimum
     best_params, best_score = results[0]
     assert best_score == min(s for _, s in results)
+
+
+def test_pipeline_hyperparameter_search_grid():
+    pipe = Pipeline()
+    pipe.add_step(
+        "scale_value",
+        module="tests.dummy_pipeline_module",
+        params={"a": 1.0},
+        name="scale",
+    )
+    def score(results):
+        return abs(results[0] - 3.0)
+    results = pipe.hyperparameter_search({"scale.scale": [1.0, 2.0, 3.0]}, score)
+    best_params, best_score = results[0]
+    assert best_params["scale.scale"] == 3.0
+    assert best_score == 0.0
+
+
+def test_pipeline_hyperparameter_search_random():
+    pipe = Pipeline()
+    pipe.add_step(
+        "scale_value",
+        module="tests.dummy_pipeline_module",
+        params={"a": 1.0},
+        name="scale",
+    )
+    def score(results):
+        return abs(results[0] - 3.0)
+    results = pipe.hyperparameter_search(
+        {"scale.scale": [1.0, 2.0, 3.0]},
+        score,
+        search="random",
+        num_samples=2,
+    )
+    assert len(results) == 2


### PR DESCRIPTION
## Summary
- extend Pipeline with `hyperparameter_search` to evaluate parameter combinations and auto-name branch steps
- wire CLI to invoke pipeline-level hyperparameter search when a pipeline file is supplied
- document pipeline hyperparameter search and mark related TODO complete

## Testing
- `pytest tests/test_hyperparameter_search.py`
- `pytest tests/test_pipeline_class.py`
- `pytest tests/test_pipeline_hooks.py`
- `pytest tests/test_pipeline_step_validation.py`
- `pytest tests/test_pipeline_cache.py`
- `pytest tests/test_pipeline_branching.py`
- `pytest tests/test_pipeline_macro_rollback.py`
- `pytest tests/test_cli.py`
- `pytest tests/test_cli_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_6890b952a06083278d16a557553c84f6