### PR TITLE
feat: add kuzu-backed persistent hybrid memory

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -318,6 +318,7 @@ Each entry is listed under its section heading.
 ## hybrid_memory
 - vector_store_path
 - symbolic_store_path
+- kuzu_store_path
 - max_entries
 
 

--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -10,3 +10,4 @@ No failing tests.
 - tests/test_streamlit_playground.py: multiple failures (TypeError: Brain.__init__() got an unexpected keyword argument 'dream_replay_buffer_size')
 - tests/test_streamlit_gui.py::test_pipeline_tab_add_and_run: IndexError: list index out of range
 - tests/test_streamlit_gui.py::test_pipeline_reorder_and_remove: IndexError: list index out of range
+- tests/test_hybrid_memory_kuzu.py::test_kuzu_memory_separate_from_topology: RuntimeError: Catalog exception: function DATETIME does not exist [resolved]

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1851,6 +1851,7 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
    hybrid_memory:
      vector_store_path: "vectors.pkl"
      symbolic_store_path: "symbols.pkl"
+     kuzu_store_path: null
    ```
 2. **Create the training script.** It saves a few values and then queries them:
    ```python
@@ -1861,6 +1862,7 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
    cfg["hybrid_memory"] = {
        "vector_store_path": "vectors.pkl",
        "symbolic_store_path": "symbols.pkl",
+       "kuzu_store_path": "memory.kuzu",  # use Kùzu for persistence
    }
    marble = create_marble_from_config(cfg)
    marble.hybrid_memory.store("a", 1.0)

--- a/config.yaml
+++ b/config.yaml
@@ -341,6 +341,7 @@ memory_system:
 hybrid_memory:
   vector_store_path: "vector_store.pkl"
   symbolic_store_path: "symbolic_memory.pkl"
+  kuzu_store_path: null
   max_entries: 1000
 data_compressor:
   compression_level: 6

--- a/kuzu_memory_tier.py
+++ b/kuzu_memory_tier.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+"""Persistent hybrid memory storage backed by a Kùzu graph database."""
+
+from typing import Any, List, Tuple
+from datetime import datetime, UTC
+
+import numpy as np
+
+from kuzu_interface import KuzuGraphDatabase
+
+
+class KuzuMemoryTier:
+    """Store key/value pairs and embedding vectors in a Kùzu database.
+
+    Each memory entry is stored as a node in the database with properties for
+    the key, associated value, embedding vector and insertion timestamp. The
+    class offers similarity search by loading all vectors into memory and
+    computing cosine similarity in numpy. ``forget_old`` removes entries beyond
+    a specified limit based on their timestamp."""
+
+    def __init__(self, db_path: str, dim: int) -> None:
+        self.db = KuzuGraphDatabase(db_path)
+        self.dim = dim
+        self._init_schema()
+
+    # ------------------------------------------------------------------
+    # schema management
+    # ------------------------------------------------------------------
+    def _init_schema(self) -> None:
+        """Ensure the ``Memory`` node table exists."""
+        try:
+            self.db.create_node_table(
+                "Memory",
+                {
+                    "key": "STRING",
+                    "value": "DOUBLE",
+                    "vector": "DOUBLE[]",
+                    "timestamp": "STRING",
+                },
+                "key",
+            )
+        except Exception:
+            # table already present
+            pass
+
+    # ------------------------------------------------------------------
+    # data manipulation
+    # ------------------------------------------------------------------
+    def add(self, key: Any, value: float, vector: np.ndarray) -> None:
+        """Insert or update a memory entry."""
+        if vector.shape[0] != self.dim:
+            vec = vector.reshape(-1)[: self.dim]
+            if vec.shape[0] < self.dim:
+                vec = np.pad(vec, (0, self.dim - vec.shape[0]))
+            vector = vec
+        params = {
+            "key": key,
+            "value": float(value),
+            "vector": vector.astype(float).tolist(),
+            "ts": datetime.now(UTC).isoformat(),
+        }
+        self.db.execute(
+            "MERGE (m:Memory {key: $key}) "
+            "SET m.value = $value, m.vector = $vector, m.timestamp = $ts;",
+            params,
+        )
+
+    def retrieve(self, key: Any) -> Any:
+        """Return the value stored for ``key`` or ``None``."""
+        rows = self.db.execute(
+            "MATCH (m:Memory {key: $key}) RETURN m.value AS value;", {"key": key}
+        )
+        if rows:
+            return rows[0]["value"]
+        return None
+
+    def query(self, vector: np.ndarray, top_k: int = 3) -> List[Tuple[Any, Any]]:
+        """Return ``top_k`` keys with highest cosine similarity to ``vector``."""
+        rows = self.db.execute(
+            "MATCH (m:Memory) RETURN m.key AS key, m.value AS value, m.vector AS vector;"
+        )
+        if not rows:
+            return []
+        vec = vector.astype(float).reshape(1, -1)
+        mat = np.array([r["vector"] for r in rows], dtype=float)
+        denom = np.linalg.norm(mat, axis=1) * np.linalg.norm(vec)
+        denom = np.where(denom == 0, 1.0, denom)
+        sims = (mat @ vec.T).flatten() / denom
+        idx = np.argsort(sims)[::-1][:top_k]
+        return [(rows[i]["key"], rows[i]["value"]) for i in idx]
+
+    def forget_old(self, max_entries: int) -> None:
+        """Trim oldest entries to keep at most ``max_entries`` records."""
+        rows = self.db.execute(
+            "MATCH (m:Memory) RETURN m.key AS key ORDER BY m.timestamp;"
+        )
+        if len(rows) <= max_entries:
+            return
+        excess = rows[:-max_entries]
+        for r in excess:
+            self.db.delete_node("Memory", "key", r["key"])
+
+
+__all__ = ["KuzuMemoryTier"]

