### PR TITLE
Add Ollama interactive training pipeline

### DIFF
--- a/ollama_pipeline.py
+++ b/ollama_pipeline.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""Pipeline plugin enabling interactive training with Ollama models.
+
+The module defines :class:`OllamaInteractiveTrainingPlugin` which performs
+four high level steps:
+
+1. Ensure the requested model is available locally by invoking
+   :func:`ollama.pull`.
+2. Load the model with the Hugging Face :mod:`transformers` library and
+   convert it into a MARBLE :class:`~marble_core.Core` via
+   :func:`pytorch_to_marble.convert_model`.
+3. Register the resulting core with an Ollama server so that prompts can be
+   served through the standard ``ollama`` API.
+4. Interact with the model through :func:`ollama_interop.chat_with_history`
+   while continuously fine‑tuning on the recent conversation history via the
+   :class:`UnifiedPairsPipeline`.
+
+The plugin automatically utilises GPU acceleration when ``cuda`` is
+available, falling back to CPU otherwise.  All heavyweight external
+operations (model loading, conversion and API calls) are organised inside the
+``initialise`` and ``execute`` lifecycle methods to integrate seamlessly with
+the generic :class:`pipeline.Pipeline` infrastructure.
+"""
+
+from typing import Iterable, List
+
+import torch
+
+import ollama
+from transformers import AutoModelForCausalLM
+
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from ollama_interop import chat_with_history, register_core
+from pipeline_plugins import PipelinePlugin, register_plugin
+from pytorch_to_marble import convert_model
+from unified_pairs_pipeline import UnifiedPairsPipeline
+from autoencoder_learning import AutoencoderLearner
+
+
+class OllamaInteractiveTrainingPlugin(PipelinePlugin):
+    """Pipeline plugin that fine-tunes an Ollama model during conversation."""
+
+    def __init__(
+        self,
+        model: str,
+        prompts: Iterable[str],
+        history_limit: int = 10,
+        epochs: int = 1,
+    ) -> None:
+        super().__init__(
+            model=model,
+            prompts=list(prompts),
+            history_limit=int(history_limit),
+            epochs=int(epochs),
+        )
+        self.model_name = model
+        self.prompts = list(prompts)
+        self.history_limit = int(history_limit)
+        self.epochs = int(epochs)
+        self.history: List[dict[str, str]] = []
+
+    def initialise(self, device: torch.device, marble: Core | None = None) -> None:
+        self.device = device
+        # Ensure model is present locally; ``ollama.pull`` is a no-op when the
+        # model already exists.  It transparently downloads either CPU or GPU
+        # weights depending on the server configuration.
+        ollama.pull(self.model_name)
+        hf_model = AutoModelForCausalLM.from_pretrained(self.model_name)
+        hf_model.to(device)
+        self.core = convert_model(hf_model)
+        self.nb = Neuronenblitz(self.core)
+        register_core(self.core, self.model_name)
+
+    def execute(self, device: torch.device, marble: Core | None = None):
+        pipeline = UnifiedPairsPipeline(
+            self.core,
+            {"autoencoder": AutoencoderLearner(self.core, self.nb)},
+            tokenizer=None,
+            use_vocab=False,
+        )
+        outputs = []
+        for prompt in self.prompts:
+            resp, self.history = chat_with_history(
+                self.core, self.model_name, prompt, self.history, self.history_limit
+            )
+            outputs.append(resp)
+            truncated = self.history[-self.history_limit :]
+            pairs = [
+                (truncated[i]["content"], truncated[i + 1]["content"])
+                for i in range(len(truncated) - 1)
+                if truncated[i]["role"] == "user" and truncated[i + 1]["role"] == "assistant"
+            ]
+            if pairs:
+                pipeline.train(pairs, epochs=self.epochs)
+        return {"core": self.core, "responses": outputs, "history": self.history}
+
+
+register_plugin("ollama_interactive_train", OllamaInteractiveTrainingPlugin)

--- a/tests/test_ollama_pipeline_plugin.py
+++ b/tests/test_ollama_pipeline_plugin.py
@@ -1,0 +1,65 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import torch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from marble_core import Core
+from tests.test_core_functions import minimal_params
+
+
+@patch("ollama_pipeline.chat_with_history")
+@patch("ollama_pipeline.UnifiedPairsPipeline")
+@patch("ollama_pipeline.Neuronenblitz")
+@patch("ollama_pipeline.register_core")
+@patch("ollama_pipeline.convert_model")
+@patch("ollama_pipeline.AutoModelForCausalLM")
+@patch("ollama_pipeline.ollama.pull")
+def test_plugin_trains_on_recent_history(pull, auto_model, convert, register, nb, pairs, chat):
+    pull.return_value = None
+    auto_model.from_pretrained.return_value = torch.nn.Linear(1, 1)
+    core = Core(minimal_params())
+    convert.return_value = core
+    nb.return_value = MagicMock()
+    pipeline_instance = MagicMock()
+    pairs.return_value = pipeline_instance
+    pipeline_instance.train.return_value = None
+    chat.side_effect = [
+        (
+            {"message": {"content": "a1"}},
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "a1"},
+            ],
+        ),
+        (
+            {"message": {"content": "a2"}},
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "a1"},
+                {"role": "user", "content": "bye"},
+                {"role": "assistant", "content": "a2"},
+            ],
+        ),
+    ]
+
+    from ollama_pipeline import OllamaInteractiveTrainingPlugin
+
+    plugin = OllamaInteractiveTrainingPlugin("tiny", ["hi", "bye"], history_limit=4)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    plugin.initialise(device)
+    result = plugin.execute(device)
+
+    pull.assert_called_once_with("tiny")
+    auto_model.from_pretrained.assert_called_once_with("tiny")
+    convert.assert_called_once()
+    register.assert_called_once_with(core, "tiny")
+    assert pipeline_instance.train.call_count == 2
+    first_pairs = pipeline_instance.train.call_args_list[0].args[0]
+    second_pairs = pipeline_instance.train.call_args_list[1].args[0]
+    assert first_pairs == [("hi", "a1")]
+    assert second_pairs == [("hi", "a1"), ("bye", "a2")]
+    assert chat.call_count == 2
+    assert result["responses"][1]["message"]["content"] == "a2"


### PR DESCRIPTION
## Summary
- refine `OllamaInteractiveTrainingPlugin` to fine-tune on rolling conversation history while chatting
- update tutorial to show interactive training with `history_limit`
- adjust tests for history-based training

## Testing
- `pytest tests/test_ollama_pipeline_plugin.py`
- `pytest tests/test_ollama_interop.py`


------
https://chatgpt.com/codex/tasks/task_e_6890d8fc155c832796d43532b6c08564