### PR TITLE
Add learning module plugin system and workspace-driven attention gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,6 +928,24 @@ codelets through the workspace. Register your own codelets via
 `attention_codelets.register_codelet` and invoke
 `attention_codelets.run_cycle()` during training.
 
+Learning algorithms can now be swapped at runtime through the dedicated
+``learning_plugins`` interface.  Implementations subclass
+``LearningModule`` and are registered with
+``learning_plugins.register_learning_module``.  ``UnifiedLearner`` accepts
+plugin names and initialises each module on CPU or GPU depending on hardware:
+
+```python
+from learning_plugins import load_learning_plugins
+
+load_learning_plugins("plugins")
+learner = UnifiedLearner(core, nb, {"custom": "my_plugin"}, plugin_dirs=["plugins"])
+```
+
+The ``attention_codelets`` system can also react to Global Workspace events.
+Invoking ``attention_codelets.enable_workspace_gating()`` subscribes to
+messages of the form ``{"codelet": "name", "gate": value}``, dynamically
+adjusting salience during coalition formation.
+
 For heavy computation on dedicated accelerators the `remote_offload` plugin
 spawns a `RemoteBrainServer` that executes message passing and learning steps on
 another machine. Local clients interact with it transparently through

--- a/TODO.md
+++ b/TODO.md
@@ -732,16 +732,16 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [ ] Implement Support streaming dataset shards during Neuronenblitz training to keep the model responsive with CPU/GPU support.
    - [ ] Add tests validating Support streaming dataset shards during Neuronenblitz training to keep the model responsive.
    - [ ] Document Support streaming dataset shards during Neuronenblitz training to keep the model responsive in README and TUTORIAL.
-218. [ ] Allow learning modules to be swapped in and out through a plugin interface.
-   - [ ] Outline design for Allow learning modules to be swapped in and out through a plugin interface.
-   - [ ] Implement Allow learning modules to be swapped in and out through a plugin interface with CPU/GPU support.
-   - [ ] Add tests validating Allow learning modules to be swapped in and out through a plugin interface.
-   - [ ] Document Allow learning modules to be swapped in and out through a plugin interface in README and TUTORIAL.
-219. [ ] Use Global Workspace events to guide dynamic attention gating.
-   - [ ] Outline design for Use Global Workspace events to guide dynamic attention gating.
-   - [ ] Implement Use Global Workspace events to guide dynamic attention gating with CPU/GPU support.
-   - [ ] Add tests validating Use Global Workspace events to guide dynamic attention gating.
-   - [ ] Document Use Global Workspace events to guide dynamic attention gating in README and TUTORIAL.
+218. [x] Allow learning modules to be swapped in and out through a plugin interface.
+   - [x] Outline design for Allow learning modules to be swapped in and out through a plugin interface.
+   - [x] Implement Allow learning modules to be swapped in and out through a plugin interface with CPU/GPU support.
+   - [x] Add tests validating Allow learning modules to be swapped in and out through a plugin interface.
+   - [x] Document Allow learning modules to be swapped in and out through a plugin interface in README and TUTORIAL.
+219. [x] Use Global Workspace events to guide dynamic attention gating.
+   - [x] Outline design for Use Global Workspace events to guide dynamic attention gating.
+   - [x] Implement Use Global Workspace events to guide dynamic attention gating with CPU/GPU support.
+   - [x] Add tests validating Use Global Workspace events to guide dynamic attention gating.
+   - [x] Document Use Global Workspace events to guide dynamic attention gating in README and TUTORIAL.
 220. [ ] Provide a reinforcement learning loop coordinated by pipeline scheduling.
    - [ ] Outline design for Provide a reinforcement learning loop coordinated by pipeline scheduling.
    - [ ] Implement Provide a reinforcement learning loop coordinated by pipeline scheduling with CPU/GPU support.

--- a/attention_codelets.py
+++ b/attention_codelets.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, List
 
-import numpy as np
+import torch
 
 import global_workspace
 
@@ -31,6 +31,7 @@ class AttentionProposal:
 _codelets: List[Callable[[], AttentionProposal]] = []
 _default_coalition_size = 1
 _salience_weight = 1.0
+_workspace_gates: dict[str, float] = {}
 
 
 def register_codelet(func: Callable[[], AttentionProposal]) -> None:
@@ -47,11 +48,33 @@ def get_codelets() -> list[Callable[[], AttentionProposal]]:
     return list(_codelets)
 
 
