### PR TITLE
Add pipeline graph visualisation and GPU concurrency control

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -554,16 +554,23 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [x] Implement Persist step results to disk for quick re-runs with CPU/GPU support.
    - [x] Add tests validating Persist step results to disk for quick re-runs.
    - [x] Document Persist step results to disk for quick re-runs in README and TUTORIAL.
-182. [ ] Visualise pipelines as graphs using the marble graph builder.
-   - [ ] Outline design for Visualise pipelines as graphs using the marble graph builder.
-   - [ ] Implement Visualise pipelines as graphs using the marble graph builder with CPU/GPU support.
-   - [ ] Add tests validating Visualise pipelines as graphs using the marble graph builder.
-   - [ ] Document Visualise pipelines as graphs using the marble graph builder in README and TUTORIAL.
-183. [ ] Limit GPU memory usage per step through concurrency controls.
-   - [ ] Outline design for Limit GPU memory usage per step through concurrency controls.
-   - [ ] Implement Limit GPU memory usage per step through concurrency controls with CPU/GPU support.
-   - [ ] Add tests validating Limit GPU memory usage per step through concurrency controls.
-   - [ ] Document Limit GPU memory usage per step through concurrency controls in README and TUTORIAL.
+182. [x] Visualise pipelines as graphs using the marble graph builder.
+   - [x] Outline design for Visualise pipelines as graphs using the marble graph builder.
+       - Represent each pipeline step as a node in a directed ``networkx`` graph.
+       - Expand macros and branches recursively with prefixed node names.
+       - Provide ``pipeline_to_core`` to convert the graph into a ``Core`` for use
+         with existing builders.
+   - [x] Implement Visualise pipelines as graphs using the marble graph builder with CPU/GPU support.
+   - [x] Add tests validating Visualise pipelines as graphs using the marble graph builder.
+   - [x] Document Visualise pipelines as graphs using the marble graph builder in README and TUTORIAL.
+183. [x] Limit GPU memory usage per step through concurrency controls.
+   - [x] Outline design for Limit GPU memory usage per step through concurrency controls.
+       - Introduce an asyncio semaphore restricting concurrent GPU branches.
+       - Expose ``max_gpu_concurrency`` parameter on ``Pipeline.execute`` and
+         propagate through macros.
+   - [x] Implement Limit GPU memory usage per step through concurrency controls with CPU/GPU support.
+   - [x] Add tests validating Limit GPU memory usage per step through concurrency controls.
+   - [x] Document Limit GPU memory usage per step through concurrency controls in README and TUTORIAL.
 184. [x] Debug steps interactively by inspecting their inputs and outputs.
    - [x] Outline design for Debug steps interactively by inspecting their inputs and outputs.
        - Introduce an ``InteractiveDebugger`` using pre and post hooks to capture

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -259,6 +259,22 @@ print(debugger.inputs[pipe.steps[0]["name"]])
 print(debugger.outputs[pipe.steps[0]["name"]])
 ```
 
+### Visualising Pipelines as Graphs
+
+Pipelines can be rendered as graphs for inspection or documentation. The
+``pipeline_to_networkx`` helper converts a sequence of step dictionaries into a
+directed ``networkx`` graph that expands macros and branches automatically.
+
+```python
+from networkx_interop import pipeline_to_networkx
+
+g = pipeline_to_networkx(pipe.steps)
+```
+
+The resulting graph can be shown with any ``networkx`` layout or converted to a
+MARBLE ``Core`` using ``pipeline_to_core`` for visualisation with the MARBLE
+graph builder.
+
 ### Caching Step Results
 
 When experimenting it is useful to skip recomputation. Supply a directory via
@@ -2014,6 +2030,16 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
       architectures without running separate experiments.  Each branch receives
       its own execution context and the merge step combines outputs once every
       branch completes.
+
+      When running on GPUs, branch execution can easily exhaust device memory.
+      Pass ``max_gpu_concurrency`` to ``Pipeline.execute`` to bound the number of
+      simultaneous GPU branches. Additional branches wait until prior ones
+      finish, preventing out-of-memory errors while keeping CPU execution
+      unrestricted.
+
+      ```python
+      pipe.execute(max_gpu_concurrency=1)
+      ```
 
 ## Project: Macro Steps and Rollback
 

--- a/networkx_interop.py
+++ b/networkx_interop.py
@@ -48,3 +48,69 @@ def networkx_to_core(graph: nx.DiGraph, params: dict) -> Core:
         core.synapses.append(syn)
         node_map[src].synapses.append(syn)
     return core
+
+
+def pipeline_to_networkx(pipeline: list[dict]) -> nx.DiGraph:
+    """Convert a pipeline description into a ``networkx`` graph.
+
+    Each step in ``pipeline`` becomes a node. Edges are created from
+    dependencies to dependents. Macros and branches are expanded
+    recursively with node names prefixed by their parents to keep them
+    unique. Sequential steps without explicit dependencies are connected
+    linearly.
+    """
+
+    graph = nx.DiGraph()
+
+    def add_steps(steps: list[dict], prefix: str = "") -> tuple[str, str]:
+        prev_name: str | None = None
+        first_name: str | None = None
+        for idx, step in enumerate(steps):
+            base = step.get("name") or f"step_{idx}"
+            name = f"{prefix}{base}"
+            label = step.get("plugin") or step.get("func")
+            if label is None:
+                label = "macro" if "macro" in step else "branch" if "branches" in step else "step"
+            graph.add_node(name, label=label, params=step.get("params", {}))
+            deps = [f"{prefix}{d}" for d in step.get("depends_on", [])]
+            if not deps and prev_name is not None:
+                deps = [prev_name]
+            for dep in deps:
+                graph.add_edge(dep, name)
+            if first_name is None:
+                first_name = name
+            if "macro" in step:
+                sub_first, sub_last = add_steps(step["macro"], prefix=f"{name}::")
+                graph.add_edge(name, sub_first)
+                prev_name = sub_last
+            elif "branches" in step:
+                branch_last = []
+                for b_idx, branch in enumerate(step["branches"]):
+                    b_first, b_last = add_steps(branch, prefix=f"{name}::b{b_idx}::")
+                    graph.add_edge(name, b_first)
+                    branch_last.append(b_last)
+                merge_spec = step.get("merge")
+                if merge_spec:
+                    merge_name = merge_spec.get("name") or "merge"
+                    merge_full = f"{name}::{merge_name}"
+                    merge_label = merge_spec.get("plugin") or merge_spec.get("func") or "merge"
+                    graph.add_node(merge_full, label=merge_label, params=merge_spec.get("params", {}))
+                    for last in branch_last:
+                        graph.add_edge(last, merge_full)
+                    prev_name = merge_full
+                else:
+                    prev_name = name
+            else:
+                prev_name = name
+        assert first_name is not None
+        return first_name, prev_name  # type: ignore
+
+    add_steps(pipeline)
+    return graph
+
+
+def pipeline_to_core(pipeline: list[dict], params: dict) -> Core:
+    """Build a :class:`Core` representation of ``pipeline``."""
+
+    graph = pipeline_to_networkx(pipeline)
+    return networkx_to_core(graph, params)

--- a/pipeline.py
+++ b/pipeline.py
@@ -391,6 +391,7 @@ class Pipeline:
         cache_dir: str | Path | None = None,
         export_path: str | Path | None = None,
         export_format: str = "json",
+        max_gpu_concurrency: int | None = None,
     ) -> list[Any]:
         results: list[Any] = []
         self._summaries = []
@@ -468,6 +469,7 @@ class Pipeline:
                         log_callback=log_callback,
                         debug_hook=debug_hook,
                         cache_dir=sub_cache,
+                        max_gpu_concurrency=max_gpu_concurrency,
                     )
                     self._summaries.extend(sub_pipeline._summaries)
                     self._benchmarks.extend(sub_pipeline._benchmarks)
@@ -481,6 +483,7 @@ class Pipeline:
                             benchmark_iterations=benchmark_iterations,
                             log_callback=log_callback,
                             debug_hook=debug_hook,
+                            max_gpu_concurrency=max_gpu_concurrency,
                         )
                     )
                     merge_spec = step.get("merge")

--- a/tests/test_branch_container_concurrency.py
+++ b/tests/test_branch_container_concurrency.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import asyncio
+import time
+import threading
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import torch
+from branch_container import BranchContainer
+
+current = 0
+peak = 0
+lock = threading.Lock()
+
+
+def sleep_step(*, device: str = "cpu"):
+    global current, peak
+    with lock:
+        current += 1
+        if current > peak:
+            peak = current
+    time.sleep(0.2)
+    with lock:
+        current -= 1
+    return device
+
+
+def test_gpu_concurrency_limit(monkeypatch):
+    global current, peak
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(BranchContainer, "_free_gpu_memory", lambda self: 8 * 1024 ** 3)
+    steps = [
+        [{"module": __name__, "func": "sleep_step", "name": "a"}],
+        [{"module": __name__, "func": "sleep_step", "name": "b"}],
+    ]
+    container = BranchContainer(steps)
+    asyncio.run(container.run(None))
+    assert peak >= 2
+    current = 0
+    peak = 0
+    asyncio.run(container.run(None, max_gpu_concurrency=1))
+    assert peak == 1

--- a/tests/test_pipeline_graph_builder.py
+++ b/tests/test_pipeline_graph_builder.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import networkx as nx
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from pipeline import Pipeline
+from networkx_interop import pipeline_to_networkx, pipeline_to_core
+from tests.test_core_functions import minimal_params
+
+
+def dummy_step(*, device: str = "cpu"):
+    return device
+
+
+def test_pipeline_to_graph_and_core():
+    pipe = Pipeline()
+    pipe.add_step("dummy_step", module=__name__, name="s1")
+    pipe.add_step("dummy_step", module=__name__, name="s2", depends_on=["s1"])
+    pipe.add_branch(
+        branches=[
+            [{"func": "dummy_step", "module": __name__, "name": "b1"}],
+            [{"func": "dummy_step", "module": __name__, "name": "b2"}],
+        ],
+        merge={"func": "dummy_step", "module": __name__, "name": "m"},
+        name="branch",
+        depends_on=["s2"],
+    )
+    g = pipeline_to_networkx(pipe.steps)
+    assert nx.is_directed_acyclic_graph(g)
+    assert ("s1", "s2") in g.edges
+    assert ("s2", "branch") in g.edges
+    assert ("branch", "branch::b0::b1") in g.edges
+    assert ("branch", "branch::b1::b2") in g.edges
+    assert ("branch::b0::b1", "branch::m") in g.edges
+    assert ("branch::b1::b2", "branch::m") in g.edges
+    core = pipeline_to_core(pipe.steps, minimal_params())
+    assert len(core.neurons) == len(g.nodes)


### PR DESCRIPTION
## Summary
- add `pipeline_to_networkx` and `pipeline_to_core` utilities for visualising pipelines
- limit concurrent GPU branch execution with `max_gpu_concurrency`
- document and test pipeline graphs and GPU memory controls

## Testing
- `pytest tests/test_networkx_interop.py`
- `pytest tests/test_pipeline_graph_builder.py`
- `pytest tests/test_branch_container_concurrency.py`
- `pytest tests/test_interactive_debug.py`
- `pytest tests/test_auto_nb_training_loop.py`
- `pytest tests/test_semi_supervised_pairs_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_6891ac79219c832782cf4e21d6584059