### PR TITLE
feat: add dream replay housekeeping and instant buffer

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -433,6 +433,9 @@ Each entry is listed under its section heading.
 - dream_replay_batch_size
 - dream_replay_weighting: Sampling strategy for the dream replay buffer
   ("linear", "exponential", "quadratic", "sqrt", "uniform").
+- dream_instant_buffer_size
+- dream_housekeeping_threshold: Minimum salience (0-1) below which experiences
+  are pruned during dream housekeeping
 - super_evolution_mode
 
 ## autograd

--- a/TODO.md
+++ b/TODO.md
@@ -1502,8 +1502,8 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 
 - [x] Tag training and ingestion pathways with emotion, arousal and stress values.
 - [x] Expose configurable weighting functions for dream replay beyond linear and exponential.
-- [ ] Implement mental housekeeping to prune low-importance connections during dreams.
-- [ ] Add short-term instant replay buffer and merge into long-term buffer.
+- [x] Implement mental housekeeping to prune low-importance connections during dreams.
+- [x] Add short-term instant replay buffer and merge into long-term buffer.
 - [ ] Orchestrate dream scheduler combining replay, weighting and housekeeping steps.
 - [ ] Persist replay buffers and neuromodulatory state in model snapshots.
 - [ ] Create integration tests verifying dreaming state survives save/load cycles.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -534,7 +534,7 @@ URL or loading routine changes.
    mutated, pruned = marble.brain.evolve(mutation_rate=0.02, prune_threshold=0.05)
    ```
    Mutations add noise to synapses while pruning removes the least useful ones.
-10. **Enable dreaming** by setting `dream_enabled: true` in `config.yaml`. Parameters like `dream_num_cycles`, `dream_interval`, and the new `dream_replay_buffer_size` and `dream_replay_batch_size` control how frequently dream cycles run and how many past experiences they consolidate.
+10. **Enable dreaming** by setting `dream_enabled: true` in `config.yaml`. Parameters like `dream_num_cycles`, `dream_interval`, `dream_replay_buffer_size`, `dream_replay_batch_size`, `dream_instant_buffer_size`, and `dream_housekeeping_threshold` control how frequently dream cycles run, how many past experiences they consolidate, how long recent memories stay in the instant buffer, and the salience required to keep memories during housekeeping.
 
 **Complete Example**
 ```python
@@ -2865,15 +2865,22 @@ Run `python project41_chat_training.py` to experiment with live conversation fin
 2. **Enable dream replay** in the configuration:
    ```yaml
    dream_enabled: true
- dream_replay_buffer_size: 50
- dream_replay_batch_size: 8
-  dream_replay_weighting: quadratic  # linear, exponential, quadratic, sqrt or uniform
+dream_replay_buffer_size: 50
+dream_replay_batch_size: 8
+ dream_replay_weighting: quadratic  # linear, exponential, quadratic, sqrt or uniform
+ dream_instant_buffer_size: 5
+ dream_housekeeping_threshold: 0.05
   ```
    The ``dream_replay_weighting`` option controls how salience biases sampling
    from the buffer. Use ``linear`` for proportional weighting, ``exponential``
    for a sharper focus on important memories, ``quadratic`` for an even
    stronger bias, ``sqrt`` to soften differences or ``uniform`` to sample
    experiences evenly.
