### PR TITLE
Add Optuna hyperparameter optimization script and tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1398,21 +1398,21 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
         - [x] Confirm invalid YAML triggers error messages in UI.
 
 328. [ ] Integrate hyperparameter optimisation via Optuna.
-    - [ ] Add `scripts/optimize.py` with Optuna study and objective function training one epoch.
-        - [ ] Define search space and objective returning validation loss.
-        - [ ] Allow resuming existing studies.
-    - [ ] Log trials to `optuna_db.sqlite3`.
-        - [ ] Configure SQLite storage backend.
-        - [ ] Expose path via CLI option.
+    - [x] Add `scripts/optimize.py` with Optuna study and objective function training one epoch.
+        - [x] Define search space and objective returning validation loss.
+        - [x] Allow resuming existing studies.
+    - [x] Log trials to `optuna_db.sqlite3`.
+        - [x] Configure SQLite storage backend.
+        - [x] Expose path via CLI option.
     - [ ] Add Streamlit tab to visualize optimization history and best config.
         - [ ] Plot trial scores and parameter importances.
         - [ ] Provide download of best config.
     - [ ] Document usage in tutorials and manuals.
         - [ ] Include setup and run instructions.
         - [ ] Describe interpretation of optimization charts.
-    - [ ] Add tests for optimization script.
-        - [ ] Use tiny dataset to run a short study.
-        - [ ] Assert database and result files are created.
+    - [x] Add tests for optimization script.
+        - [x] Use tiny dataset to run a short study.
+        - [x] Assert database and result files are created.
 
 329. [ ] Implement live neuron graph visualisation.
     - [ ] Export graph as `{"nodes": [...], "edges": [...]}` in core.

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,6 +86,7 @@ numpy==1.26.4
 ollama==0.5.1
 openpyxl==3.1.2
 opt_einsum==3.4.0
+optuna==3.6.1
 packaging==24.0
 pandas==2.3.1
 parso==0.8.4

--- a/scripts/optimize.py
+++ b/scripts/optimize.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Hyperparameter optimisation using Optuna.
+
+This script performs a small Optuna study training a simple model for one
+epoch on synthetic data. Results and the Optuna study are persisted to disk
+so that studies can be resumed and analysed later.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import optuna
+import torch
+import yaml
+from torch import nn, optim
+from torch.utils.data import DataLoader, random_split
+from torchvision import datasets, transforms
+
+
+def _build_dataloaders() -> tuple[DataLoader, DataLoader]:
+    """Create training and validation loaders using ``FakeData``.
+
+    The dataset is intentionally tiny so that optimisation runs quickly. A
+    separate validation loader is returned for computing the objective value.
+    """
+
+    transform = transforms.ToTensor()
+    dataset = datasets.FakeData(
+        size=120,
+        image_size=(1, 28, 28),
+        num_classes=10,
+        transform=transform,
+    )
+    train_set, val_set = random_split(dataset, [100, 20])
+    train_loader = DataLoader(train_set, batch_size=32, shuffle=True)
+    val_loader = DataLoader(val_set, batch_size=32)
+    return train_loader, val_loader
+
+
+def _train_one_epoch(
+    model: nn.Module,
+    loader: DataLoader,
+    criterion: nn.Module,
+    optimizer: optim.Optimizer,
+    device: torch.device,
+) -> None:
+    """Train ``model`` for a single epoch."""
+
+    model.train()
+    for inputs, targets in loader:
+        inputs, targets = inputs.to(device), targets.to(device)
+        optimizer.zero_grad(set_to_none=True)
+        outputs = model(inputs)
+        loss = criterion(outputs, targets)
+        loss.backward()
+        optimizer.step()
+
+
+def _validate(
+    model: nn.Module, loader: DataLoader, criterion: nn.Module, device: torch.device
+) -> float:
+    """Return average validation loss for ``model``."""
+
+    model.eval()
+    total = 0.0
+    count = 0
+    with torch.no_grad():
+        for inputs, targets in loader:
+            inputs, targets = inputs.to(device), targets.to(device)
+            outputs = model(inputs)
+            total += criterion(outputs, targets).item()
+            count += 1
+    return total / max(1, count)
+
+
+def _objective(trial: optuna.Trial) -> float:
+    """Optuna objective returning validation loss."""
+
+    lr = trial.suggest_float("lr", 1e-4, 1e-1, log=True)
+    hidden = trial.suggest_int("hidden", 32, 128)
+    dropout = trial.suggest_float("dropout", 0.0, 0.5)
+
+    train_loader, val_loader = _build_dataloaders()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = nn.Sequential(
+        nn.Flatten(),
+        nn.Linear(28 * 28, hidden),
+        nn.ReLU(),
+        nn.Dropout(dropout),
+        nn.Linear(hidden, 10),
+    ).to(device)
+    optimizer = optim.SGD(model.parameters(), lr=lr)
+    criterion = nn.CrossEntropyLoss()
+
+    _train_one_epoch(model, train_loader, criterion, optimizer, device)
+    return _validate(model, val_loader, criterion, device)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Hyperparameter optimisation")
+    parser.add_argument(
+        "--trials", type=int, default=5, help="Number of Optuna trials to run"
+    )
+    parser.add_argument(
+        "--study-name", type=str, default="marble-optuna", help="Optuna study name"
+    )
+    parser.add_argument(
+        "--storage",
+        type=str,
+        default="sqlite:///optuna_db.sqlite3",
+        help="Storage URL for Optuna study (e.g. sqlite:///optuna.db)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("best_params.yaml"),
+        help="File to write best parameters as YAML",
+    )
+    args = parser.parse_args()
+
+    storage = optuna.storages.RDBStorage(args.storage)
+    study = optuna.create_study(
+        study_name=args.study_name,
+        storage=storage,
+        direction="minimize",
+        load_if_exists=True,
+    )
+    study.optimize(_objective, n_trials=args.trials)
+
+    args.output.write_text(yaml.safe_dump(study.best_trial.params))
+    print(f"Best trial saved to {args.output}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_optimize_script.py
+++ b/tests/test_optimize_script.py
@@ -1,0 +1,31 @@
+"""Tests for Optuna optimisation script."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def test_optimize_script_runs_and_creates_files(tmp_path: Path) -> None:
+    db_path = tmp_path / "optuna_db.sqlite3"
+    out_path = tmp_path / "best_params.yaml"
+
+    cmd = [
+        sys.executable,
+        "scripts/optimize.py",
+        "--trials",
+        "1",
+        "--storage",
+        f"sqlite:///{db_path}",
+        "--output",
+        str(out_path),
+    ]
+    subprocess.run(cmd, check=True, cwd=Path(__file__).resolve().parents[1])
+
+    assert db_path.exists(), "Optuna database was not created"
+    assert out_path.exists(), "Best params file was not created"
+    data = yaml.safe_load(out_path.read_text())
+    assert isinstance(data, dict) and data, "Best params YAML is empty"


### PR DESCRIPTION
## Summary
- add `scripts/optimize.py` to run Optuna study and save best hyperparameters
- log Optuna trials to configurable SQLite DB
- test optimization script and document progress in `TODO.md`

## Testing
- `pip install -r requirements.txt`
- `pre-commit run --files requirements.txt scripts/optimize.py tests/test_optimize_script.py TODO.md`
- `pytest tests/test_optimize_script.py`


------
https://chatgpt.com/codex/tasks/task_e_689224210f308327a2c9c44fab9fc4df