### PR TITLE
feat: configurable dream intervals

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -584,6 +584,8 @@ Each entry is listed under its section heading.
 - episodes
 - dream_cycles
 - dream_strength
+- dream_interval
+- dream_cycle_duration
 
 ## continuous_weight_field_learning
 - enabled

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1635,7 +1635,7 @@ Run `python project21_quantum_flux.py` to experiment with quantum flux updates.
 
 **Goal:** Combine dreaming with reinforcement-like updates.**
 
-1. **Enable dream reinforcement** by setting `dream_reinforcement_learning.enabled: true` in the YAML file and configure `episodes`, `dream_cycles` and `dream_strength`.
+1. **Enable dream reinforcement** by setting `dream_reinforcement_learning.enabled: true` in the YAML file and configure `episodes`, `dream_cycles`, `dream_strength`, `dream_interval` and `dream_cycle_duration`.
 2. **Instantiate the learner**:
    ```python
    from dream_reinforcement_learning import DreamReinforcementLearner
@@ -1659,7 +1659,7 @@ Run `python project21_quantum_flux.py` to experiment with quantum flux updates.
            yield obs, reward
            obs = next_obs
    ```
-5. **Train episodes** by repeatedly calling `learner.train_episode(inp, tgt)` for each step. Imaginary updates occur after each real step; `dream_cycles` controls how many of these dreaming iterations happen.
+5. **Train episodes** by repeatedly calling `learner.train_episode(inp, tgt)` for each step. Imaginary updates occur periodically based on `dream_interval`; `dream_cycles` controls how many dream iterations run once triggered, and `dream_cycle_duration` sets an optional pause after each dream step.
 
 **Complete Example**
 ```python

--- a/config.yaml
+++ b/config.yaml
@@ -553,6 +553,8 @@ dream_reinforcement_learning:
   episodes: 1
   dream_cycles: 1
   dream_strength: 0.5
+  dream_interval: 1
+  dream_cycle_duration: null
 
 continuous_weight_field_learning:
   enabled: false

--- a/dream_reinforcement_learning.py
+++ b/dream_reinforcement_learning.py
@@ -1,30 +1,52 @@
-from marble_imports import *
-from marble_core import perform_message_passing, Core
+import time
+
+from marble_core import Core, perform_message_passing
+from marble_imports import *  # noqa: F403
 from marble_neuronenblitz import Neuronenblitz
+
 
 class DreamReinforcementLearner:
     """Hybrid reinforcement paradigm mixing real and dreamed experiences."""
 
-    def __init__(self, core: Core, nb: Neuronenblitz, dream_cycles: int = 1, dream_strength: float = 0.5) -> None:
+    def __init__(
+        self,
+        core: Core,
+        nb: Neuronenblitz,
+        dream_cycles: int = 1,
+        dream_strength: float = 0.5,
+        dream_interval: int = 1,
+        dream_cycle_duration: float | None = None,
+    ) -> None:
         self.core = core
         self.nb = nb
         self.dream_cycles = int(dream_cycles)
         self.dream_strength = float(dream_strength)
+        # ``dream_interval`` controls after how many wander cycles dream steps run.
+        # Value must be at least one.
+        self.dream_interval = max(1, int(dream_interval))
+        # Optional fixed duration (in seconds) for each dream step. ``None`` uses
+        # the natural execution time without extra delay.
+        self.dream_cycle_duration = dream_cycle_duration
         self.history: list[dict] = []
+        self._wander_count = 0
 
     def _dream_step(self, value: float) -> None:
         dream_output, path = self.nb.dynamic_wander(value)
         error = value - dream_output
         self.nb.apply_weight_updates_and_attention(path, error * self.dream_strength)
         perform_message_passing(self.core)
+        if self.dream_cycle_duration is not None:
+            time.sleep(self.dream_cycle_duration)
 
     def train_episode(self, input_value: float, target_value: float) -> float:
         output, path = self.nb.dynamic_wander(input_value)
         error = target_value - output
         self.nb.apply_weight_updates_and_attention(path, error)
         perform_message_passing(self.core)
-        for _ in range(self.dream_cycles):
-            self._dream_step(output)
+        self._wander_count += 1
+        if self._wander_count % self.dream_interval == 0:
+            for _ in range(self.dream_cycles):
+                self._dream_step(output)
         self.history.append({"error": float(error)})
         return float(error)
 

--- a/tests/test_dream_reinforcement_learning.py
+++ b/tests/test_dream_reinforcement_learning.py
@@ -1,11 +1,14 @@
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from tests.test_core_functions import minimal_params
+from unittest.mock import patch
+
+from dream_reinforcement_learning import DreamReinforcementLearner
 from marble_core import Core
 from marble_neuronenblitz import Neuronenblitz
-from dream_reinforcement_learning import DreamReinforcementLearner
+from tests.test_core_functions import minimal_params
 
 
 def test_dream_reinforcement_learning_runs():
@@ -16,3 +19,23 @@ def test_dream_reinforcement_learning_runs():
     err = learner.train_episode(0.5, 1.0)
     assert isinstance(err, float)
     assert learner.history
+
+
+def test_dream_interval_and_duration():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    learner = DreamReinforcementLearner(
+        core, nb, dream_cycles=1, dream_interval=2, dream_cycle_duration=0.001
+    )
+    with patch.object(
+        DreamReinforcementLearner, "_dream_step", wraps=learner._dream_step
+    ) as mock_dream:
+        learner.train_episode(0.2, 0.4)
+        assert mock_dream.call_count == 0
+        learner.train_episode(0.3, 0.6)
+        assert mock_dream.call_count == 1
+    # verify duration triggers sleep
+    with patch("time.sleep") as mock_sleep:
+        learner._dream_step(0.1)
+        mock_sleep.assert_called_once_with(0.001)

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -1365,6 +1365,12 @@ dream_reinforcement_learning:
   episodes: Number of training episodes consisting of input-target pairs.
   dream_cycles: How many dream updates follow each real step.
   dream_strength: Multiplier applied to dream errors before weight updates.
+  dream_interval: Number of real wander steps between dream batches. ``1`` means
+    dream after every wander cycle; higher values postpone dreaming. Values must
+    be positive integers. Typical range: 1–10.
+  dream_cycle_duration: Optional pause inserted after each dream step expressed
+    in seconds (fractional values allow millisecond precision). When ``null`` no
+    additional delay is added and dream steps take their natural execution time.
 
 continuous_weight_field_learning:
   # Optimises a weight vector ``W(x)`` that varies smoothly with the input ``x``.


### PR DESCRIPTION
## Summary
- allow DreamReinforcementLearner to run dream cycles every N wander cycles and optionally sleep after each dream
- expose `dream_interval` and `dream_cycle_duration` in config and docs
- test interval scheduling and sleep injection

## Testing
- `pre-commit run --files dream_reinforcement_learning.py config.yaml CONFIGURABLE_PARAMETERS.md yaml-manual.txt TUTORIAL.md tests/test_dream_reinforcement_learning.py`
- `pytest tests/test_dream_reinforcement_learning.py`


------
https://chatgpt.com/codex/tasks/task_e_6892f44ee7d88327bdfa924f75122b45