### PR TITLE
Add pipeline resource estimation and run profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,6 +903,38 @@ pipe.execute(max_gpu_concurrency=1)
 This control applies recursively to macro steps and nested branches ensuring
 consistent behaviour across complex pipelines.
 
+### Estimating Resource Needs
+
+``Pipeline.execute`` can plan allocations ahead of time. Steps may expose
+an estimator by defining a ``<func>_estimate`` helper or, for plugins,
+an ``estimate_memory`` method. During a pre-execution pass the pipeline
+calls these estimators and reports the predicted byte usage to a
+``MemoryManager``.
+
+```python
+from memory_manager import MemoryManager
+pipe = Pipeline([...])
+mgr = MemoryManager()
+pipe.execute(memory_manager=mgr)
+print(mgr.total_reserved())
+```
+
+### Saving Run Profiles
+
+Supplying ``run_profile_path`` writes a JSON file describing the exact
+step sequence.  The profiler records start and end times and the CPU or
+GPU device for each step, including those inside macros and branches.
+
+```python
+pipe.execute(run_profile_path="profile.json")
+```
+
+The resulting file lists entries like
+
+```json
+[{"step": "load", "start": 0.0, "end": 0.1, "device": "cpu"}]
+```
+
 ## PyTorch to MARBLE Conversion
 The project ships with a converter that maps PyTorch models into the MARBLE
 format. Run the CLI to transform a saved ``.pt`` file into JSON:

--- a/TODO.md
+++ b/TODO.md
@@ -622,16 +622,23 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [x] Implement Distribute dataset shards across parallel pipelines with CPU/GPU support.
    - [x] Add tests validating Distribute dataset shards across parallel pipelines.
    - [x] Document Distribute dataset shards across parallel pipelines in README and TUTORIAL.
-193. [ ] Estimate resource needs ahead of execution to inform the memory manager.
-   - [ ] Outline design for Estimate resource needs ahead of execution to inform the memory manager.
-   - [ ] Implement Estimate resource needs ahead of execution to inform the memory manager with CPU/GPU support.
-   - [ ] Add tests validating Estimate resource needs ahead of execution to inform the memory manager.
-   - [ ] Document Estimate resource needs ahead of execution to inform the memory manager in README and TUTORIAL.
-194. [ ] Save run profiles capturing the exact execution order.
-   - [ ] Outline design for Save run profiles capturing the exact execution order.
-   - [ ] Implement Save run profiles capturing the exact execution order with CPU/GPU support.
-   - [ ] Add tests validating Save run profiles capturing the exact execution order.
-   - [ ] Document Save run profiles capturing the exact execution order in README and TUTORIAL.
+193. [x] Estimate resource needs ahead of execution to inform the memory manager.
+   - [x] Outline design for Estimate resource needs ahead of execution to inform the memory manager.
+       - Added a recursive `Pipeline.estimate_resources` that invokes step-specific
+         estimators (`<func>_estimate` helpers or plugin `estimate_memory` methods)
+         before any execution. The pass aggregates byte requirements across macros
+         and branches and notifies a `MemoryManager` with device-aware sizes.
+   - [x] Implement Estimate resource needs ahead of execution to inform the memory manager with CPU/GPU support.
+   - [x] Add tests validating Estimate resource needs ahead of execution to inform the memory manager.
+   - [x] Document Estimate resource needs ahead of execution to inform the memory manager in README and TUTORIAL.
+194. [x] Save run profiles capturing the exact execution order.
+   - [x] Outline design for Save run profiles capturing the exact execution order.
+       - Introduced a thread-safe `RunProfiler` recording start/end times and device
+         for every step. `Pipeline.execute` integrates the profiler and writes
+         sorted JSON logs capturing the precise order of macros and branches.
+   - [x] Implement Save run profiles capturing the exact execution order with CPU/GPU support.
+   - [x] Add tests validating Save run profiles capturing the exact execution order.
+   - [x] Document Save run profiles capturing the exact execution order in README and TUTORIAL.
 195. [ ] Edit pipeline definitions interactively through the GUI.
    - [ ] Outline design for Edit pipeline definitions interactively through the GUI.
    - [ ] Implement Edit pipeline definitions interactively through the GUI with CPU/GPU support.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2730,3 +2730,35 @@ conversation pairs.
 
 The plugin uses GPU acceleration when available and falls back to CPU
 otherwise.
+
+## Project: Estimating Memory and Profiling Execution
+
+This project shows how to plan memory usage and record the exact order of
+executed steps.
+
+1. **Construct a tiny pipeline** that allocates a tensor and requests a
+   run profile:
+
+   ```python
+   from pipeline import Pipeline
+   from memory_manager import MemoryManager
+
+   steps = [
+       {"module": "tests.test_resource_estimation", "func": "make_tensor", "params": {"size": 8}, "name": "alloc"}
+   ]
+   pipe = Pipeline(steps)
+   mgr = MemoryManager()
+   pipe.execute(memory_manager=mgr, run_profile_path="profile.json")
+   print("Reserved bytes:", mgr.total_reserved())
+   ```
+
+2. **Inspect the profile** saved to ``profile.json``:
+
+   ```python
+   import json, pprint
+   with open("profile.json") as f:
+       pprint.pprint(json.load(f))
+   ```
+
+The profile lists each step with start and end times and the CPU or GPU
+device used during execution.