+def _workspace_listener(msg: global_workspace.BroadcastMessage) -> None:
+    if not isinstance(msg.content, dict):
+        return
+    name = msg.content.get("codelet")
+    gate = msg.content.get("gate")
+    if name is None or gate is None:
+        return
+    try:
+        _workspace_gates[name] = float(gate)
+    except Exception:  # pragma: no cover - defensive
+        return
+
+
+def enable_workspace_gating() -> None:
+    """Subscribe to Global Workspace events to adjust codelet salience."""
+
+    if global_workspace.workspace is None:
+        global_workspace.activate()
+    global_workspace.workspace.subscribe(_workspace_listener)
+
+
 def form_coalition(
     coalition_size: int | None = None,
     *,
     saliences: list[float] | None = None,
     salience_weight: float | None = None,
+    device: torch.device | None = None,
 ) -> list[AttentionProposal]:
     """Return the highest scoring proposals.
 
@@ -67,16 +90,30 @@ def form_coalition(
         coalition_size = _default_coalition_size
     if salience_weight is None:
         salience_weight = _salience_weight
+    if device is None:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     proposals = [codelet() for codelet in _codelets]
     if not proposals:
         return []
-    scores = np.array([p.score for p in proposals], dtype=float)
+    scores = torch.tensor(
+        [p.score for p in proposals], dtype=torch.float32, device=device
+    )
     if saliences is not None:
-        sarr = np.array(saliences, dtype=float)
+        sarr = torch.tensor(saliences, dtype=torch.float32, device=device)
         scores = scores + salience_weight * sarr
-    probs = np.exp(scores) / np.sum(np.exp(scores))
-    idx = np.argsort(probs)[-coalition_size:][::-1]
-    return [proposals[i] for i in idx]
+    if _workspace_gates:
+        gates = torch.tensor(
+            [
+                _workspace_gates.get(getattr(codelet, "__name__", str(i)), 0.0)
+                for i, codelet in enumerate(_codelets)
+            ],
+            dtype=torch.float32,
+            device=device,
+        )
+        scores = scores + gates
+    probs = torch.softmax(scores, dim=0)
+    idx = torch.argsort(probs, descending=True)[:coalition_size]
+    return [proposals[i] for i in idx.tolist()]
 
 
 def broadcast_coalition(coalition: list[AttentionProposal]) -> None:
@@ -93,10 +130,12 @@ def broadcast_coalition(coalition: list[AttentionProposal]) -> None:
         global_workspace.workspace.publish("attention_codelets", msg)
 
 
-def run_cycle(coalition_size: int | None = None) -> None:
+def run_cycle(
+    coalition_size: int | None = None, *, device: torch.device | None = None
+) -> None:
     """Form a coalition and broadcast the winners."""
 
-    coalition = form_coalition(coalition_size)
+    coalition = form_coalition(coalition_size, device=device)
     if global_workspace.workspace is not None:
         for proposal in coalition:
             global_workspace.workspace.publish("attention_codelets", proposal.content)

--- a/learning_plugins.py
+++ b/learning_plugins.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from importlib import metadata, util
+from pathlib import Path
+from typing import Dict, Iterable, Type
+
+import torch
+
+"""Plugin interface for MARBLE learning modules.
+
+This module allows different learning algorithms to be swapped in and out at
+runtime.  Each plugin is a subclass of :class:`LearningModule` and may be
+registered either via the :func:`register_learning_module` function, by exposing
+an entry point under ``marble.learning_plugins`` or by providing a ``register``
+function inside a Python file located in a configured directory.
+
+Plugins receive the active ``torch.device`` so implementations can run on CPU or
+GPU seamlessly.  The optional ``marble`` argument provides access to the
+currently active model for more advanced algorithms.
+"""
+
+
+class LearningModule:
+    """Base class for swappable learning modules."""
+
+    def __init__(self, **kwargs) -> None:  # pragma: no cover - storage only
+        self.params = kwargs
+
+    def initialise(self, device: torch.device, marble=None) -> None:
+        """Prepare the module for training on ``device``."""
+
+    def train_step(
+        self, *args, device: torch.device, marble=None
+    ):  # pragma: no cover - abstract
+        """Execute a single training step and optionally return a loss."""
+        raise NotImplementedError
+
+    def teardown(self) -> None:
+        """Release any held resources."""
+
+
+# Registry of learning module classes
+LEARNING_MODULES: Dict[str, Type[LearningModule]] = {}
+
+
+def register_learning_module(name: str, cls: Type[LearningModule]) -> None:
+    """Register ``cls`` under ``name`` replacing any existing entry."""
+
+    LEARNING_MODULES[name] = cls
+
+
+def get_learning_module(name: str) -> Type[LearningModule]:
+    """Return the learning module class registered as ``name``."""
+
+    return LEARNING_MODULES[name]
+
+
+def load_learning_plugins(dirs: Iterable[str] | str | None = None) -> None:
+    """Discover learning module plugins from entry points or directories."""
+
+    try:
+        entry_points = metadata.entry_points(group="marble.learning_plugins")
+    except Exception:  # pragma: no cover - metadata behaviour varies
+        entry_points = []
+    for ep in entry_points:
+        cls = ep.load()
+        register_learning_module(ep.name, cls)
+
+    if dirs is None:
+        return
+    if isinstance(dirs, str):
+        dirs = [dirs]
+
+    for d in dirs:
+        path = Path(d)
+        if not path.is_dir():
+            continue
+        for file in path.glob("*.py"):
+            spec = util.spec_from_file_location(file.stem, file)
+            if spec and spec.loader:
+                module = util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                if hasattr(module, "register"):
+                    module.register(register_learning_module)

--- a/tests/test_attention_workspace_gating.py
+++ b/tests/test_attention_workspace_gating.py
@@ -1,0 +1,26 @@
+import torch
+
+import attention_codelets as ac
+import global_workspace
+
+
+def test_workspace_events_affect_gating():
+    global_workspace.activate()
+    ac._codelets.clear()
+    ac._workspace_gates.clear()
+
+    def c1():
+        return ac.AttentionProposal(score=0.1, content="a")
+
+    def c2():
+        return ac.AttentionProposal(score=0.2, content="b")
+
+    ac.register_codelet(c1)
+    ac.register_codelet(c2)
+    ac.enable_workspace_gating()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    winner = ac.form_coalition(coalition_size=1, device=device)[0]
+    assert winner.content == "b"
+    global_workspace.workspace.publish("test", {"codelet": "c1", "gate": 1.0})
+    winner = ac.form_coalition(coalition_size=1, device=device)[0]
+    assert winner.content == "a"

--- a/tests/test_learning_plugin_interface.py
+++ b/tests/test_learning_plugin_interface.py
@@ -1,0 +1,73 @@
+import torch
+
+from learning_plugins import get_learning_module, load_learning_plugins
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from tests.test_core_functions import minimal_params
+from unified_learning import UnifiedLearner
+
+
+def test_learning_module_plugin_swapping(tmp_path):
+    plugin1 = (
+        "import torch\n"
+        "from learning_plugins import LearningModule, register_learning_module\n"
+        "class AddLearner(LearningModule):\n"
+        "    def initialise(self, device, marble=None):\n"
+        "        self.device = device\n"
+        "    def train_step(self, x, y, *, device, marble=None):\n"
+        "        return torch.tensor(x, device=device) + torch.tensor(y, device=device)\n"
+        "def register(reg):\n"
+        "    reg('math', AddLearner)\n"
+    )
+    file = tmp_path / "plugin.py"
+    file.write_text(plugin1)
+    load_learning_plugins(str(tmp_path))
+    cls = get_learning_module("math")
+    learner = cls()
+    learner.initialise(torch.device("cpu"))
+    res = learner.train_step(1.0, 2.0, device=torch.device("cpu"))
+    assert res.item() == 3.0
+    file.unlink()
+
+    plugin2 = (
+        "import torch\n"
+        "from learning_plugins import LearningModule, register_learning_module\n"
+        "class MulLearner(LearningModule):\n"
+        "    def initialise(self, device, marble=None):\n"
+        "        self.device = device\n"
+        "    def train_step(self, x, y, *, device, marble=None):\n"
+        "        return torch.tensor(x, device=device) * torch.tensor(y, device=device)\n"
+        "def register(reg):\n"
+        "    reg('math', MulLearner)\n"
+    )
+    file2 = tmp_path / "plugin2.py"
+    file2.write_text(plugin2)
+    load_learning_plugins(str(tmp_path))
+    cls2 = get_learning_module("math")
+    learner2 = cls2()
+    learner2.initialise(torch.device("cpu"))
+    res2 = learner2.train_step(2.0, 3.0, device=torch.device("cpu"))
+    assert res2.item() == 6.0
+
+
+def test_unified_learner_uses_plugin(tmp_path):
+    plugin = (
+        "import torch\n"
+        "from learning_plugins import LearningModule, register_learning_module\n"
+        "class LossLearner(LearningModule):\n"
+        "    def initialise(self, device, marble=None):\n"
+        "        self.device = device\n"
+        "    def train_step(self, x, y, *, device, marble=None):\n"
+        "        pred = torch.tensor(x, device=device)\n"
+        "        target = torch.tensor(y, device=device)\n"
+        "        return (pred - target).abs().sum()\n"
+        "def register(reg):\n"
+        "    reg('loss', LossLearner)\n"
+    )
+    file = tmp_path / "loss_plugin.py"
+    file.write_text(plugin)
+    core = Core(minimal_params())
+    nb = Neuronenblitz(core)
+    ul = UnifiedLearner(core, nb, {"l": "loss"}, plugin_dirs=[str(tmp_path)])
+    ul.train_step((2.0, 1.0))
+    assert ul.loss_history["l"]


### PR DESCRIPTION
## Summary
- add `learning_plugins` interface so learning modules can be swapped dynamically
- allow `UnifiedLearner` to initialise learning plugins on CPU or GPU
- gate attention codelets based on Global Workspace events
- document new plugin system and attention gating in README and tutorial

## Testing
- `pytest tests/test_learning_plugin_interface.py`
- `pytest tests/test_attention_workspace_gating.py`


------
https://chatgpt.com/codex/tasks/task_e_6891ff7a27d483278e468eea6b29c335