### PR TITLE
Optimize MARBLE activation CUDA kernel

### DIFF
--- a/marble_activation_kernel.py
+++ b/marble_activation_kernel.py
@@ -31,17 +31,21 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         cuda_sources="""
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <cuda_fp16.h>
 #include <torch/extension.h>
 
-// Optimized MARBLE activation kernel leveraging vectorized loads,
-// grid-stride loops and branchless computation for maximum throughput.
-__global__ void marble_activation_kernel(const float* __restrict__ x,
-                                         float* __restrict__ y,
-                                         float threshold, float a, float b, float c,
-                                         long n) {
+// High-performance MARBLE activation kernels for float32 and float16.
+// The float kernel uses vectorized float4 operations while the half kernel
+// leverages half2 intrinsics for maximum throughput.
+
+__global__ void marble_activation_kernel_float(const float* __restrict__ x,
+                                               float* __restrict__ y,
+                                               float threshold, float a,
+                                               float b, float c, long n) {
     long idx = blockIdx.x * blockDim.x + threadIdx.x;
     long stride = blockDim.x * gridDim.x;
 
+    float diff = a - c;
     long n4 = n / 4;
     const float4* x4 = reinterpret_cast<const float4*>(x);
     float4* y4 = reinterpret_cast<float4*>(y);
@@ -51,13 +55,13 @@ __global__ void marble_activation_kernel(const float* __restrict__ x,
         float4 out;
 
         float m = xv.x > threshold;
-        out.x = __fmaf_rn(xv.x, m * a + (1.f - m) * c, m * b);
+        out.x = __fmaf_rn(xv.x, m * diff + c, m * b);
         m = xv.y > threshold;
-        out.y = __fmaf_rn(xv.y, m * a + (1.f - m) * c, m * b);
+        out.y = __fmaf_rn(xv.y, m * diff + c, m * b);
         m = xv.z > threshold;
-        out.z = __fmaf_rn(xv.z, m * a + (1.f - m) * c, m * b);
+        out.z = __fmaf_rn(xv.z, m * diff + c, m * b);
         m = xv.w > threshold;
-        out.w = __fmaf_rn(xv.w, m * a + (1.f - m) * c, m * b);
+        out.w = __fmaf_rn(xv.w, m * diff + c, m * b);
 
         y4[i] = out;
     }
@@ -65,7 +69,39 @@ __global__ void marble_activation_kernel(const float* __restrict__ x,
     for (long i = n4 * 4 + idx; i < n; i += stride) {
         float v = x[i];
         float m = v > threshold;
-        y[i] = __fmaf_rn(v, m * a + (1.f - m) * c, m * b);
+        y[i] = __fmaf_rn(v, m * diff + c, m * b);
+    }
+}
+
+__global__ void marble_activation_kernel_half(const __half* __restrict__ x,
+                                              __half* __restrict__ y,
+                                              __half threshold, __half a,
+                                              __half b, __half c, long n) {
+    long idx = blockIdx.x * blockDim.x + threadIdx.x;
+    long stride = blockDim.x * gridDim.x;
+
+    __half diff = __hsub(a, c);
+    long n2 = n / 2;
+    const __half2* x2 = reinterpret_cast<const __half2*>(x);
+    __half2* y2 = reinterpret_cast<__half2*>(y);
+
+    __half2 thresh2 = __half2half2(threshold);
+    __half2 diff2 = __half2half2(diff);
+    __half2 c2 = __half2half2(c);
+    __half2 b2 = __half2half2(b);
+
+    for (long i = idx; i < n2; i += stride) {
+        __half2 xv = x2[i];
+        __half2 m = __hgt2(xv, thresh2);
+        __half2 t = __hfma2(diff2, m, c2);
+        y2[i] = __hfma2(xv, t, __hmul2(m, b2));
+    }
+
+    for (long i = n2 * 2 + idx; i < n; i += stride) {
+        __half xv = x[i];
+        __half m = __hgt(xv, threshold);
+        __half t = __hfma(diff, m, c);
+        y[i] = __hfma(xv, t, __hmul(m, b));
     }
 }
 
@@ -74,9 +110,23 @@ void marble_activation_launcher(const at::Tensor& x, at::Tensor& y,
     const long n = x.numel();
     const int threads = 256;
     const int blocks = std::min<int>((n + threads - 1) / threads, 65535);
-    marble_activation_kernel<<<blocks, threads>>>(x.data_ptr<float>(),
-                                                  y.data_ptr<float>(),
-                                                  threshold, a, b, c, n);
+
+    if (x.scalar_type() == at::kFloat) {
+        marble_activation_kernel_float<<<blocks, threads>>>(x.data_ptr<float>(),
+                                                           y.data_ptr<float>(),
+                                                           threshold, a, b, c, n);
+    } else if (x.scalar_type() == at::kHalf) {
+        __half th = __float2half(threshold);
+        __half ah = __float2half(a);
+        __half bh = __float2half(b);
+        __half ch = __float2half(c);
+        marble_activation_kernel_half<<<blocks, threads>>>(
+            reinterpret_cast<const __half*>(x.data_ptr<at::Half>()),
+            reinterpret_cast<__half*>(y.data_ptr<at::Half>()),
+            th, ah, bh, ch, n);
+    } else {
+        AT_ERROR("marble_activation: unsupported tensor dtype");
+    }
 }
 """,
         functions=["marble_activation_launcher"],

--- a/tests/test_marble_activation_kernel.py
+++ b/tests/test_marble_activation_kernel.py
@@ -36,3 +36,12 @@ def test_gpu_handles_non_multiple_of_four():
     out_gpu = marble_activation(x, threshold=-0.3, a=0.8, b=0.1, c=1.2)
     out_cpu = marble_activation(cpu, threshold=-0.3, a=0.8, b=0.1, c=1.2)
     assert torch.allclose(out_gpu.cpu(), out_cpu, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_gpu_half_precision_matches_cpu():
+    x = torch.randn(2048, device="cuda", dtype=torch.float16)
+    cpu = x.cpu().float()
+    out_gpu = marble_activation(x, threshold=0.2, a=0.9, b=0.3, c=1.1)
+    out_cpu = marble_activation(cpu, threshold=0.2, a=0.9, b=0.3, c=1.1).half()
+    assert torch.allclose(out_gpu.cpu(), out_cpu, atol=1e-3, rtol=1e-3)


### PR DESCRIPTION
## Summary
- Accelerate float32 activation with a vectorized CUDA kernel that reuses arithmetic and reduces per-element work
- Add half-precision kernel leveraging `half2` intrinsics for efficient GPU execution and dtype-aware dispatch
- Extend tests to verify float16 GPU results against CPU computations

## Testing
- `pytest tests/test_marble_activation_kernel.py`


------
https://chatgpt.com/codex/tasks/task_e_6891e7e833f48327903741d181e33b0c