### PR TITLE
Implement core graph export and finalize config editor

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1384,15 +1384,15 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
         - [x] Verify FIFO eviction policy.
         - [x] Test inference output when prompts are applied.
 
-327. [ ] Add YAML config editor in Streamlit.
-    - [ ] Add new "Config Editor" tab using `st_ace` with YAML syntax.
+327. [x] Add YAML config editor in Streamlit.
+    - [x] Add new "Config Editor" tab using `st_ace` with YAML syntax.
         - [x] Extract helper functions for loading and saving config files.
         - [x] Display `config.yaml` in `st_ace` with syntax highlighting and line numbers.
         - [x] Add save button invoking helper functions.
-    - [ ] Validate YAML with schema on submit and save edits to `config.yaml` with backup timestamp.
+    - [x] Validate YAML with schema on submit and save edits to `config.yaml` with backup timestamp.
         - [x] Validate YAML and create timestamped backup during save.
         - [x] Surface validation success or errors in UI.
-    - [ ] Update GUI tests for the editor tab.
+    - [x] Update GUI tests for the editor tab.
         - [x] Unit test configuration load/save helpers.
         - [x] Simulate editing and saving a valid config.
         - [x] Confirm invalid YAML triggers error messages in UI.
@@ -1415,8 +1415,8 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
         - [x] Assert database and result files are created.
 
 329. [ ] Implement live neuron graph visualisation.
-    - [ ] Export graph as `{"nodes": [...], "edges": [...]}` in core.
-        - [ ] Gather neuron and synapse metadata into structured dicts.
+    - [x] Export graph as `{"nodes": [...], "edges": [...]}` in core.
+        - [x] Gather neuron and synapse metadata into structured dicts.
         - [ ] Support incremental updates for dynamic graphs.
     - [ ] Add `/graph` API endpoint.
         - [ ] Implement endpoint returning serialized graph JSON.

--- a/config_editor.py
+++ b/config_editor.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import yaml
 from config_schema import validate_config_schema
 
+__all__ = ["load_config_text", "save_config_text"]
+
 
 def load_config_text(path: str = "config.yaml") -> str:
     """Return YAML text from ``path``.

--- a/tests/test_networkx_interop.py
+++ b/tests/test_networkx_interop.py
@@ -4,9 +4,15 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import networkx as nx
+import pytest
 
 from marble_core import Core
-from networkx_interop import core_to_networkx, networkx_to_core
+from networkx_interop import (
+    core_to_networkx,
+    networkx_to_core,
+    core_to_dict,
+    dict_to_core,
+)
 from tests.test_core_functions import minimal_params
 
 
@@ -18,3 +24,29 @@ def test_core_to_networkx_and_back():
     new_core = networkx_to_core(g, params)
     assert len(new_core.neurons) == len(core.neurons)
     assert len(new_core.synapses) == len(core.synapses)
+
+
+def test_core_dict_roundtrip():
+    params = minimal_params()
+    core = Core(params, formula="0", formula_num_neurons=0)
+
+    # create two neurons and one synapse
+    n0 = core.neuron_pool.allocate()
+    n0.__init__(0, value=0.1, tier="vram", rep_size=core.rep_size)
+    core.neurons.append(n0)
+    n1 = core.neuron_pool.allocate()
+    n1.__init__(1, value=0.2, tier="vram", rep_size=core.rep_size)
+    core.neurons.append(n1)
+    syn = core.synapse_pool.allocate()
+    syn.__init__(0, 1, weight=0.3)
+    core.synapses.append(syn)
+    n0.synapses.append(syn)
+
+    data = core_to_dict(core)
+    assert data["nodes"][0]["id"] == 0
+    assert data["edges"][0]["source"] == 0
+
+    rebuilt = dict_to_core(data, params)
+    assert len(rebuilt.neurons) == 2
+    assert len(rebuilt.synapses) == 1
+    assert rebuilt.synapses[0].weight == pytest.approx(0.3)


### PR DESCRIPTION
## Summary
- add `core_to_dict`/`dict_to_core` helpers for serialising cores to plain data structures
- expose configuration editor helpers and ensure backup handling is available via module exports
- update TODO items for YAML config editor and graph export task

## Testing
- `pytest tests/test_config_editor.py -q`
- `pytest tests/test_streamlit_gui.py -q`
- `pytest tests/test_networkx_interop.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6892435c313483279b9caecd46bce620