### PR TITLE
feat: ensure parallel wanderers support CPU

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1447,9 +1447,9 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
         - [x] QuantizedTensor CPU path.
             - [x] Force CPU execution for quantized tensor tests.
             - [x] Confirm outputs match GPU path.
-        - [ ] Parallel wanderers CPU fallback.
-            - [ ] Disable CUDA and run wanderer tests.
-            - [ ] Document any discrepancies.
+        - [x] Parallel wanderers CPU fallback.
+            - [x] Disable CUDA and run wanderer tests.
+            - [x] Document any discrepancies (none observed).
         - [ ] PromptMemory CPU performance baseline.
             - [ ] Run load tests with CUDA disabled.
             - [ ] Compare timings with GPU-enabled runs.


### PR DESCRIPTION
## Summary
- select efficient multiprocessing start method based on CUDA availability
- add regression test verifying CPU fallback for parallel wanderers
- mark TODO for parallel wanderers CPU fallback as completed

## Testing
- `pytest tests/test_parallel_wander.py`
- `pytest tests/test_neuronenblitz_enhancements.py`
- `pytest tests/test_neuronenblitz_package.py`


------
https://chatgpt.com/codex/tasks/task_e_68918b4179148327991ee6240238a8d4