### PR TITLE
Improve example stability via metrics toggle

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,6 @@
+import os
+
+# Disable metrics visualisation for example runs to keep them fast and
+# avoid heavy matplotlib usage during automated execution environments.
+os.environ.setdefault("MARBLE_DISABLE_METRICS", "1")
+

--- a/examples/project03_remote_offloading.py
+++ b/examples/project03_remote_offloading.py
@@ -23,13 +23,14 @@ def main() -> None:
     client = RemoteBrainClient("http://localhost:8005")
     cfg = load_config()
     marble = MARBLE(cfg["core"], remote_client=client)
+    marble.neuronenblitz.remote_timeout = 10.0
     brain = marble.brain
     brain.offload_enabled = True
     brain.lobe_manager.genesis(range(len(marble.core.neurons)))
     brain.offload_high_attention(threshold=-1.0)
     brain.train(train, epochs=1, validation_examples=val)
-    server.stop()
     print("Validation loss:", brain.validate(val))
+    server.stop()
 
 
 if __name__ == "__main__":

--- a/marble_main.py
+++ b/marble_main.py
@@ -1,4 +1,5 @@
 # ruff: noqa: F401, F403, F405
+import os
 from marble import MarbleConverter
 from marble_autograd import MarbleAutogradLayer
 from marble_base import MetricsVisualizer
@@ -53,22 +54,29 @@ class MARBLE:
         }
         if mv_params is not None:
             mv_defaults.update(mv_params)
-        self.metrics_visualizer = MetricsVisualizer(
-            fig_width=mv_defaults["fig_width"],
-            fig_height=mv_defaults["fig_height"],
-            refresh_rate=mv_defaults["refresh_rate"],
-            color_scheme=mv_defaults["color_scheme"],
-            show_neuron_ids=mv_defaults["show_neuron_ids"],
-            dpi=mv_defaults["dpi"],
-            track_memory_usage=mv_defaults["track_memory_usage"],
-            track_cpu_usage=mv_defaults["track_cpu_usage"],
-            log_dir=mv_defaults["log_dir"],
-            csv_log_path=mv_defaults["csv_log_path"],
-            json_log_path=mv_defaults["json_log_path"],
-            anomaly_std_threshold=mv_defaults["anomaly_std_threshold"],
-        )
+        disable_metrics = os.environ.get("MARBLE_DISABLE_METRICS", "").lower() in ("1", "true")
+        self.metrics_visualizer = None
+        if not disable_metrics:
+            self.metrics_visualizer = MetricsVisualizer(
+                fig_width=mv_defaults["fig_width"],
+                fig_height=mv_defaults["fig_height"],
+                refresh_rate=mv_defaults["refresh_rate"],
+                color_scheme=mv_defaults["color_scheme"],
+                show_neuron_ids=mv_defaults["show_neuron_ids"],
+                dpi=mv_defaults["dpi"],
+                track_memory_usage=mv_defaults["track_memory_usage"],
+                track_cpu_usage=mv_defaults["track_cpu_usage"],
+                log_dir=mv_defaults["log_dir"],
+                csv_log_path=mv_defaults["csv_log_path"],
+                json_log_path=mv_defaults["json_log_path"],
+                anomaly_std_threshold=mv_defaults["anomaly_std_threshold"],
+            )
         self.metrics_dashboard = None
-        if dashboard_params is not None and dashboard_params.get("enabled", False):
+        if (
+            self.metrics_visualizer is not None
+            and dashboard_params is not None
+            and dashboard_params.get("enabled", False)
+        ):
             from metrics_dashboard import MetricsDashboard
 
             self.metrics_dashboard = MetricsDashboard(

--- a/tests/test_metrics_disable_env.py
+++ b/tests/test_metrics_disable_env.py
@@ -1,0 +1,13 @@
+import os
+
+from config_loader import load_config
+from marble_main import MARBLE
+
+
+def test_metrics_visualizer_disabled_via_env():
+    os.environ["MARBLE_DISABLE_METRICS"] = "1"
+    cfg = load_config()
+    marble = MARBLE(cfg["core"])
+    assert marble.get_metrics_visualizer() is None
+    del os.environ["MARBLE_DISABLE_METRICS"]
+


### PR DESCRIPTION
## Summary
- add environment variable to disable MetricsVisualizer and skip dashboard when unset
- default examples to run with metrics disabled
- increase remote offload timeout and stop server after validation
- test environment variable disabling behavior

## Testing
- `pytest tests/test_metrics_disable_env.py`
- `pytest tests/test_marble_interface.py`
- `python -m examples.project01_numeric_regression`
- `python -m examples.project02_image_classification`
- `python -m examples.project03_remote_offloading`
- `python -m examples.project04_autograd_pytorch_challenge`

------
https://chatgpt.com/codex/tasks/task_e_6890f8dc29cc83278936e977787cd4b1