### PR TITLE
feat: vectorize neuronenblitz CUDA kernel

### DIFF
--- a/neuronenblitz_kernel.py
+++ b/neuronenblitz_kernel.py
@@ -40,7 +40,7 @@ void nb_apply_launcher(const at::Tensor& source,
 #include <cuda_fp16.h>
 #include <torch/extension.h>
 
-// Kernel for float32
+// Kernel for float32 leveraging vectorized float4 operations
 __global__ void nb_apply_kernel_float(const float* __restrict__ source,
                                       float* __restrict__ weights,
                                       float* __restrict__ potentials,
@@ -63,7 +63,131 @@ __global__ void nb_apply_kernel_float(const float* __restrict__ source,
                                       int n) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int stride = blockDim.x * gridDim.x;
-    for (int i = idx; i < n; i += stride) {
+    int n4 = n / 4;
+    const float4* source4 = reinterpret_cast<const float4*>(source);
+    float4* weights4 = reinterpret_cast<float4*>(weights);
+    float4* potentials4 = reinterpret_cast<float4*>(potentials);
+    float4* momentum4 = reinterpret_cast<float4*>(momentum);
+    float4* grad_sq4 = reinterpret_cast<float4*>(grad_sq);
+    float4* prev_grad4 = reinterpret_cast<float4*>(prev_grad);
+    const float4* eligibility4 = reinterpret_cast<const float4*>(eligibility);
+    const float4* mem_gate4 = reinterpret_cast<const float4*>(mem_gate);
+    float4* scores4 = reinterpret_cast<float4*>(scores);
+    for (int i = idx; i < n4; i += stride) {
+        float4 src = source4[i];
+        float4 w = weights4[i];
+        float4 pot = potentials4[i];
+        float4 mom = momentum4[i];
+        float4 gs = grad_sq4[i];
+        float4 pg = prev_grad4[i];
+        float4 elig = eligibility4[i];
+        float4 mem = mem_gate4[i];
+        float4 sc;
+
+        // Lane 0
+        float delta = (error * src.x) / (path_len + 1.0f);
+        float prev = pg.x;
+        if (prev * delta < 0.f) delta *= 0.5f;
+        pg.x = delta;
+        delta *= elig.x;
+        float prev_v = gs.x;
+        float v = rms_beta * prev_v + (1.f - rms_beta) * (delta * delta);
+        gs.x = v;
+        float scaled_delta = delta / sqrtf(v + grad_epsilon);
+        float mom_prev = mom.x;
+        float m = momentum_coeff * mom_prev + scaled_delta;
+        mom.x = m;
+        float update = learning_rate * (momentum_coeff * m + scaled_delta);
+        if (update > cap) update = cap;
+        else if (update < -cap) update = -cap;
+        float wv = w.x + update;
+        wv = fminf(weight_limit, fmaxf(-weight_limit, wv));
+        w.x = wv;
+        float potv = pot.x + fabsf(scaled_delta) * gradient_score_scale;
+        pot.x = fminf(synapse_potential_cap, potv);
+        float mem_factor = 1.0f + mem.x;
+        sc.x = fabsf(error) * fabsf(wv) / (float)path_len * mem_factor;
+
+        // Lane 1
+        delta = (error * src.y) / (path_len + 1.0f);
+        prev = pg.y;
+        if (prev * delta < 0.f) delta *= 0.5f;
+        pg.y = delta;
+        delta *= elig.y;
+        prev_v = gs.y;
+        v = rms_beta * prev_v + (1.f - rms_beta) * (delta * delta);
+        gs.y = v;
+        scaled_delta = delta / sqrtf(v + grad_epsilon);
+        mom_prev = mom.y;
+        m = momentum_coeff * mom_prev + scaled_delta;
+        mom.y = m;
+        update = learning_rate * (momentum_coeff * m + scaled_delta);
+        if (update > cap) update = cap;
+        else if (update < -cap) update = -cap;
+        wv = w.y + update;
+        wv = fminf(weight_limit, fmaxf(-weight_limit, wv));
+        w.y = wv;
+        potv = pot.y + fabsf(scaled_delta) * gradient_score_scale;
+        pot.y = fminf(synapse_potential_cap, potv);
+        mem_factor = 1.0f + mem.y;
+        sc.y = fabsf(error) * fabsf(wv) / (float)path_len * mem_factor;
+
+        // Lane 2
+        delta = (error * src.z) / (path_len + 1.0f);
+        prev = pg.z;
+        if (prev * delta < 0.f) delta *= 0.5f;
+        pg.z = delta;
+        delta *= elig.z;
+        prev_v = gs.z;
+        v = rms_beta * prev_v + (1.f - rms_beta) * (delta * delta);
+        gs.z = v;
+        scaled_delta = delta / sqrtf(v + grad_epsilon);
+        mom_prev = mom.z;
+        m = momentum_coeff * mom_prev + scaled_delta;
+        mom.z = m;
+        update = learning_rate * (momentum_coeff * m + scaled_delta);
+        if (update > cap) update = cap;
+        else if (update < -cap) update = -cap;
+        wv = w.z + update;
+        wv = fminf(weight_limit, fmaxf(-weight_limit, wv));
+        w.z = wv;
+        potv = pot.z + fabsf(scaled_delta) * gradient_score_scale;
+        pot.z = fminf(synapse_potential_cap, potv);
+        mem_factor = 1.0f + mem.z;
+        sc.z = fabsf(error) * fabsf(wv) / (float)path_len * mem_factor;
+
+        // Lane 3
+        delta = (error * src.w) / (path_len + 1.0f);
+        prev = pg.w;
+        if (prev * delta < 0.f) delta *= 0.5f;
+        pg.w = delta;
+        delta *= elig.w;
+        prev_v = gs.w;
+        v = rms_beta * prev_v + (1.f - rms_beta) * (delta * delta);
+        gs.w = v;
+        scaled_delta = delta / sqrtf(v + grad_epsilon);
+        mom_prev = mom.w;
+        m = momentum_coeff * mom_prev + scaled_delta;
+        mom.w = m;
+        update = learning_rate * (momentum_coeff * m + scaled_delta);
+        if (update > cap) update = cap;
+        else if (update < -cap) update = -cap;
+        wv = w.w + update;
+        wv = fminf(weight_limit, fmaxf(-weight_limit, wv));
+        w.w = wv;
+        potv = pot.w + fabsf(scaled_delta) * gradient_score_scale;
+        pot.w = fminf(synapse_potential_cap, potv);
+        mem_factor = 1.0f + mem.w;
+        sc.w = fabsf(error) * fabsf(wv) / (float)path_len * mem_factor;
+
+        weights4[i] = w;
+        potentials4[i] = pot;
+        momentum4[i] = mom;
+        grad_sq4[i] = gs;
+        prev_grad4[i] = pg;
+        scores4[i] = sc;
+    }
+    for (int i = n4 * 4 + idx; i < n; i += stride) {
         float src = source[i];
         float delta = (error * src) / (path_len + 1.0f);
         float prev = prev_grad[i];
@@ -90,7 +214,7 @@ __global__ void nb_apply_kernel_float(const float* __restrict__ source,
     }
 }
 
-// Kernel for float16 using float math internally
+// Kernel for float16 using vectorized half2 operations
 __global__ void nb_apply_kernel_half(const __half* __restrict__ source,
                                      __half* __restrict__ weights,
                                      __half* __restrict__ potentials,
@@ -113,7 +237,83 @@ __global__ void nb_apply_kernel_half(const __half* __restrict__ source,
                                      int n) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int stride = blockDim.x * gridDim.x;
-    for (int i = idx; i < n; i += stride) {
+    int n2 = n / 2;
+    const __half2* source2 = reinterpret_cast<const __half2*>(source);
+    __half2* weights2 = reinterpret_cast<__half2*>(weights);
+    __half2* potentials2 = reinterpret_cast<__half2*>(potentials);
+    __half2* momentum2 = reinterpret_cast<__half2*>(momentum);
+    __half2* grad_sq2 = reinterpret_cast<__half2*>(grad_sq);
+    __half2* prev_grad2 = reinterpret_cast<__half2*>(prev_grad);
+    const __half2* eligibility2 = reinterpret_cast<const __half2*>(eligibility);
+    const __half2* mem_gate2 = reinterpret_cast<const __half2*>(mem_gate);
+    __half2* scores2 = reinterpret_cast<__half2*>(scores);
+    for (int i = idx; i < n2; i += stride) {
+        float2 src = __half22float2(source2[i]);
+        float2 w = __half22float2(weights2[i]);
+        float2 pot = __half22float2(potentials2[i]);
+        float2 mom = __half22float2(momentum2[i]);
+        float2 gs = __half22float2(grad_sq2[i]);
+        float2 pg = __half22float2(prev_grad2[i]);
+        float2 elig = __half22float2(eligibility2[i]);
+        float2 mem = __half22float2(mem_gate2[i]);
+        float2 sc;
+
+        // Lane 0
+        float delta = (error * src.x) / (path_len + 1.0f);
+        float prev = pg.x;
+        if (prev * delta < 0.f) delta *= 0.5f;
+        pg.x = delta;
+        delta *= elig.x;
+        float prev_v = gs.x;
+        float v = rms_beta * prev_v + (1.f - rms_beta) * (delta * delta);
+        gs.x = v;
+        float scaled_delta = delta / sqrtf(v + grad_epsilon);
+        float mom_prev = mom.x;
+        float m = momentum_coeff * mom_prev + scaled_delta;
+        mom.x = m;
+        float update = learning_rate * (momentum_coeff * m + scaled_delta);
+        if (update > cap) update = cap;
+        else if (update < -cap) update = -cap;
+        float wv = w.x + update;
+        wv = fminf(weight_limit, fmaxf(-weight_limit, wv));
+        w.x = wv;
+        float potv = pot.x + fabsf(scaled_delta) * gradient_score_scale;
+        pot.x = fminf(synapse_potential_cap, potv);
+        float mem_factor = 1.0f + mem.x;
+        sc.x = fabsf(error) * fabsf(wv) / (float)path_len * mem_factor;
+
+        // Lane 1
+        delta = (error * src.y) / (path_len + 1.0f);
+        prev = pg.y;
+        if (prev * delta < 0.f) delta *= 0.5f;
+        pg.y = delta;
+        delta *= elig.y;
+        prev_v = gs.y;
+        v = rms_beta * prev_v + (1.f - rms_beta) * (delta * delta);
+        gs.y = v;
+        scaled_delta = delta / sqrtf(v + grad_epsilon);
+        mom_prev = mom.y;
+        m = momentum_coeff * mom_prev + scaled_delta;
+        mom.y = m;
+        update = learning_rate * (momentum_coeff * m + scaled_delta);
+        if (update > cap) update = cap;
+        else if (update < -cap) update = -cap;
+        wv = w.y + update;
+        wv = fminf(weight_limit, fmaxf(-weight_limit, wv));
+        w.y = wv;
+        potv = pot.y + fabsf(scaled_delta) * gradient_score_scale;
+        pot.y = fminf(synapse_potential_cap, potv);
+        mem_factor = 1.0f + mem.y;
+        sc.y = fabsf(error) * fabsf(wv) / (float)path_len * mem_factor;
+
+        weights2[i] = __floats2half2_rn(w.x, w.y);
+        potentials2[i] = __floats2half2_rn(pot.x, pot.y);
+        momentum2[i] = __floats2half2_rn(mom.x, mom.y);
+        grad_sq2[i] = __floats2half2_rn(gs.x, gs.y);
+        prev_grad2[i] = __floats2half2_rn(pg.x, pg.y);
+        scores2[i] = __floats2half2_rn(sc.x, sc.y);
+    }
+    for (int i = n2 * 2 + idx; i < n; i += stride) {
         float src = __half2float(source[i]);
         float delta = (error * src) / (path_len + 1.0f);
         float prev = __half2float(prev_grad[i]);

--- a/tests/test_neuronenblitz_cuda.py
+++ b/tests/test_neuronenblitz_cuda.py
@@ -3,8 +3,21 @@ import numpy as np
 import pytest
 import torch
 
+from marble_core import Core, Neuron
 from marble_neuronenblitz import Neuronenblitz
+from tests.test_core_functions import minimal_params
 from tests.test_neuronenblitz_enhancements import create_simple_core
+
+
+def create_chain_core(length: int = 9):
+    params = minimal_params()
+    core = Core(params)
+    core.neurons = [Neuron(i, value=0.0) for i in range(length + 1)]
+    core.synapses = []
+    syns = []
+    for i in range(length):
+        syns.append(core.add_synapse(i, i + 1, weight=1.0))
+    return core, syns
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -29,3 +42,29 @@ def test_cuda_weight_update_matches_cpu():
 
     assert np.isclose(syn_gpu.weight, expected_weight, atol=1e-6)
     assert np.isclose(core_gpu.neurons[1].attention_score, expected_attention, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_cuda_weight_update_matches_cpu_batch():
+    random.seed(0)
+    np.random.seed(0)
+    core_cpu, syns_cpu = create_chain_core(9)
+    nb_cpu = Neuronenblitz(core_cpu, consolidation_probability=0.0, weight_decay=0.0)
+    nb_cpu.learning_rate = 0.1
+    for n in core_cpu.neurons[:-1]:
+        n.value = 1.0
+    nb_cpu.apply_weight_updates_and_attention(syns_cpu, error=1.0)
+    expected_weights = [syn.weight for syn in syns_cpu]
+    expected_attention = [core_cpu.neurons[i + 1].attention_score for i in range(len(syns_cpu))]
+
+    core_gpu, syns_gpu = create_chain_core(9)
+    nb_gpu = Neuronenblitz(core_gpu, consolidation_probability=0.0, weight_decay=0.0)
+    nb_gpu.learning_rate = 0.1
+    for n in core_gpu.neurons[:-1]:
+        n.value = 1.0
+    nb_gpu.apply_weight_updates_and_attention(syns_gpu, error=1.0)
+
+    for syn, ew in zip(syns_gpu, expected_weights):
+        assert np.isclose(syn.weight, ew, atol=1e-6)
+    for idx, ea in enumerate(expected_attention):
+        assert np.isclose(core_gpu.neurons[idx + 1].attention_score, ea, atol=1e-6)


### PR DESCRIPTION
## Summary
- optimize Neuronenblitz CUDA kernel using float4/half2 vectorization for faster wandering weight updates
- add GPU batch parity test to validate CUDA kernel against CPU implementation

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_neuronenblitz_cuda.py -q`
- `pytest tests/test_neuronenblitz_enhancements.py -q`
- `pytest tests/test_neuronenblitz_new_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891f142465c8327ac005690754928e6