### PR TITLE
Add dream consolidation benchmark

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1507,4 +1507,4 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 - [x] Orchestrate dream scheduler combining replay, weighting and housekeeping steps.
 - [x] Persist replay buffers and neuromodulatory state in model snapshots.
 - [x] Create integration tests verifying dreaming state survives save/load cycles.
-- [ ] Benchmark learning performance with and without dream consolidation.
+- [x] Benchmark learning performance with and without dream consolidation.

--- a/benchmark_dream_consolidation.py
+++ b/benchmark_dream_consolidation.py
@@ -1,0 +1,67 @@
+"""Benchmark impact of dream consolidation on learning performance.
+
+This script trains a small Neuronenblitz learner on a synthetic task
+and compares learning with and without dream-based consolidation.
+It reports average error and runtime for both settings.
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+from typing import Dict, List, Tuple
+
+from dream_reinforcement_learning import DreamReinforcementLearner
+from marble_core import Core
+from marble_imports import cp
+from marble_neuronenblitz import Neuronenblitz
+from tests.test_core_functions import minimal_params
+
+
+def _generate_dataset(num_examples: int) -> List[Tuple[float, float]]:
+    """Generate a simple linear dataset ``y = 2x`` for training."""
+    xs = cp.linspace(0, 1, num_examples)
+    ys = 2 * xs
+    return [(float(x), float(y)) for x, y in zip(xs, ys)]
+
+
+def _run_cycle(dream_cycles: int, episodes: int) -> Dict[str, float]:
+    """Run training for a given number of dream cycles and collect metrics."""
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    learner = DreamReinforcementLearner(core, nb, dream_cycles=dream_cycles)
+    dataset = _generate_dataset(episodes)
+
+    start = time.time()
+    learner.train(dataset, repeat=1)
+    duration = time.time() - start
+
+    errors = [h["error"] for h in learner.history]
+    avg_error = float(statistics.fmean(errors)) if errors else float("nan")
+    final_error = float(errors[-1]) if errors else float("nan")
+
+    return {
+        "dream_cycles": dream_cycles,
+        "avg_error": avg_error,
+        "final_error": final_error,
+        "duration": duration,
+    }
+
+
+def run_benchmark(episodes: int = 50) -> Dict[str, Dict[str, float]]:
+    """Compare learning with and without dream consolidation."""
+    with_dream = _run_cycle(dream_cycles=1, episodes=episodes)
+    without_dream = _run_cycle(dream_cycles=0, episodes=episodes)
+    return {"with_dream": with_dream, "without_dream": without_dream}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual benchmark
+    results = run_benchmark()
+    print("Dream consolidation benchmark results:")
+    for label, metrics in results.items():
+        print(
+            f"{label} -> avg_error: {metrics['avg_error']:.6f}, "
+            f"final_error: {metrics['final_error']:.6f}, "
+            f"duration: {metrics['duration']:.4f}s"
+        )

--- a/tests/test_benchmark_dream_consolidation.py
+++ b/tests/test_benchmark_dream_consolidation.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+
+import benchmark_dream_consolidation as bdc
+
+
+def test_benchmark_dream_consolidation_runs():
+    results = bdc.run_benchmark(episodes=10)
+    assert "with_dream" in results and "without_dream" in results
+    wd = results["with_dream"]
+    wo = results["without_dream"]
+    assert wd["avg_error"] == pytest.approx(wd["avg_error"])
+    assert wo["avg_error"] == pytest.approx(wo["avg_error"])
+    assert wd["duration"] >= 0.0 and wo["duration"] >= 0.0


### PR DESCRIPTION
## Summary
- add benchmark to compare learning with and without dream consolidation
- test harness for dream benchmark
- mark TODO item completed

## Testing
- `pre-commit run --files benchmark_dream_consolidation.py tests/test_benchmark_dream_consolidation.py TODO.md`
- `pytest tests/test_benchmark_dream_consolidation.py`
- `python benchmark_dream_consolidation.py`


------
https://chatgpt.com/codex/tasks/task_e_6892f1984cc08327a74d299c754ad683