### PR TITLE
feat: remote tier step scheduling and shard distribution

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -21,6 +21,7 @@ Each entry is listed under its section heading.
 - async_enabled
 - cache_dir
 - macro (step field allowing a list of sub-steps)
+- tier (step field selecting a remote hardware tier)
 
 ## sync
 - interval_ms

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ shards training data:
 - `shard_index` – the shard index handled by this process.
 - `offline` – disable remote downloads for fully local operation.
 - `encryption_key` – optional key used to encrypt on-disk dataset caches.
+When pipelines use parallel branches, the framework automatically assigns each
+branch a unique ``shard_index`` so dataset shards are distributed evenly across
+branches. This keeps parallel pipelines processing disjoint data without manual
+parameter tweaks.
 
 Logging behaviour is configured under the `logging` section:
 
@@ -679,6 +683,10 @@ devices. Specify a module implementing ``get_remote_tier`` under
 ``GrpcRemoteTier`` communicates with a gRPC service for acceleration. See
 [``docs/public_api.md``](docs/public_api.md#remote-hardware-plugins) for details
 on writing custom tiers.
+Individual pipeline steps can target these tiers by adding a ``tier`` field to
+their specification. When present, the step executes on the named remote tier
+while other steps continue locally, allowing seamless mixing of local CPU/GPU
+work and specialised hardware.
 A dedicated **Metrics** tab graphs loss, memory usage and other statistics in
 real time inside the browser. A **System Stats** tab displays current CPU and
 GPU memory usage. Another **Documentation** tab provides quick access to the

--- a/TODO.md
+++ b/TODO.md
@@ -612,16 +612,16 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [x] Implement Integrate hyperparameter search that plugs directly into the pipeline engine with CPU/GPU support.
    - [x] Add tests validating Integrate hyperparameter search that plugs directly into the pipeline engine.
    - [x] Document Integrate hyperparameter search that plugs directly into the pipeline engine in README and TUTORIAL.
-191. [ ] Schedule individual steps on remote hardware tiers seamlessly.
-   - [ ] Outline design for Schedule individual steps on remote hardware tiers seamlessly.
-   - [ ] Implement Schedule individual steps on remote hardware tiers seamlessly with CPU/GPU support.
-   - [ ] Add tests validating Schedule individual steps on remote hardware tiers seamlessly.
-   - [ ] Document Schedule individual steps on remote hardware tiers seamlessly in README and TUTORIAL.
-192. [ ] Distribute dataset shards across parallel pipelines.
-   - [ ] Outline design for Distribute dataset shards across parallel pipelines.
-   - [ ] Implement Distribute dataset shards across parallel pipelines with CPU/GPU support.
-   - [ ] Add tests validating Distribute dataset shards across parallel pipelines.
-   - [ ] Document Distribute dataset shards across parallel pipelines in README and TUTORIAL.
+191. [x] Schedule individual steps on remote hardware tiers seamlessly.
+   - [x] Outline design for Schedule individual steps on remote hardware tiers seamlessly.
+   - [x] Implement Schedule individual steps on remote hardware tiers seamlessly with CPU/GPU support.
+   - [x] Add tests validating Schedule individual steps on remote hardware tiers seamlessly.
+   - [x] Document Schedule individual steps on remote hardware tiers seamlessly in README and TUTORIAL.
+192. [x] Distribute dataset shards across parallel pipelines.
+   - [x] Outline design for Distribute dataset shards across parallel pipelines.
+   - [x] Implement Distribute dataset shards across parallel pipelines with CPU/GPU support.
+   - [x] Add tests validating Distribute dataset shards across parallel pipelines.
+   - [x] Document Distribute dataset shards across parallel pipelines in README and TUTORIAL.
 193. [ ] Estimate resource needs ahead of execution to inform the memory manager.
    - [ ] Outline design for Estimate resource needs ahead of execution to inform the memory manager.
    - [ ] Implement Estimate resource needs ahead of execution to inform the memory manager with CPU/GPU support.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -577,7 +577,9 @@ For specialised accelerators, implement a remote hardware plugin exposing a
 ``remote_hardware.tier_plugin`` in ``config.yaml``. During training the core
 will delegate heavy computations to the custom tier, enabling seamless use of
 non‑standard devices. Refer to [public_api.md](docs/public_api.md#remote-hardware-plugins)
-for the programming interface.
+for the programming interface. Individual pipeline steps can opt in to remote
+execution by including a ``tier`` field with the name of the registered tier.
+Steps without this field continue to run locally on CPU or GPU as usual.
 
 ## Project 3b – Remote Inference API (Medium)
 
@@ -1909,6 +1911,10 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
        dataloader=dataloader,
    )
    ```
+   When defining parallel ``branches`` in a pipeline, ``BranchContainer`` sets
+   ``num_shards`` to the number of branches and assigns each branch a unique
+   ``shard_index`` automatically. This distributes large datasets across
+   parallel pipelines with no extra configuration.
 4. **Create and train a MARBLE system** using a pandas dataframe:
    ```python
    import pandas as pd

--- a/pipeline_schema.py
+++ b/pipeline_schema.py
@@ -19,6 +19,7 @@ STEP_SCHEMA: dict = {
         "params": {"type": "object"},
         "plugin": {"type": "string"},
         "depends_on": {"type": "array", "items": {"type": "string"}},
+        "tier": {"type": "string"},
         "branches": {
             "type": "array",
             "items": {

--- a/remote_hardware/__init__.py
+++ b/remote_hardware/__init__.py
@@ -2,6 +2,7 @@
 
 from .base import RemoteTier
 from .grpc_tier import GrpcRemoteTier
+from .mock_tier import MockRemoteTier
 from .plugin_loader import load_remote_tier_plugin
 
-__all__ = ["RemoteTier", "GrpcRemoteTier", "load_remote_tier_plugin"]
+__all__ = ["RemoteTier", "GrpcRemoteTier", "MockRemoteTier", "load_remote_tier_plugin"]

--- a/remote_hardware/base.py
+++ b/remote_hardware/base.py
@@ -3,10 +3,20 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any
+
+import torch
 
 
 class RemoteTier(ABC):
-    """Abstract base class for remote compute tiers."""
+    """Abstract base class for remote compute tiers.
+
+    Subclasses provide the mechanism for connecting to an external piece of
+    hardware and executing work there.  In addition to offloading entire core
+    state blobs, tiers may be asked to run individual pipeline steps via
+    :meth:`run_step`.  Implementations should honour the provided ``device``
+    argument so steps execute on CPU or GPU consistently with local execution.
+    """
 
     name: str = "remote"
 
@@ -20,6 +30,12 @@ class RemoteTier(ABC):
     @abstractmethod
     def offload_core(self, core_bytes: bytes) -> bytes:
         """Send serialized core state and return processed state."""
+
+    @abstractmethod
+    def run_step(
+        self, step: dict, marble: Any | None, device: torch.device
+    ) -> Any:
+        """Execute ``step`` on the remote tier and return its result."""
 
     @abstractmethod
     def close(self) -> None:

--- a/remote_hardware/grpc_tier.py
+++ b/remote_hardware/grpc_tier.py
@@ -52,6 +52,15 @@ class GrpcRemoteTier(RemoteTier):
                 time.sleep(self.backoff_factor * (2**attempt))
                 self.connect()
 
+    def run_step(self, step, marble, device):
+        """Execute a pipeline step on the remote tier.
+
+        The gRPC tier only supports core offloading and therefore does not
+        implement step execution. Subclasses targeting specific services should
+        override this method.
+        """
+        raise NotImplementedError("gRPC tier does not support run_step")
+
     def close(self) -> None:
         """Close the gRPC channel."""
         if self.channel:

--- a/remote_hardware/mock_tier.py
+++ b/remote_hardware/mock_tier.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import torch
+
+from .base import RemoteTier
+import pipeline_plugins
+
+
+class MockRemoteTier(RemoteTier):
+    """Local execution tier used for tests and examples.
+
+    The tier pretends to be remote but simply executes the supplied step in the
+    current process. It respects the requested device so tests can exercise the
+    remote scheduling code paths without needing an actual service.
+    """
+
+    name = "mock"
+
+    def connect(self) -> None:  # pragma: no cover - nothing to do
+        pass
+
+    def offload_core(self, core_bytes: bytes) -> bytes:  # pragma: no cover
+        return core_bytes
+
+    def run_step(self, step: dict, marble: Any | None, device: torch.device) -> Any:
+        module_name = step.get("module")
+        func_name = step.get("func")
+        params = dict(step.get("params", {}))
+        params.setdefault("device", device.type)
+        if "plugin" in step:
+            plugin_cls = pipeline_plugins.get_plugin(step["plugin"])
+            plugin = plugin_cls(**params)
+            plugin.initialise(device=device, marble=marble)
+            try:
+                return plugin.execute(device=device, marble=marble)
+            finally:
+                plugin.teardown()
+        if func_name is None:
+            raise ValueError("Step missing 'func'")
+        module = importlib.import_module(module_name) if module_name else importlib.import_module("__main__")
+        func = getattr(module, func_name)
+        try:
+            return func(marble, **params)
+        except TypeError:
+            return func(**params)
+
+    def close(self) -> None:  # pragma: no cover - nothing to do
+        pass
+
+
+def get_remote_tier(address: str = "", **kwargs) -> MockRemoteTier:
+    return MockRemoteTier(address)

--- a/tests/test_parallel_dataset_shards.py
+++ b/tests/test_parallel_dataset_shards.py
@@ -1,0 +1,38 @@
+import asyncio
+import csv
+from pathlib import Path
+
+import torch
+
+from branch_container import BranchContainer
+from dataset_loader import load_dataset
+
+
+def load_ids(source, *, num_shards=None, shard_index=0, device="cpu"):
+    pairs = load_dataset(source, num_shards=num_shards, shard_index=shard_index)
+    ids = [int(a) for a, _ in pairs]
+    return torch.tensor(ids, device=device)
+
+
+def test_distribute_shards_across_branches(tmp_path):
+    csv_path = Path(tmp_path) / "data.csv"
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["input", "target"])
+        for i in range(4):
+            writer.writerow([i, i])
+    step = {
+        "name": "load_ids",
+        "module": __name__,
+        "func": "load_ids",
+        "params": {"source": str(csv_path)},
+    }
+    branches = [[step], [step]]
+    container = BranchContainer(branches)
+    results = asyncio.run(container.run(None))
+    ids0 = set(results[0].tolist())
+    ids1 = set(results[1].tolist())
+    assert ids0.isdisjoint(ids1)
+    assert ids0 | ids1 == {0, 1, 2, 3}
+    if torch.cuda.is_available():
+        assert results[0].device.type == results[1].device.type

--- a/tests/test_remote_step_scheduling.py
+++ b/tests/test_remote_step_scheduling.py
@@ -1,0 +1,50 @@
+import torch
+from pipeline import Pipeline
+from remote_hardware import load_remote_tier_plugin
+from marble_core import TIER_REGISTRY
+
+
+def add_tensors(a, b, *, device="cpu"):
+    return (a + b).to(device)
+
+
+def test_remote_step_cpu():
+    tier = load_remote_tier_plugin("remote_hardware.mock_tier")
+    TIER_REGISTRY[tier.name] = tier
+    steps = [
+        {
+            "name": "add",
+            "module": __name__,
+            "func": "add_tensors",
+            "params": {"a": torch.tensor(1), "b": torch.tensor(2)},
+            "tier": tier.name,
+        }
+    ]
+    pipe = Pipeline(steps)
+    out = pipe.execute()[0]
+    assert out.item() == 3
+    assert out.device.type == "cpu"
+
+
+def test_remote_step_gpu():
+    if not torch.cuda.is_available():
+        import pytest
+
+        pytest.skip("CUDA not available")
+    tier = load_remote_tier_plugin("remote_hardware.mock_tier")
+    TIER_REGISTRY[tier.name] = tier
+    a = torch.tensor(1, device="cuda")
+    b = torch.tensor(2, device="cuda")
+    steps = [
+        {
+            "name": "add",
+            "module": __name__,
+            "func": "add_tensors",
+            "params": {"a": a, "b": b},
+            "tier": tier.name,
+        }
+    ]
+    pipe = Pipeline(steps)
+    out = pipe.execute()[0]
+    assert out.item() == 3
+    assert out.device.type == "cuda"

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -53,6 +53,9 @@ pipeline:
     results, allowing complex workflows to be bundled into a single step within
     the YAML description. Macros honour dependencies, hooks and caching on both
     CPU and GPU devices.
+  tier: Each step may specify a ``tier`` referencing a registered remote
+    hardware backend. When provided the step runs on that tier instead of the
+    local CPU or GPU, enabling seamless offload to specialised accelerators.
 
 sync:
   interval_ms: Number of milliseconds between background tensor synchronization cycles


### PR DESCRIPTION
## Summary
- allow pipeline steps to target remote hardware tiers via new `tier` field
- auto-distribute dataset shards across parallel branch pipelines
- document remote tier step scheduling and automatic sharding

## Testing
- `pytest tests/test_remote_hardware_plugin.py -q`
- `pytest tests/test_branch_container_concurrency.py -q`
- `pytest tests/test_pipeline_step_validation.py -q`
- `pytest tests/test_remote_step_scheduling.py -q`
- `pytest tests/test_parallel_dataset_shards.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891affdaae48327a0a6184b1630051d