### PR TITLE
feat: support loss module plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -968,7 +968,7 @@ pre-commit install
 
 to automatically format and lint changes before each commit.
 
-\nMARBLE can be extended via a simple plugin system. Specify directories in the `plugins` list of the configuration and each module's `register` function will be invoked to add custom neuron or synapse types.
+\nMARBLE can be extended via a simple plugin system. Specify directories in the `plugins` list of the configuration and each module's `register` function will be invoked to add custom neuron, synapse, or loss modules. Registered loss modules become available via the ``loss_module`` configuration field and are initialised on CPU or GPU depending on hardware.
 Neuronenblitz exposes a runtime plugin API. After creating a `Neuronenblitz` instance you may activate modules via `n_plugin.activate("my_plugin")`. The plugin\x27s `activate(nb)` function receives the instance and can freely read or modify any attributes or methods.
 The repository now also provides a `global_workspace` plugin which broadcasts small messages to all registered listeners. Enable it by adding a `global_workspace` section to `config.yaml` and activating the plugin with `n_plugin.activate("global_workspace")`.
 An additional `attention_codelets` plugin can broadcast the output of custom

--- a/TODO.md
+++ b/TODO.md
@@ -770,11 +770,11 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [x] Implement Inspect neural pathways interactively via the GUI with CPU/GPU support.
    - [x] Add tests validating Inspect neural pathways interactively via the GUI.
    - [x] Document Inspect neural pathways interactively via the GUI in README and TUTORIAL.
-225. [ ] Register custom loss modules through the plugin system.
-   - [ ] Outline design for Register custom loss modules through the plugin system.
-   - [ ] Implement Register custom loss modules through the plugin system with CPU/GPU support.
-   - [ ] Add tests validating Register custom loss modules through the plugin system.
-   - [ ] Document Register custom loss modules through the plugin system in README and TUTORIAL.
+225. [x] Register custom loss modules through the plugin system.
+   - [x] Outline design for Register custom loss modules through the plugin system.
+   - [x] Implement Register custom loss modules through the plugin system with CPU/GPU support.
+   - [x] Add tests validating Register custom loss modules through the plugin system.
+   - [x] Document Register custom loss modules through the plugin system in README and TUTORIAL.
 226. [ ] Transfer knowledge between models using dataset serialisation features.
    - [ ] Outline design for Transfer knowledge between models using dataset serialisation features.
    - [ ] Implement Transfer knowledge between models using dataset serialisation features with CPU/GPU support.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -3260,3 +3260,51 @@ inspect the results within the Streamlit playground.
      tuning further.
    * *Best Configuration* – expander listing the top-performing parameters with a
      download button to export them as ``best_params.yaml`` for future runs.
+
+## Project 99 – Custom Loss Module Plugin
+
+**Goal:** Register a custom loss function through the plugin system and use it
+within Neuronenblitz training.
+
+1. **Create the plugin** in ``plugins/custom_loss.py``:
+
+   ```python
+   import torch.nn as nn
+
+   def register(reg_neuron, reg_synapse, reg_loss):
+       class SmoothL1(nn.Module):
+           def forward(self, pred, target):
+               return nn.functional.smooth_l1_loss(pred, target)
+
+       reg_loss("smooth_l1", SmoothL1)
+   ```
+
+2. **Download a dataset** for experimentation:
+
+   ```python
+   from torchvision.datasets import MNIST
+
+   MNIST("data", download=True)
+   ```
+
+3. **Load the plugin and construct a model**:
+
+   ```python
+   from plugin_system import load_plugins
+   from marble_core import Core
+   from marble_neuronenblitz import Neuronenblitz
+
+   load_plugins("plugins")
+   core = Core({})
+   nb = Neuronenblitz(core, loss_module="smooth_l1")
+   ```
+
+4. **Train on a single example to verify the loss**:
+
+   ```python
+   nb.train_example(0.5, 0.2)
+   ```
+
+This project demonstrates that loss modules provided by plugins can be
+referenced by name and are automatically initialised on CPU or GPU depending on
+hardware availability.

--- a/marble.py
+++ b/marble.py
@@ -21,7 +21,7 @@ from tqdm.notebook import tqdm  # For Jupyter-optimized progress bars
 
 from data_compressor import DataCompressor
 from dream_replay_buffer import DreamExperience, DreamReplayBuffer
-from marble_core import Core, Neuron, Synapse
+from marble_core import LOSS_MODULES, Core, Neuron, Synapse
 from marble_imports import cp
 
 
@@ -578,6 +578,13 @@ class Neuronenblitz:
         self.loss_fn = (
             loss_fn if loss_fn is not None else (lambda target, output: target - output)
         )
