### PR TITLE
Add graph API endpoint with optional authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ from tests.test_core_functions import minimal_params
 core = Core(minimal_params())
 nb = Neuronenblitz(core)
 brain = Brain(core, nb, DataLoader())
-server = InferenceServer(brain)
+server = InferenceServer(brain, api_token="secret")
 server.start()
 ```
 
@@ -549,6 +549,12 @@ Query the API using ``curl``:
 ```bash
 curl -X POST http://localhost:5000/infer -H 'Content-Type: application/json' \
      -d '{"input": 0.5}'
+```
+
+Retrieve the current neuron graph:
+
+```bash
+curl -H 'Authorization: Bearer secret' http://localhost:5000/graph
 ```
 
 Call ``server.stop()`` to shut it down.
@@ -913,7 +919,10 @@ metrics at regular intervals and writes them to CSV for later inspection.
 
 `web_api.InferenceServer` exposes a trained brain through a minimal Flask
 application. Sending a JSON payload to `/infer` returns the decoded output so
-other services can integrate MARBLE predictions.
+other services can integrate MARBLE predictions.  The server also provides a
+`/graph` endpoint returning the current neuron graph as JSON.  When the server
+is created with ``api_token="..."`` requests to `/graph` must include the header
+``Authorization: Bearer ...``.
 
 ## Troubleshooting
 If training diverges or produces NaNs:

--- a/TODO.md
+++ b/TODO.md
@@ -1418,9 +1418,9 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
     - [x] Export graph as `{"nodes": [...], "edges": [...]}` in core.
         - [x] Gather neuron and synapse metadata into structured dicts.
         - [ ] Support incremental updates for dynamic graphs.
-    - [ ] Add `/graph` API endpoint.
-        - [ ] Implement endpoint returning serialized graph JSON.
-        - [ ] Secure endpoint with optional authentication.
+    - [x] Add `/graph` API endpoint.
+        - [x] Implement endpoint returning serialized graph JSON.
+        - [x] Secure endpoint with optional authentication.
     - [ ] Render graph with `plotly.graph_objects.Sankey` or `pyvis.network` and add sliders for filtering.
         - [ ] Build reusable visualization component.
         - [ ] Provide sliders for weight and degree thresholds.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -662,17 +662,23 @@ Steps without this field continue to run locally on CPU or GPU as usual.
    from marble_core import Core, DataLoader
    from marble_neuronenblitz import Neuronenblitz
    from marble_brain import Brain
-   from web_api import InferenceServer
+from web_api import InferenceServer
 
-   core = Core(minimal_params())
-   nb = Neuronenblitz(core)
-    brain = Brain(core, nb, DataLoader())  # numeric inference values
-   server = InferenceServer(brain)
-   server.start()
+core = Core(minimal_params())
+nb = Neuronenblitz(core)
+brain = Brain(core, nb, DataLoader())  # numeric inference values
+server = InferenceServer(brain, api_token="secret")
+server.start()
    ```
 2. **Send requests** to `http://localhost:5000/infer` with JSON
    `{"input": 0.42}` and read back the numeric output.
-3. **Stop the server** by calling `server.stop()` when finished.
+3. **Fetch the neuron graph** by issuing:
+
+   ```bash
+   curl -H 'Authorization: Bearer secret' http://localhost:5000/graph
+   ```
+
+4. **Stop the server** by calling `server.stop()` when finished.
 
 This project highlights how MARBLE can integrate with external services through
 a minimal web API.

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -1,15 +1,17 @@
-import os, sys, time
-from threading import Thread
+import os
+import sys
+import time
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import requests
-from marble_core import Core
-from marble_neuronenblitz import Neuronenblitz
+
 from marble_brain import Brain
-from marble_core import DataLoader
+from marble_core import Core, DataLoader
+from marble_neuronenblitz import Neuronenblitz
+from prompt_memory import PromptMemory
 from tests.test_core_functions import minimal_params
 from web_api import InferenceServer
-from prompt_memory import PromptMemory
 
 
 def test_inference_server(tmp_path):
@@ -22,7 +24,9 @@ def test_inference_server(tmp_path):
     try:
         # wait briefly for server
         time.sleep(0.5)
-        resp = requests.post("http://localhost:5090/infer", json={"input": 0.1}, timeout=5)
+        resp = requests.post(
+            "http://localhost:5090/infer", json={"input": 0.1}, timeout=5
+        )
         assert resp.status_code == 200
         data = resp.json()
         assert "output" in data
@@ -41,11 +45,51 @@ def test_inference_server_with_prompt_memory(tmp_path):
     server.start()
     try:
         time.sleep(0.5)
-        resp = requests.post("http://localhost:5091/infer", json={"text": "hello"}, timeout=5)
+        resp = requests.post(
+            "http://localhost:5091/infer", json={"text": "hello"}, timeout=5
+        )
         assert resp.status_code == 200
         data = resp.json()
         assert "output" in data
         assert len(memory.get_pairs()) == 1
         assert memory.get_pairs()[0][0] == "hello"
+    finally:
+        server.stop()
+
+
+def test_graph_endpoint(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader())
+    server = InferenceServer(brain, host="localhost", port=5092)
+    server.start()
+    try:
+        time.sleep(0.5)
+        resp = requests.get("http://localhost:5092/graph", timeout=5)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "nodes" in data and "edges" in data
+    finally:
+        server.stop()
+
+
+def test_graph_endpoint_auth(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader())
+    server = InferenceServer(brain, host="localhost", port=5093, api_token="secret")
+    server.start()
+    try:
+        time.sleep(0.5)
+        resp = requests.get("http://localhost:5093/graph", timeout=5)
+        assert resp.status_code == 401
+        resp = requests.get(
+            "http://localhost:5093/graph",
+            headers={"Authorization": "Bearer secret"},
+            timeout=5,
+        )
+        assert resp.status_code == 200
     finally:
         server.stop()


### PR DESCRIPTION
## Summary
- expose a new `/graph` route in `InferenceServer` that serializes the current brain graph and optionally requires a bearer token
- document usage of the graph endpoint and API token in README and tutorial
- add tests covering the graph endpoint and authentication

## Testing
- `pre-commit run --files web_api.py tests/test_web_api.py README.md TUTORIAL.md TODO.md`
- `pytest tests/test_web_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68925472cdd483279367037f9e6b6d32