### PR TITLE
feat: add ollama chat history support

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2533,3 +2533,35 @@ sharing a dataset between them.
 Executing the snippet above on a GPU-equipped machine automatically transfers
 the tensors to CUDA for zero-copy processing.
 
+## Project 41 – Online Chat Training with Ollama
+
+**Goal:** Continuously fine-tune a MARBLE core using recent chat exchanges served by Ollama.**
+
+1. **Download a seed conversation dataset** to initialise history:
+   ```python
+   from datasets import load_dataset
+   ds = load_dataset("OpenAssistant/oasst1", split="train[:5]")
+   history = [
+       {"role": m["role"], "content": m["content"]}
+       for m in ds[0]["messages"]
+   ]
+   ```
+2. **Instantiate MARBLE and connect to Ollama**:
+   ```python
+   from config_loader import load_config
+   from marble_main import MARBLE
+   from ollama_interop import chat_with_history
+
+   cfg = load_config()
+   marble = MARBLE(cfg["core"])
+   response, history = chat_with_history(
+       marble.core, "marble-chat", "Hello there!", history, history_limit=8
+   )
+   print(response["message"]["content"])
+   ```
+3. **Train on updated history** by converting the collected messages into
+   token sequences and feeding them to your learner (see projects above for
+   dataset preparation techniques).
+
+Run `python project41_chat_training.py` to experiment with live conversation fine-tuning.
+

--- a/tests/test_ollama_interop.py
+++ b/tests/test_ollama_interop.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from marble_core import Core
-from ollama_interop import core_to_modelfile, generate, register_core
+from ollama_interop import chat_with_history, core_to_modelfile, generate, register_core
 from tests.test_core_functions import minimal_params
 
 
@@ -35,3 +35,27 @@ def test_generate_registers_and_calls_generate(mock_create, mock_generate):
     mock_create.assert_called_once()
     mock_generate.assert_called_once()
     assert out["response"] == "ok"
+
+
+@patch("ollama_interop.ollama.chat")
+@patch("ollama_interop.ollama.create")
+def test_chat_with_history_truncates_and_appends(mock_create, mock_chat):
+    params = minimal_params()
+    core = Core(params)
+    original = [
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "u2"},
+        {"role": "assistant", "content": "a2"},
+    ]
+    expected_sent = original[-3:] + [{"role": "user", "content": "u3"}]
+    mock_chat.return_value = {"message": {"content": "a3"}}
+    response, updated = chat_with_history(
+        core, "mtest", "u3", original, history_limit=3
+    )
+    # ensure older messages were dropped and new user/assistant messages appended
+    sent = mock_chat.call_args.kwargs["messages"][:-1]
+    mock_chat.assert_called_once()
+    assert sent == expected_sent
+    assert updated == expected_sent + [{"role": "assistant", "content": "a3"}]
+    assert response["message"]["content"] == "a3"


### PR DESCRIPTION
## Summary
- enable MARBLE cores to exchange chat messages via `chat_with_history` while preserving a rolling window
- document live Ollama training in new tutorial project
- cover chat history logic with unit tests

## Testing
- `pytest tests/test_ollama_interop.py`

------
https://chatgpt.com/codex/tasks/task_e_6890d0df437c8327bac860463309c845