### PR TITLE
Add Kuzu graph database interface

### DIFF
--- a/kuzu_interface.py
+++ b/kuzu_interface.py
@@ -1,0 +1,175 @@
+"""High-level interface for interacting with a persistent Kùzu graph database.
+
+This module provides a :class:`KuzuGraphDatabase` class that wraps the
+:mod:`kuzu` Python API and exposes convenience methods for common graph
+operations. All queries use the Cypher query language supported by Kùzu.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import kuzu
+
+
+class KuzuGraphDatabase:
+    """A convenience wrapper around :mod:`kuzu` for persistent graph storage.
+
+    Parameters
+    ----------
+    db_path:
+        Filesystem path to the database. The path should point to a location
+        that does not already exist; a new database will be created there.
+        To reopen an existing database simply pass the same path again.
+    """
+
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+        self._db = kuzu.Database(db_path)
+        self._conn = kuzu.Connection(self._db)
+
+    # ------------------------------------------------------------------
+    # context management utilities
+    # ------------------------------------------------------------------
+    def __enter__(self) -> "KuzuGraphDatabase":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        self.close()
+
+    def close(self) -> None:
+        """Close the underlying connection."""
+        if hasattr(self, "_conn") and self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    # ------------------------------------------------------------------
+    # schema operations
+    # ------------------------------------------------------------------
+    def create_node_table(
+        self, label: str, columns: Dict[str, str], primary_key: str
+    ) -> None:
+        """Create a node table with ``label`` and ``columns``.
+
+        ``columns`` maps column names to Kùzu data types. ``primary_key`` must
+        be one of the column names.
+        """
+
+        cols = ", ".join(f"{name} {dtype}" for name, dtype in columns.items())
+        query = f"CREATE NODE TABLE {label}({cols}, PRIMARY KEY({primary_key}));"
+        self.execute(query)
+
+    def create_relationship_table(
+        self,
+        rel_name: str,
+        src_table: str,
+        dst_table: str,
+        columns: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """Create a relationship table.
+
+        Parameters
+        ----------
+        rel_name:
+            Name of the relationship type.
+        src_table:
+            Source node table.
+        dst_table:
+            Destination node table.
+        columns:
+            Optional mapping of additional relationship properties and their
+            data types.
+        """
+
+        cols = (
+            ", " + ", ".join(f"{k} {v}" for k, v in columns.items()) if columns else ""
+        )
+        query = f"CREATE REL TABLE {rel_name}(FROM {src_table} TO {dst_table}{cols});"
+        self.execute(query)
+
+    # ------------------------------------------------------------------
+    # data manipulation helpers
+    # ------------------------------------------------------------------
+    def add_node(self, label: str, properties: Dict[str, Any]) -> None:
+        """Insert a node with ``label`` and ``properties``."""
+        placeholders = ", ".join(f"{k}: ${k}" for k in properties)
+        query = f"CREATE (:{label} {{{placeholders}}});"
+        self.execute(query, properties)
+
+    def add_relationship(
+        self,
+        src_label: str,
+        src_key: str,
+        src_value: Any,
+        rel_type: str,
+        dst_label: str,
+        dst_key: str,
+        dst_value: Any,
+        properties: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Create a relationship between two existing nodes."""
+
+        prop_str = (
+            " {" + ", ".join(f"{k}: ${k}" for k in properties) + "}"
+            if properties
+            else ""
+        )
+        params = {"src_val": src_value, "dst_val": dst_value}
+        if properties:
+            params.update(properties)
+        query = (
+            f"MATCH (a:{src_label} {{{src_key}: $src_val}}), "
+            f"(b:{dst_label} {{{dst_key}: $dst_val}}) "
+            f"CREATE (a)-[:{rel_type}{prop_str}]->(b);"
+        )
+        self.execute(query, params)
+
+    def update_node(
+        self, label: str, key: str, key_val: Any, updates: Dict[str, Any]
+    ) -> None:
+        """Update properties of a node matching ``key`` = ``key_val``."""
+        set_clause = ", ".join(f"n.{k} = ${k}" for k in updates)
+        params = {"key_val": key_val, **updates}
+        query = f"MATCH (n:{label} {{{key}: $key_val}}) SET {set_clause};"
+        self.execute(query, params)
+
+    def delete_node(self, label: str, key: str, key_val: Any) -> None:
+        """Delete a node and all its relationships."""
+        query = f"MATCH (n:{label} {{{key}: $val}}) DETACH DELETE n;"
+        self.execute(query, {"val": key_val})
+
+    def delete_relationship(
+        self,
+        src_label: str,
+        src_key: str,
+        src_val: Any,
+        rel_type: str,
+        dst_label: str,
+        dst_key: str,
+        dst_val: Any,
+    ) -> None:
+        """Delete a relationship between two nodes."""
+        params = {"src_val": src_val, "dst_val": dst_val}
+        query = (
+            f"MATCH (a:{src_label} {{{src_key}: $src_val}})-"
+            f"[r:{rel_type}]->(b:{dst_label} {{{dst_key}: $dst_val}}) DELETE r;"
+        )
+        self.execute(query, params)
+
+    # ------------------------------------------------------------------
+    # query interface
+    # ------------------------------------------------------------------
+    def execute(
+        self, query: str, parameters: Optional[Dict[str, Any]] = None
+    ) -> List[Dict[str, Any]]:
+        """Execute ``query`` with optional ``parameters`` and return rows.
+
+        Returns a list of dictionaries mapping column names to values.
+        """
+
+        result = self._conn.execute(query, parameters or {})
+        cols = result.get_column_names()
+        return [dict(zip(cols, row)) for row in result]
+
+
+__all__ = ["KuzuGraphDatabase"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,6 +65,7 @@ jsonschema-specifications==2025.4.1
 jsonschema==4.25.0
 jupyterlab_widgets==3.0.15
 kiwisolver==1.4.8
+kuzu==0.11.1
 markdown-it-py==3.0.0
 matplotlib-inline==0.1.7
 matplotlib==3.10.3

--- a/tests/test_kuzu_interface.py
+++ b/tests/test_kuzu_interface.py
@@ -1,0 +1,64 @@
+from kuzu_interface import KuzuGraphDatabase
+
+
+def setup_db(tmp_path):
+    db_path = tmp_path / "kuzu_db"
+    db = KuzuGraphDatabase(str(db_path))
+    db.create_node_table("Person", {"name": "STRING", "age": "INT64"}, "name")
+    db.create_node_table("City", {"name": "STRING"}, "name")
+    db.create_relationship_table("LIVES_IN", "Person", "City", {"since": "INT64"})
+    return db, db_path
+
+
+def test_create_and_query(tmp_path):
+    db, _ = setup_db(tmp_path)
+    db.add_node("Person", {"name": "Alice", "age": 30})
+    db.add_node("City", {"name": "Wonderland"})
+    db.add_relationship(
+        "Person",
+        "name",
+        "Alice",
+        "LIVES_IN",
+        "City",
+        "name",
+        "Wonderland",
+        {"since": 2024},
+    )
+    rows = db.execute(
+        "MATCH (p:Person)-[r:LIVES_IN]->(c:City) "
+        "RETURN p.name AS pname, p.age AS age, c.name AS city, r.since AS since;"
+    )
+    assert rows == [{"pname": "Alice", "age": 30, "city": "Wonderland", "since": 2024}]
+
+
+def test_update_and_delete(tmp_path):
+    db, _ = setup_db(tmp_path)
+    db.add_node("Person", {"name": "Bob", "age": 25})
+    db.update_node("Person", "name", "Bob", {"age": 26})
+    rows = db.execute(
+        "MATCH (p:Person {name:$name}) RETURN p.age AS age", {"name": "Bob"}
+    )
+    assert rows[0]["age"] == 26
+    db.add_node("City", {"name": "NY"})
+    db.add_relationship("Person", "name", "Bob", "LIVES_IN", "City", "name", "NY")
+    db.delete_relationship("Person", "name", "Bob", "LIVES_IN", "City", "name", "NY")
+    rows = db.execute(
+        "MATCH (:Person {name:$name})-[:LIVES_IN]->() RETURN count(*) AS cnt",
+        {"name": "Bob"},
+    )
+    assert rows[0]["cnt"] == 0
+    db.delete_node("Person", "name", "Bob")
+    rows = db.execute(
+        "MATCH (p:Person {name:$name}) RETURN count(*) AS cnt", {"name": "Bob"}
+    )
+    assert rows[0]["cnt"] == 0
+
+
+def test_persistence(tmp_path):
+    db, path = setup_db(tmp_path)
+    db.add_node("Person", {"name": "Eve", "age": 22})
+    db.close()
+    db2 = KuzuGraphDatabase(str(path))
+    rows = db2.execute("MATCH (p:Person) RETURN p.name AS name")
+    assert {"name": "Eve"} in rows
+    db2.close()


### PR DESCRIPTION
## Summary
- add `KuzuGraphDatabase` wrapper for persistent Kùzu stores
- exercise node/relationship creation, updates and persistence in tests
- include kuzu dependency in requirements

## Testing
- `pre-commit run --files kuzu_interface.py tests/test_kuzu_interface.py requirements.txt`
- `pytest tests/test_kuzu_interface.py`


------
https://chatgpt.com/codex/tasks/task_e_6891c49650bc8327adb38098ebc40879