--- a/tests/test_hybrid_memory_kuzu.py
+++ b/tests/test_hybrid_memory_kuzu.py
@@ -1,0 +1,24 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from hybrid_memory import HybridMemory
+from topology_kuzu import TopologyKuzuTracker
+from tests.test_core_functions import minimal_params
+
+
+def test_kuzu_memory_separate_from_topology(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    topo_path = tmp_path / "topology.kuzu"
+    mem_path = tmp_path / "memory.kuzu"
+    TopologyKuzuTracker(core, str(topo_path))
+    hm = HybridMemory(core, nb, kuzu_path=str(mem_path))
+    hm.store("a", 1.0)
+    res = hm.retrieve(1.0, top_k=1)
+    assert res and res[0][0] == "a"
+    assert topo_path.exists() and mem_path.exists()
+    assert topo_path != mem_path

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -817,6 +817,13 @@ hybrid_memory:
     directory.
   symbolic_store_path: File used to persist key/value pairs and timestamps.
     This mirrors the vector store so recalls can return the original data.
+  kuzu_store_path: Optional path to a Kùzu graph database file used to persist
+    all memory entries. When provided, both ``vector_store_path`` and
+    ``symbolic_store_path`` are ignored and the hybrid memory stores nodes in
+    the specified Kùzu database. Each entry becomes a node with the key, value,
+    embedding vector and insertion timestamp as properties. The path must be
+    distinct from the one used for the topology tracker so both databases can
+    operate simultaneously without interference.
   max_entries: Maximum number of items retained in the vector and symbolic
     stores. When the count exceeds this limit the oldest entries are removed
     to keep memory usage bounded.


### PR DESCRIPTION
## Summary
- allow HybridMemory to persist in a Kùzu graph instead of pickle files
- document new `hybrid_memory.kuzu_store_path` parameter and tutorial usage
- add tests for Kùzu memory tier alongside existing topology graph

## Testing
- `pytest tests/test_hybrid_memory.py`
- `pytest tests/test_hybrid_memory_eviction.py`
- `pytest tests/test_hybrid_memory_kuzu.py`


------
https://chatgpt.com/codex/tasks/task_e_6891cd59b6508327a176717bc368b5cc