### PR TITLE
Add MARBLE-specific CUDA activation kernel with CPU fallback and tests

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -3031,3 +3031,37 @@ databases.
 The first call performs a web search while the second queries the Kùzu database.
 The ``ToolManagerPlugin`` decides which tool to use without manual intervention.
 
+
+## Project: Accelerated MARBLE Activation with a Custom CUDA Kernel
+
+This project demonstrates the `marble_activation` function, which uses a
+hand-crafted CUDA kernel when a GPU is available and falls back to a pure
+PyTorch implementation on CPU. The activation applies a piecewise linear
+transformation that is heavily used in MARBLE's neuromorphic processing
+pipelines.
+
+1. **Download a real dataset.** Here we use the classic Iris dataset:
+   ```bash
+   wget https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data -O iris.csv
+   ```
+2. **Load the data and apply the activation.**
+   ```python
+   import pandas as pd
+   import torch
+   from marble_activation_kernel import marble_activation
+
+   df = pd.read_csv("iris.csv", header=None)
+   features = torch.tensor(df.iloc[:, :4].values, dtype=torch.float32)
+   activated = marble_activation(features, threshold=1.0, a=1.5, b=0.1, c=0.5)
+   print("Activated sample:", activated[:5])
+   ```
+3. **Run on the GPU if available.** The same function automatically compiles
+   and dispatches the CUDA kernel:
+   ```python
+   if torch.cuda.is_available():
+       activated_gpu = marble_activation(features.cuda(), threshold=1.0, a=1.5, b=0.1, c=0.5)
+       print("GPU activation sample:", activated_gpu[:5])
+   ```
+
+This project verifies that the MARBLE-specific CUDA kernel operates correctly on
+real data and seamlessly integrates with the rest of the framework.

--- a/marble_activation_kernel.py
+++ b/marble_activation_kernel.py
@@ -1,0 +1,118 @@
+import torch
+from functools import lru_cache
+from torch.utils.cpp_extension import load_inline
+
+__all__ = ["marble_activation"]
+
+
+@lru_cache(maxsize=None)
+def _load_kernel():
+    """Compile and return the MARBLE activation CUDA extension.
+
+    Returns ``None`` when CUDA is unavailable so that CPU execution is still
+    possible without raising an error.
+    """
+    if not torch.cuda.is_available():
+        return None
+    return load_inline(
+        name="marble_activation_cuda",
+        cpp_sources="""
+#include <torch/extension.h>
+
+void marble_activation_launcher(const at::Tensor& x, at::Tensor& y,
+                                float threshold, float a, float b, float c);
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("marble_activation_launcher", &marble_activation_launcher,
+          "MARBLE custom activation forward launcher");
+}
+""",
+        cuda_sources="""
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <torch/extension.h>
+
+__global__ void marble_activation_kernel(const float* x, float* y,
+                                         float threshold, float a, float b, float c,
+                                         long n) {
+    long idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        float v = x[idx];
+        y[idx] = v > threshold ? a * v + b : c * v;
+    }
+}
+
+void marble_activation_launcher(const at::Tensor& x, at::Tensor& y,
+                                float threshold, float a, float b, float c) {
+    const long n = x.numel();
+    const int threads = 256;
+    const int blocks = (n + threads - 1) / threads;
+    marble_activation_kernel<<<blocks, threads>>>(x.data_ptr<float>(),
+                                                  y.data_ptr<float>(),
+                                                  threshold, a, b, c, n);
+}
+""",
+        functions=["marble_activation_launcher"],
+        verbose=False,
+    )
+
+
+def _marble_activation_forward(x: torch.Tensor, threshold: float, a: float, b: float, c: float) -> torch.Tensor:
+    """Forward computation of the MARBLE activation.
+
+    Uses a custom CUDA kernel when running on GPU, otherwise falls back to a
+    pure PyTorch implementation. The operation applies a piecewise linear
+    transformation tailored to MARBLE's neuromorphic processing style.
+    """
+    if x.device.type == "cuda":
+        module = _load_kernel()
+        if module is None:
+            raise RuntimeError("CUDA not available for MARBLE activation kernel")
+        y = torch.empty_like(x)
+        module.marble_activation_launcher(x.contiguous(), y,
+                                          float(threshold), float(a), float(b), float(c))
+        return y
+    else:
+        return torch.where(x > threshold, a * x + b, c * x)
+
+
+class _MarbleActivationFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x: torch.Tensor, threshold: float, a: float, b: float, c: float):
+        ctx.save_for_backward(x)
+        ctx.threshold = threshold
+        ctx.a = a
+        ctx.c = c
+        return _marble_activation_forward(x, threshold, a, b, c)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (x,) = ctx.saved_tensors
+        grad_x = torch.where(x > ctx.threshold,
+                             torch.tensor(ctx.a, device=x.device, dtype=x.dtype),
+                             torch.tensor(ctx.c, device=x.device, dtype=x.dtype))
+        return grad_output * grad_x, None, None, None, None
+
+
+def marble_activation(x: torch.Tensor, threshold: float, a: float, b: float, c: float) -> torch.Tensor:
+    """Piecewise linear activation used across MARBLE components.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input tensor.
+    threshold : float
+        Boundary at which the activation switches behavior.
+    a : float
+        Slope above the threshold.
+    b : float
+        Intercept above the threshold.
+    c : float
+        Slope below the threshold.
+
+    Returns
+    -------
+    torch.Tensor
+        Activated tensor.
+    """
+    return _MarbleActivationFunction.apply(x, float(threshold), float(a), float(b), float(c))

--- a/tests/test_marble_activation_kernel.py
+++ b/tests/test_marble_activation_kernel.py
@@ -1,0 +1,29 @@
+import torch
+import pytest
+
+from marble_activation_kernel import marble_activation
+
+
+def test_cpu_marble_activation_forward_and_backward():
+    x = torch.tensor([-1.0, 0.5, 2.0], requires_grad=True)
+    y = marble_activation(x, threshold=0.0, a=2.0, b=1.0, c=0.5)
+    expected = torch.where(x > 0.0, 2.0 * x + 1.0, 0.5 * x)
+    assert torch.allclose(y, expected)
+
+    y.sum().backward()
+    expected_grad = torch.tensor([0.5, 2.0, 2.0])
+    assert torch.allclose(x.grad, expected_grad)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_gpu_matches_cpu():
+    x = torch.randn(1024, device="cuda")
+    cpu = x.cpu()
+    out_gpu = marble_activation(x, threshold=0.1, a=1.5, b=0.2, c=0.7)
+    out_cpu = marble_activation(cpu, threshold=0.1, a=1.5, b=0.2, c=0.7)
+    assert torch.allclose(out_gpu.cpu(), out_cpu, atol=1e-6)
+
+    x.requires_grad = True
+    y = marble_activation(x, threshold=0.1, a=1.5, b=0.2, c=0.7)
+    y.sum().backward()
+    assert x.grad is not None


### PR DESCRIPTION
## Summary
- implement `marble_activation` CUDA kernel with autograd and CPU fallback
- add comprehensive tests for CPU and GPU parity
- extend tutorial with project demonstrating the new kernel on the Iris dataset

## Testing
- `pytest tests/test_marble_activation_kernel.py::test_cpu_marble_activation_forward_and_backward -q`
- `pytest tests/test_marble_activation_kernel.py::test_gpu_matches_cpu -q` *(skipped: CUDA is not available)*

------
https://chatgpt.com/codex/tasks/task_e_6891e26b71b8832791b4e0bbc5723f62