+   The ``dream_instant_buffer_size`` option controls how many recent
+   experiences are temporarily staged before merging into the long-term replay
+   buffer. ``dream_housekeeping_threshold`` specifies the minimum salience
+   (between ``0`` and ``1``) an experience must have to survive the pruning step
+   that runs after each merge, allowing low-importance memories to be discarded.
 
 3. **Train and trigger dreaming** to observe consolidation:
    ```python

--- a/config.yaml
+++ b/config.yaml
@@ -311,6 +311,8 @@ brain:
   dream_replay_buffer_size: 100
   dream_replay_batch_size: 8
   dream_replay_weighting: "linear"
+  dream_instant_buffer_size: 10
+  dream_housekeeping_threshold: 0.05
   tier_decision_params:
     vram_usage_threshold: 0.9
     ram_usage_threshold: 0.9

--- a/config_loader.py
+++ b/config_loader.py
@@ -2,8 +2,9 @@ from pathlib import Path
 
 import yaml
 
+import tensor_backend as tb
 from config_schema import validate_config_schema
-from marble_core import MemorySystem, TIER_REGISTRY
+from marble_core import TIER_REGISTRY, MemorySystem
 from marble_main import MARBLE
 from meta_parameter_controller import MetaParameterController
 from neuromodulatory_system import NeuromodulatorySystem
@@ -11,8 +12,6 @@ from plugin_system import load_plugins
 from remote_hardware import load_remote_tier_plugin
 from remote_offload import RemoteBrainClient, RemoteBrainServer
 from torrent_offload import BrainTorrentClient, BrainTorrentTracker
-
-import tensor_backend as tb
 
 DEFAULT_CONFIG_FILE = Path(__file__).resolve().parent / "config.yaml"
 
@@ -89,9 +88,6 @@ def create_marble_from_config(
     neuro_base_neurons = brain_params.pop("neurogenesis_base_neurons", 5)
     neuro_base_synapses = brain_params.pop("neurogenesis_base_synapses", 10)
     super_evolution_mode = brain_params.pop("super_evolution_mode", False)
-    brain_params.pop("dream_replay_buffer_size", None)
-    brain_params.pop("dream_replay_batch_size", None)
-    brain_params.pop("dream_replay_weighting", None)
 
     formula = cfg.get("formula")
     formula_num_neurons = cfg.get("formula_num_neurons", 100)

--- a/marble.py
+++ b/marble.py
@@ -790,6 +790,8 @@ class Brain:
         dream_replay_weighting: str = "linear",
         dream_cycle_sleep: float = 0.1,
         dream_synapse_decay: float = 0.995,
+        dream_instant_buffer_size: int = 10,
+        dream_housekeeping_threshold: float = 0.05,
     ):
         self.core = core
         self.neuronenblitz = neuronenblitz
@@ -805,11 +807,16 @@ class Brain:
         self.dream_thread = None
 
         self.dream_buffer = DreamReplayBuffer(
-            dream_replay_buffer_size, weighting=dream_replay_weighting
+            dream_replay_buffer_size,
+            weighting=dream_replay_weighting,
+            instant_capacity=dream_instant_buffer_size,
+            housekeeping_threshold=dream_housekeeping_threshold,
         )
         self.dream_replay_batch_size = dream_replay_batch_size
         self.dream_cycle_sleep = dream_cycle_sleep
         self.dream_synapse_decay = dream_synapse_decay
+        self.dream_instant_buffer_size = dream_instant_buffer_size
+        self.dream_housekeeping_threshold = dream_housekeeping_threshold
 
         os.makedirs(self.save_dir, exist_ok=True)
         self.best_validation_loss = float("inf")
@@ -1164,6 +1171,13 @@ class MARBLE:
             "torrent_offload_enabled": False,
             "pytorch_model": None,
             "pytorch_input_size": None,
+            "dream_replay_buffer_size": 100,
+            "dream_replay_batch_size": 8,
+            "dream_replay_weighting": "linear",
+            "dream_cycle_sleep": 0.1,
+            "dream_synapse_decay": 0.995,
+            "dream_instant_buffer_size": 10,
+            "dream_housekeeping_threshold": 0.05,
         }
         if brain_params is not None:
             brain_defaults.update(brain_params)
@@ -1179,6 +1193,13 @@ class MARBLE:
             torrent_offload_enabled=brain_defaults["torrent_offload_enabled"],
             pytorch_model=brain_defaults["pytorch_model"],
             pytorch_input_size=brain_defaults["pytorch_input_size"],
+            dream_replay_buffer_size=brain_defaults["dream_replay_buffer_size"],
+            dream_replay_batch_size=brain_defaults["dream_replay_batch_size"],
+            dream_replay_weighting=brain_defaults["dream_replay_weighting"],
+            dream_cycle_sleep=brain_defaults["dream_cycle_sleep"],
+            dream_synapse_decay=brain_defaults["dream_synapse_decay"],
+            dream_instant_buffer_size=brain_defaults["dream_instant_buffer_size"],
+            dream_housekeeping_threshold=brain_defaults["dream_housekeeping_threshold"],
         )
 
         self.metrics_visualizer = MetricsVisualizer()

--- a/marble_main.py
+++ b/marble_main.py
@@ -1,5 +1,6 @@
 # ruff: noqa: F401, F403, F405
 import os
+
 from marble import MarbleConverter
 from marble_autograd import MarbleAutogradLayer
 from marble_base import MetricsVisualizer
@@ -54,7 +55,10 @@ class MARBLE:
         }
         if mv_params is not None:
             mv_defaults.update(mv_params)
-        disable_metrics = os.environ.get("MARBLE_DISABLE_METRICS", "").lower() in ("1", "true")
+        disable_metrics = os.environ.get("MARBLE_DISABLE_METRICS", "").lower() in (
+            "1",
+            "true",
+        )
         self.metrics_visualizer = None
         if not disable_metrics:
             self.metrics_visualizer = MetricsVisualizer(
@@ -223,6 +227,11 @@ class MARBLE:
             "super_evolution_mode": False,
             "dream_decay_arousal_scale": 0.0,
             "dream_decay_stress_scale": 0.0,
+            "dream_replay_buffer_size": 100,
+            "dream_replay_batch_size": 8,
+            "dream_replay_weighting": "linear",
+            "dream_instant_buffer_size": 10,
+            "dream_housekeeping_threshold": 0.05,
         }
         if brain_params is not None:
             brain_defaults.update(brain_params)
@@ -351,7 +360,9 @@ def insert_into_torch_model(
         marble = MARBLE(config["core"])
 
     train_in_graph = mode != "transparent"
-    hooked = attach_marble_layer(model, marble, after=position, train_in_graph=train_in_graph)
+    hooked = attach_marble_layer(
+        model, marble, after=position, train_in_graph=train_in_graph
+    )
     return hooked, marble
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,6 +98,11 @@ def test_load_config_defaults():
     assert cfg["data_compressor"]["compression_enabled"] is True
     assert cfg["brain"]["loss_growth_threshold"] == 0.1
     assert cfg["brain"]["dream_cycle_sleep"] == 0.1
+    assert cfg["brain"]["dream_replay_buffer_size"] == 100
+    assert cfg["brain"]["dream_replay_batch_size"] == 8
+    assert cfg["brain"]["dream_replay_weighting"] == "linear"
+    assert cfg["brain"]["dream_instant_buffer_size"] == 10
+    assert cfg["brain"]["dream_housekeeping_threshold"] == 0.05
     assert cfg["lobe_manager"]["attention_increase_factor"] == 1.05
     assert cfg["lobe_manager"]["attention_decrease_factor"] == 0.95
     assert cfg["network"]["remote_server"]["enabled"] is False
@@ -157,6 +162,11 @@ def test_create_marble_from_config():
     assert marble.core.synapse_weight_decay == 0.0
     assert marble.brain.loss_growth_threshold == 0.1
     assert marble.brain.dream_cycle_sleep == 0.1
+    assert marble.brain.dream_buffer.capacity == 100
+    assert marble.brain.dream_replay_batch_size == 8
+    assert marble.brain.dream_buffer.weighting == "linear"
+    assert marble.brain.dream_buffer.instant_capacity == 10
+    assert marble.brain.dream_buffer.housekeeping_threshold == 0.05
     assert marble.brain.lobe_manager.attention_increase_factor == 1.05
     assert marble.brain.lobe_manager.attention_decrease_factor == 0.95
     assert marble.brain.super_evolution_mode is False

--- a/tests/test_dream_replay_buffer.py
+++ b/tests/test_dream_replay_buffer.py
@@ -4,7 +4,7 @@ from dream_replay_buffer import DreamExperience, DreamReplayBuffer
 
 
 def test_eviction_by_salience():
-    buf = DreamReplayBuffer(capacity=2)
+    buf = DreamReplayBuffer(capacity=2, instant_capacity=1)
     low = DreamExperience(0.0, 0.0, reward=0.1, emotion=0.1, arousal=0.1, stress=0.0)
     high = DreamExperience(0.0, 0.0, reward=0.9, emotion=0.9, arousal=0.9, stress=0.0)
     buf.add(low)
@@ -37,8 +37,31 @@ def test_sampling_bias():
 def test_weighting_functions():
     sal = np.array([0.2, 0.8], dtype=float)
     buf = DreamReplayBuffer(capacity=3, weighting="quadratic")
-    assert np.allclose(buf._apply_weighting(sal), sal ** 2)
+    assert np.allclose(buf._apply_weighting(sal), sal**2)
     buf = DreamReplayBuffer(capacity=3, weighting="sqrt")
     assert np.allclose(buf._apply_weighting(sal), np.sqrt(sal))
     buf = DreamReplayBuffer(capacity=3, weighting="uniform")
     assert np.allclose(buf._apply_weighting(sal), np.ones_like(sal))
+
+
+def test_housekeeping_prunes_low_salience():
+    buf = DreamReplayBuffer(capacity=5, instant_capacity=2, housekeeping_threshold=0.5)
+    low = DreamExperience(0, 0, 0.1, 0.1, 0.1, 0.0)
+    high = DreamExperience(0, 0, 0.9, 0.9, 0.9, 0.0)
+    buf.add(low)
+    buf.add(high)  # triggers merge + housekeeping
+    assert len(buf.buffer) == 1
+    assert buf.buffer[0] is high
+
+
+def test_instant_buffer_merge():
+    buf = DreamReplayBuffer(capacity=3, instant_capacity=3)
+    exps = [
+        DreamExperience(0, 0, 0.2, 0.2, 0.2, 0.0),
+        DreamExperience(0, 0, 0.3, 0.3, 0.3, 0.0),
+        DreamExperience(0, 0, 0.4, 0.4, 0.4, 0.0),
+    ]
+    for exp in exps:
+        buf.add(exp)
+    assert len(buf.buffer) == 3
+    assert len(buf.instant_buffer) == 0

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -779,6 +779,17 @@ brain:
     salience items. ``"quadratic"`` squares the salience for a strong bias,
     ``"sqrt"`` uses the square root to soften differences and ``"uniform"``
     treats all memories equally.
+  dream_instant_buffer_size: Size of the short-term buffer that holds newly
+    observed experiences before consolidation. When the instant buffer reaches
+    this size it is merged into the main replay buffer. Values between ``1`` and
+    ``50`` work well in practice; larger sizes reduce merge frequency at the cost
+    of delayed consolidation.
+  dream_housekeeping_threshold: Minimum salience required for an experience to
+    remain after housekeeping during dreams. Salience is computed from reward,
+    emotion, arousal and stress and ranges from ``0`` (unimportant) to ``1``
+    (highly important). Experiences below this threshold are pruned to keep the
+    buffer focused on meaningful memories. Set to ``0`` to disable pruning
+    entirely.
   tier_decision_params:
     vram_usage_threshold: Fraction of VRAM usage that triggers migration of
       neurons to a lower tier.


### PR DESCRIPTION
## Summary
- extend DreamReplayBuffer with instant buffer and housekeeping pruning
- expose dream replay buffer sizing and pruning options through Brain and configuration
- document new dream replay settings and update tutorial and TODO

## Testing
- `pytest tests/test_dream_replay_buffer.py`
- `pytest tests/test_config.py`
- `pytest tests/test_brain_io.py`
- `pytest tests/test_dream_modulation.py`


------
https://chatgpt.com/codex/tasks/task_e_689281f3b8ec8327bb4bbad1b92e014d