### PR TITLE
Add Ollama interactive training pipeline

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2565,3 +2565,39 @@ the tensors to CUDA for zero-copy processing.
 
 Run `python project41_chat_training.py` to experiment with live conversation fine-tuning.
 
+
+### Project: Interactive Ollama Training Pipeline
+
+This project demonstrates how to convert an Ollama model into a MARBLE `Core`
+using the new `OllamaInteractiveTrainingPlugin` and fine‑tune it with
+conversation pairs.
+
+1. **Prepare a small dataset** of prompts and desired replies.  The example
+   below uses the Stanford Sentiment Treebank which can be downloaded via the
+   `datasets` library:
+   ```python
+   from datasets import load_dataset
+
+   raw = load_dataset("sst2", split="train[:10]")
+   pairs = [
+       (rec["sentence"], "positive" if rec["label"] else "negative")
+       for rec in raw
+   ]
+   ```
+2. **Create a pipeline with the plugin and execute it**.  The plugin pulls the
+   model from Ollama, converts it and trains on the provided pairs:
+   ```python
+   from pipeline import Pipeline
+   from ollama_pipeline import OllamaInteractiveTrainingPlugin
+
+   pipe = Pipeline([
+       {"plugin": "ollama_interactive_train", "params": {"model": "llama3", "interactions": pairs}}
+   ])
+   result = pipe.execute()[0]
+   print(result["responses"][0]["message"]["content"])
+   ```
+3. **Inspect the conversation history** stored in `result["history"]` to review
+   how the assistant responded to each prompt after training.
+
+The plugin uses GPU acceleration when available and falls back to CPU
+otherwise.

--- a/ollama_pipeline.py
+++ b/ollama_pipeline.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""Pipeline plugin enabling interactive training with Ollama models.
+
+The module defines :class:`OllamaInteractiveTrainingPlugin` which performs
+four high level steps:
+
+1. Ensure the requested model is available locally by invoking
+   :func:`ollama.pull`.
+2. Load the model with the Hugging Face :mod:`transformers` library and
+   convert it into a MARBLE :class:`~marble_core.Core` via
+   :func:`pytorch_to_marble.convert_model`.
+3. Register the resulting core with an Ollama server so that prompts can be
+   served through the standard ``ollama`` API.
+4. Train the core on user supplied ``(prompt, response)`` pairs using the
+   :class:`UnifiedPairsPipeline` and finally generate replies for the provided
+   prompts via :func:`ollama_interop.chat_with_history`.
+
+The plugin automatically utilises GPU acceleration when ``cuda`` is
+available, falling back to CPU otherwise.  All heavyweight external
+operations (model loading, conversion and API calls) are organised inside the
+``initialise`` and ``execute`` lifecycle methods to integrate seamlessly with
+the generic :class:`pipeline.Pipeline` infrastructure.
+"""
+
+from typing import Iterable, List, Tuple
+
+import torch
+
+import ollama
+from transformers import AutoModelForCausalLM
+
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from ollama_interop import chat_with_history, register_core
+from pipeline_plugins import PipelinePlugin, register_plugin
+from pytorch_to_marble import convert_model
+from unified_pairs_pipeline import UnifiedPairsPipeline
+from autoencoder_learning import AutoencoderLearner
+
+
+class OllamaInteractiveTrainingPlugin(PipelinePlugin):
+    """Pipeline plugin that fine-tunes an Ollama model based on user pairs."""
+
+    def __init__(
+        self,
+        model: str,
+        interactions: Iterable[Tuple[str, str]],
+        epochs: int = 1,
+    ) -> None:
+        super().__init__(model=model, interactions=list(interactions), epochs=int(epochs))
+        self.model_name = model
+        self.interactions = list(interactions)
+        self.epochs = int(epochs)
+        self.history: List[dict[str, str]] = []
+
+    def initialise(self, device: torch.device, marble: Core | None = None) -> None:
+        self.device = device
+        # Ensure model is present locally; ``ollama.pull`` is a no-op when the
+        # model already exists.  It transparently downloads either CPU or GPU
+        # weights depending on the server configuration.
+        ollama.pull(self.model_name)
+        hf_model = AutoModelForCausalLM.from_pretrained(self.model_name)
+        hf_model.to(device)
+        self.core = convert_model(hf_model)
+        self.nb = Neuronenblitz(self.core)
+        register_core(self.core, self.model_name)
+
+    def execute(self, device: torch.device, marble: Core | None = None):
+        # Train the core on the provided (prompt, response) interactions.
+        pipeline = UnifiedPairsPipeline(
+            self.core,
+            {"autoencoder": AutoencoderLearner(self.core, self.nb)},
+            tokenizer=None,
+            use_vocab=False,
+        )
+        pipeline.train(self.interactions, epochs=self.epochs)
+        # After training, generate responses for the prompts to verify that the
+        # model has been registered correctly with Ollama.
+        outputs = []
+        for prompt, _expected in self.interactions:
+            resp, self.history = chat_with_history(
+                self.core, self.model_name, prompt, self.history, history_limit=10
+            )
+            outputs.append(resp)
+        return {"core": self.core, "responses": outputs, "history": self.history}
+
+
+register_plugin("ollama_interactive_train", OllamaInteractiveTrainingPlugin)

--- a/tests/test_ollama_pipeline_plugin.py
+++ b/tests/test_ollama_pipeline_plugin.py
@@ -1,0 +1,45 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import torch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from marble_core import Core
+from tests.test_core_functions import minimal_params
+
+
+@patch("ollama_pipeline.chat_with_history")
+@patch("ollama_pipeline.UnifiedPairsPipeline")
+@patch("ollama_pipeline.Neuronenblitz")
+@patch("ollama_pipeline.register_core")
+@patch("ollama_pipeline.convert_model")
+@patch("ollama_pipeline.AutoModelForCausalLM")
+@patch("ollama_pipeline.ollama.pull")
+def test_plugin_executes_full_flow(pull, auto_model, convert, register, nb, pairs, chat):
+    pull.return_value = None
+    auto_model.from_pretrained.return_value = torch.nn.Linear(1, 1)
+    core = Core(minimal_params())
+    convert.return_value = core
+    nb.return_value = MagicMock()
+    pipeline_instance = MagicMock()
+    pairs.return_value = pipeline_instance
+    pipeline_instance.train.return_value = None
+    chat.return_value = ({"message": {"content": "ok"}}, [])
+
+    from ollama_pipeline import OllamaInteractiveTrainingPlugin
+
+    plugin = OllamaInteractiveTrainingPlugin("tiny", [("hi", "hello")])
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    plugin.initialise(device)
+    result = plugin.execute(device)
+
+    pull.assert_called_once_with("tiny")
+    auto_model.from_pretrained.assert_called_once_with("tiny")
+    convert.assert_called_once()
+    register.assert_called_once_with(core, "tiny")
+    pipeline_instance.train.assert_called_once()
+    chat.assert_called_once()
+    assert "responses" in result
+    assert result["responses"][0]["message"]["content"] == "ok"


### PR DESCRIPTION
## Summary
- add `OllamaInteractiveTrainingPlugin` to convert Hugging Face models to MARBLE, register with Ollama and fine‑tune via user pairs
- document interactive Ollama training pipeline in tutorial
- test plugin initialization, training and chat flow

## Testing
- `pytest tests/test_ollama_pipeline_plugin.py`
- `pytest tests/test_ollama_interop.py`


------
https://chatgpt.com/codex/tasks/task_e_6890d8fc155c832796d43532b6c08564