--- a/branch_container.py
+++ b/branch_container.py
@@ -47,6 +47,7 @@ class BranchContainer:
         *,
         branch_idx: int,
         num_branches: int,
+        pre_estimate: bool,
     ) -> Any:
         steps_with_device: List[dict] = []
         for s in steps:
@@ -64,7 +65,7 @@ class BranchContainer:
                 from pipeline import Pipeline
 
                 pipe = Pipeline(steps_with_device)
-                results = pipe.execute(marble=marble, **kwargs)
+                results = pipe.execute(marble=marble, pre_estimate=pre_estimate, **kwargs)
                 return results[-1] if results else None
 
             return await asyncio.to_thread(_execute)
@@ -79,6 +80,7 @@ class BranchContainer:
         marble: Any | None,
         *,
         max_gpu_concurrency: int | None = None,
+        pre_estimate: bool = True,
         **kwargs,
     ) -> List[Any]:
         devices = self._allocate_devices()
@@ -96,6 +98,7 @@ class BranchContainer:
                 sem,
                 branch_idx=idx,
                 num_branches=len(self.branches),
+                pre_estimate=pre_estimate,
             )
             for idx, (steps, dev) in enumerate(zip(self.branches, devices))
         ]

--- a/run_profiler.py
+++ b/run_profiler.py
@@ -1,0 +1,50 @@
+import json, threading, time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+import torch
+
+@dataclass
+class RunRecord:
+    step: str
+    start: float
+    end: float
+    device: str
+
+class RunProfiler:
+    """Record execution order of pipeline steps."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path = Path(path) if path else None
+        if self.path:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.records: List[RunRecord] = []
+        self._lock = threading.Lock()
+        self._current: dict[int, tuple[str, float, str]] = {}
+
+    def start(self, step: str, device: torch.device) -> None:
+        if device.type == "cuda" and torch.cuda.is_available():
+            torch.cuda.synchronize()
+        start = time.perf_counter()
+        tid = threading.get_ident()
+        with self._lock:
+            self._current[tid] = (step, start, device.type)
+
+    def end(self) -> None:
+        tid = threading.get_ident()
+        if tid not in self._current:
+            return
+        step, start, dev = self._current.pop(tid)
+        if dev == "cuda" and torch.cuda.is_available():
+            torch.cuda.synchronize()
+        end = time.perf_counter()
+        with self._lock:
+            self.records.append(RunRecord(step, start, end, dev))
+
+    def save(self) -> None:
+        if not self.path:
+            return
+        data = [r.__dict__ for r in sorted(self.records, key=lambda r: r.start)]
+        with open(self.path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)

--- a/tests/test_resource_estimation.py
+++ b/tests/test_resource_estimation.py
@@ -1,0 +1,34 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import torch
+import pytest
+from pipeline import Pipeline
+from memory_manager import MemoryManager
+
+
+def make_tensor(size: int, *, device: str = "cpu"):
+    return torch.zeros(size, device=device)
+
+
+def make_tensor_estimate(size: int, *, device: str = "cpu"):
+    return size * torch.tensor(0.0, device=device).element_size()
+
+
+def test_pipeline_memory_estimation_cpu():
+    mgr = MemoryManager()
+    pipe = Pipeline([
+        {"module": __name__, "func": "make_tensor", "params": {"size": 4}, "name": "alloc"}
+    ])
+    pipe.execute(memory_manager=mgr)
+    assert mgr.total_reserved() == 4 * torch.tensor(0.0).element_size()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_pipeline_memory_estimation_gpu():
+    mgr = MemoryManager()
+    pipe = Pipeline([
+        {"module": __name__, "func": "make_tensor", "params": {"size": 4}, "name": "alloc"}
+    ])
+    pipe.execute(memory_manager=mgr)
+    assert mgr.total_reserved() == 4 * torch.tensor(0.0).element_size()

--- a/tests/test_run_profile.py
+++ b/tests/test_run_profile.py
@@ -1,0 +1,27 @@
+import os, sys, json
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import torch
+import pytest
+from pipeline import Pipeline
+
+
+def step_a(*, device: str = "cpu"):
+    return torch.tensor(1, device=device)
+
+
+def step_b(*, device: str = "cpu"):
+    return torch.tensor(2, device=device)
+
+
+def test_run_profile_records_order(tmp_path):
+    profile = tmp_path / "profile.json"
+    pipe = Pipeline([
+        {"module": __name__, "func": "step_a", "name": "first"},
+        {"module": __name__, "func": "step_b", "name": "second"},
+    ])
+    pipe.execute(run_profile_path=profile)
+    data = json.loads(profile.read_text())
+    assert [r["step"] for r in data] == ["first", "second"]
+    expected = "cuda" if torch.cuda.is_available() else "cpu"
+    assert all(r["device"] == expected for r in data)


### PR DESCRIPTION
## Summary
- estimate step memory requirements ahead of execution and notify MemoryManager
- capture exact step execution order through a new RunProfiler and pipeline hooks
- document resource estimation and run profiling in README and TUTORIAL

## Testing
- `pytest tests/test_resource_estimation.py -q`
- `pytest tests/test_run_profile.py -q`
- `pytest tests/test_pipeline_macro_rollback.py -q`
- `pytest tests/test_branch_container_concurrency.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891b4500c40832797917d8d9dca2aaa