+        if isinstance(loss_module, str):
+            if loss_module not in LOSS_MODULES:
+                raise ValueError(
+                    f"Unknown loss_module '{loss_module}'. Available: {', '.join(LOSS_MODULES)}"
+                )
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            loss_module = LOSS_MODULES[loss_module]().to(device)
         self.loss_module = loss_module
         self.weight_update_fn = (
             weight_update_fn

--- a/marble_core.py
+++ b/marble_core.py
@@ -10,16 +10,16 @@ import random
 import time
 from collections import deque
 from datetime import datetime
-from typing import Any, Callable, Hashable
+from typing import Any, Callable, Hashable, Type
 
 import numpy as np
 import torch
 import torch.distributed as dist
+import torch.nn as nn
 from tokenizers import Tokenizer
-from event_bus import global_event_bus
 
 import tensor_backend as tb
-
+from event_bus import global_event_bus
 from marble_base import MetricsVisualizer
 from marble_imports import *  # noqa: F401,F403,F405
 from memory_pool import MemoryPool
@@ -401,6 +401,9 @@ SYNAPSE_TYPES = [
     "dropout",
     "batchnorm",
 ]
+
+# Registry of custom loss modules mapped by name
+LOSS_MODULES: dict[str, Type[nn.Module]] = {}
 
 # Global registry for all tiers
 TIER_REGISTRY = {}

--- a/tests/test_loss_module.py
+++ b/tests/test_loss_module.py
@@ -1,9 +1,11 @@
 import random
+
 import torch
 import torch.nn as nn
 
 from marble_core import Core
 from marble_neuronenblitz import Neuronenblitz
+from plugin_system import register_loss_module
 from tests.test_core_functions import minimal_params
 
 
@@ -14,6 +16,26 @@ def test_neuronenblitz_accepts_loss_module():
     loss_mod = nn.MSELoss()
     nb = Neuronenblitz(core, loss_module=loss_mod)
     out, err, _ = nb.train_example(0.5, 0.2)
-    expected = loss_mod(torch.tensor([out], dtype=torch.float32),
-                        torch.tensor([0.2], dtype=torch.float32)).item()
+    expected = loss_mod(
+        torch.tensor([out], dtype=torch.float32),
+        torch.tensor([0.2], dtype=torch.float32),
+    ).item()
+    assert abs(err - expected) < 1e-6
+
+
+def test_neuronenblitz_accepts_loss_module_name():
+    class L1Loss(nn.Module):
+        def forward(self, pred, target):
+            return nn.functional.l1_loss(pred, target)
+
+    register_loss_module("l1", L1Loss)
+    random.seed(0)
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core, loss_module="l1")
+    out, err, _ = nb.train_example(0.5, 0.2)
+    expected = L1Loss()(
+        torch.tensor([out], dtype=torch.float32),
+        torch.tensor([0.2], dtype=torch.float32),
+    ).item()
     assert abs(err - expected) < 1e-6

--- a/tests/test_plugin_system.py
+++ b/tests/test_plugin_system.py
@@ -3,20 +3,39 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+import torch.nn as nn
+
+from marble_core import LOSS_MODULES, NEURON_TYPES, SYNAPSE_TYPES
 from plugin_system import load_plugins
-from marble_core import NEURON_TYPES, SYNAPSE_TYPES
 
 
 def test_plugin_registration(tmp_path):
     plugin_code = (
-        "def register(reg_neuron, reg_synapse):\n"
+        "import torch.nn as nn\n"
+        "class MyLoss(nn.Module):\n"
+        "    def forward(self, pred, target):\n"
+        "        return nn.functional.l1_loss(pred, target)\n"
+        "def register(reg_neuron, reg_synapse, reg_loss):\n"
         "    reg_neuron('test_neuron')\n"
         "    reg_synapse('test_synapse')\n"
+        "    reg_loss('test_loss', MyLoss)\n"
     )
     plugin_file = tmp_path / "my_plugin.py"
     plugin_file.write_text(plugin_code)
+
+    legacy_code = (
+        "def register(reg_neuron, reg_synapse):\n"
+        "    reg_neuron('legacy_neuron')\n"
+        "    reg_synapse('legacy_synapse')\n"
+    )
+    legacy_file = tmp_path / "legacy_plugin.py"
+    legacy_file.write_text(legacy_code)
 
     load_plugins([str(tmp_path)])
 
     assert "test_neuron" in NEURON_TYPES
     assert "test_synapse" in SYNAPSE_TYPES
+    assert "test_loss" in LOSS_MODULES
+    assert issubclass(LOSS_MODULES["test_loss"], nn.Module)
+    assert "legacy_neuron" in NEURON_TYPES
+    assert "legacy_synapse" in SYNAPSE_TYPES

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -424,9 +424,11 @@ neuronenblitz:
   backtrack_enabled: If false, wandering never returns to previously visited
     neurons regardless of ``backtrack_probability``.
   loss_scale: Multiplier for training errors before they are applied to weights.
-  loss_module: PyTorch loss module object to compute training errors. If set to
-    an instance such as ``torch.nn.MSELoss()``, all weight updates use this
-    module's output as the error value.
+  loss_module: PyTorch loss module object or registry key to compute training
+    errors. Provide either an instance such as ``torch.nn.MSELoss()`` or the
+    name of a plugin-registered module (see ``plugin_system``). When a string
+    name is supplied the corresponding registered class is instantiated on CPU
+    or GPU depending on hardware availability.
   exploration_bonus: Additional reward added to rarely used synapses when they
     are traversed, encouraging exploration.
   synapse_potential_cap: Upper bound for ``synapse.potential`` to prevent


### PR DESCRIPTION
## Summary
- allow plugins to register loss modules and expose registry in plugin loader
- enable Neuronenblitz to instantiate loss modules by name with CPU/GPU support
- document loss-module plugin workflow and add tests

## Testing
- `pytest tests/test_plugin_system.py`
- `pytest tests/test_loss_module.py`


------
https://chatgpt.com/codex/tasks/task_e_689264c85b608327b1a12fa283cc6c5e