### PR TITLE
feat: enable training from configurable Kùzu graphs

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -4,11 +4,18 @@ This file enumerates every parameter that can be specified in `config.yaml`.
 Each entry is listed under its section heading.
 
 ## dataset
+- source
 - num_shards
 - shard_index
 - offline
 - encryption_key
 - cache_url: Base URL of ``DatasetCacheServer`` to fetch cached files from.
+- use_kuzu_graph
+- kuzu_graph.db_path
+- kuzu_graph.query
+- kuzu_graph.input_column
+- kuzu_graph.target_column
+- kuzu_graph.limit
 
 ## logging
 - structured
@@ -453,6 +460,13 @@ Each entry is listed under its section heading.
 - shard_index
 - offline
 - encryption_key
+- source
+- use_kuzu_graph
+- kuzu_graph.db_path
+- kuzu_graph.query
+- kuzu_graph.input_column
+- kuzu_graph.target_column
+- kuzu_graph.limit
 
 ## distillation
 - enabled

--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ HTTP endpoints so that remote workers receive identical copies.  When combined
 with the high level ``dataset_loader`` utility, datasets can be prefetched,
 sharded and cached transparently using a memory pool and optional metrics
 visualisation.
+It now also supports loading training pairs directly from a persistent Kùzu
+graph via ``load_kuzu_graph`` or the ``dataset.use_kuzu_graph`` configuration
+toggle, enabling graph-structured data to feed the model without conversion.
 
 Several helper pipelines leverage ``BitTensorDataset`` to train various
 learning paradigms on arbitrary Python objects, including ``AutoencoderPipeline``,

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1913,6 +1913,27 @@ Run `python project26_cip.py` to watch concepts emerge through blending.
        dataloader=dataloader,
    )
    ```
+5. **Load training data from a Kùzu graph** instead of a flat dataset:
+   ```python
+   from dataset_loader import load_kuzu_graph
+   from kuzu_interface import KuzuGraphDatabase
+
+   # Build a small graph with input/target properties
+   db = KuzuGraphDatabase("training.kuzu")
+   db.create_node_table("Sample", {"id": "INT64", "input": "DOUBLE", "target": "DOUBLE"}, "id")
+   db.add_node("Sample", {"id": 1, "input": 0.1, "target": 0.2})
+   db.add_node("Sample", {"id": 2, "input": 0.2, "target": 0.4})
+
+   pairs = load_kuzu_graph(
+       "training.kuzu",
+       "MATCH (s:Sample) RETURN s.input AS input, s.target AS target",
+       dataloader=dataloader,
+   )
+   ```
+   The loader executes any Cypher ``query`` and converts the result rows into
+   ``(input, target)`` tuples. Use this when your training data already resides
+   in a Kùzu graph.
+
    When defining parallel ``branches`` in a pipeline, ``BranchContainer`` sets
    ``num_shards`` to the number of branches and assigns each branch a unique
    ``shard_index`` automatically. This distributes large datasets across

--- a/config.yaml
+++ b/config.yaml
@@ -5,11 +5,19 @@
 # ===================
 
 dataset:
+  source: null           # Local path or URL of the default dataset
   num_shards: 1       # Total shards for distributed datasets
   shard_index: 0      # Index of this shard for multi-node setups
   offline: false      # Disable remote dataset downloads
   encryption_key: null  # Optional key for dataset encryption
   cache_url: null      # Optional URL of DatasetCacheServer
+  use_kuzu_graph: false  # When true, load training data from a Kùzu graph instead of ``source``
+  kuzu_graph:
+    db_path: "training.kuzu"  # Filesystem path of the Kùzu database containing training data
+    query: "MATCH (n:Sample) RETURN n.input AS input, n.target AS target"  # Cypher query returning training pairs
+    input_column: "input"     # Column name for input values
+    target_column: "target"   # Column name for target values
+    limit: null               # Optional limit on number of pairs loaded from the graph
 logging:
   structured: false   # Output logs in JSON format when true
   log_file: "marble.log"  # Path of the main log file

--- a/config_schema.py
+++ b/config_schema.py
@@ -44,6 +44,18 @@ CONFIG_SCHEMA = {
                 "shard_index": {"type": "integer", "minimum": 0},
                 "offline": {"type": "boolean"},
                 "encryption_key": {"type": ["string", "null"]},
+                "source": {"type": ["string", "null"]},
+                "use_kuzu_graph": {"type": "boolean"},
+                "kuzu_graph": {
+                    "type": "object",
+                    "properties": {
+                        "db_path": {"type": "string"},
+                        "query": {"type": "string"},
+                        "input_column": {"type": "string"},
+                        "target_column": {"type": "string"},
+                        "limit": {"type": ["integer", "null"], "minimum": 1},
+                    },
+                },
             },
         },
         "logging": {

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -40,6 +40,8 @@ This document lists the main classes and functions intended for external use.
 - `dataset_loader.load_dataset`
 - `dataset_loader.prefetch_dataset`
 - `dataset_loader.export_dataset`
+- `dataset_loader.load_kuzu_graph`
+- `dataset_loader.load_training_data_from_config`
 - `dataset_versioning.create_version`
 - `dataset_versioning.apply_version`
 - `dataset_replication.replicate_dataset`

--- a/tests/test_kuzu_graph_loader.py
+++ b/tests/test_kuzu_graph_loader.py
@@ -1,0 +1,40 @@
+from dataset_loader import load_kuzu_graph, load_training_data_from_config
+from kuzu_interface import KuzuGraphDatabase
+
+
+def build_graph(path):
+    db = KuzuGraphDatabase(path)
+    db.create_node_table(
+        "Sample",
+        {"id": "INT64", "input": "DOUBLE", "target": "DOUBLE"},
+        "id",
+    )
+    db.add_node("Sample", {"id": 1, "input": 0.1, "target": 0.2})
+    db.add_node("Sample", {"id": 2, "input": 0.2, "target": 0.4})
+    return db
+
+
+def test_load_kuzu_graph(tmp_path):
+    db_path = tmp_path / "train.kuzu"
+    db = build_graph(str(db_path))
+    db.close()
+    pairs = load_kuzu_graph(
+        str(db_path),
+        "MATCH (s:Sample) RETURN s.input AS input, s.target AS target",
+    )
+    assert pairs == [(0.1, 0.2), (0.2, 0.4)]
+
+
+def test_load_training_data_from_config_kuzu(tmp_path):
+    db_path = tmp_path / "train.kuzu"
+    db = build_graph(str(db_path))
+    db.close()
+    cfg = {
+        "use_kuzu_graph": True,
+        "kuzu_graph": {
+            "db_path": str(db_path),
+            "query": "MATCH (s:Sample) RETURN s.input AS input, s.target AS target",
+        },
+    }
+    pairs = load_training_data_from_config(cfg)
+    assert pairs == [(0.1, 0.2), (0.2, 0.4)]

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -10,6 +10,10 @@ are automatically filled with the defaults from `config.yaml`, allowing small
 YAML snippets to override just the options you need.
 
 dataset:
+  source: Path or URL of the primary training dataset. Accepts local filesystem
+    paths as well as ``http://`` or ``https://`` URLs. When ``use_kuzu_graph`` is
+    ``true`` this field is ignored. Set to ``null`` when supplying data
+    programmatically.
   num_shards: Number of shards the training dataset is split into. When greater
     than ``1`` each training worker should set ``shard_index`` to a unique value
     between ``0`` and ``num_shards - 1`` so that only a subset of samples is
@@ -24,6 +28,25 @@ dataset:
   cache_url: Base URL of a running ``DatasetCacheServer``. When set, files are
     fetched from the cache first and only downloaded from the original source if
     missing. This keeps datasets synchronised across multiple machines.
+  use_kuzu_graph: Toggle that switches the training input to a Kùzu graph rather
+    than a flat dataset. When ``true`` the ``kuzu_graph`` subsection must be
+    provided and the ``source`` field above is ignored. This allows Marble to
+    train directly from graph-structured data stored in a Kùzu database without
+    intermediate export steps.
+  kuzu_graph:
+    db_path: Filesystem location of the Kùzu database storing the training
+      graph. The database is opened in read-only mode so it must already exist
+      and contain the relevant nodes or relationships.
+    query: Cypher query returning training samples. The query should yield at
+      least two columns representing input and target values. For example:
+      ``MATCH (s:Sample) RETURN s.input AS input, s.label AS target``.
+    input_column: Name of the column in the query result used as the model
+      input. Defaults to ``"input"`` if omitted.
+    target_column: Name of the column providing the expected output for each
+      sample. Defaults to ``"target"``.
+    limit: Optional integer restricting how many rows are read from the graph.
+      ``null`` reads the entire result set. Use this to cap training size during
+      experiments or when only a subset is needed.
   hf_token: Path to a file containing your Hugging Face API token. When the
     file exists Marble automatically logs in before downloading datasets or
     models. The default location is ``~/.cache/marble/hf_token``.


### PR DESCRIPTION
## Summary
- add `load_kuzu_graph` and `load_training_data_from_config` utilities so models can train directly from Kùzu graphs
- expand dataset configuration and schema for optional Kùzu graph sources and document new options
- cover Kùzu graph loading with dedicated tests and tutorial updates

## Testing
- `pytest tests/test_kuzu_graph_loader.py -q`
- `pytest tests/test_dataset_loader.py -q`
- `pytest tests/test_dataset_events.py -q`
- `pytest tests/test_dataset_event_notifications.py -q`
- `pytest tests/test_prefetch_integration.py -q`
- `pytest tests/test_memory_manager_integration.py -q`
- `pytest tests/test_pipeline_summary.py -q`
- `pytest tests/test_streaming_csv_loader.py -q`
- `pytest tests/test_parallel_dataset_shards.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891d11dc58883278457c7f27ead162a