### PR TITLE
Add configuration benchmarking utility

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -467,6 +467,30 @@ pipe.execute(cache_dir="cache")  # second run loads from disk
    ```
    The helper moves tensors back to the CPU for scoring and empties the GPU cache between trials so even long searches run reliably on limited hardware.
 
+13. **Benchmark multiple configurations** using `benchmark_training_configs`:
+   ```python
+   import csv, urllib.request
+   from pathlib import Path
+   from benchmark_config_training import benchmark_training_configs
+
+   url = "https://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/winequality-red.csv"
+   raw = urllib.request.urlopen(url).read().decode("utf-8").splitlines()[1:51]
+   reader = csv.reader(raw, delimiter=";")
+   data = [(float(r[0]), float(r[-1])) for r in reader]
+
+   Path("config1.yaml").write_text("brain:\n  manual_seed: 0\nneuronenblitz:\n  learning_rate: 0.01\n")
+   Path("config2.yaml").write_text("brain:\n  manual_seed: 0\nneuronenblitz:\n  learning_rate: 0.02\n")
+
+   results, best_path = benchmark_training_configs(
+       data,
+       ["config1.yaml", "config2.yaml"],
+   )
+   print("Best configuration:", best_path)
+   ```
+   The function trains a fresh MARBLE instance for each YAML file, reports
+   validation loss for every configuration and renames the best performing file
+   to `best_config.yaml`.
+
 **Complete Example**
 ```python
 # project1_numeric_regression.py

--- a/benchmark_config_training.py
+++ b/benchmark_config_training.py
@@ -1,0 +1,79 @@
+"""Benchmark MARBLE training across multiple YAML configurations."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable, Tuple, Dict, List
+
+import torch
+
+from config_loader import create_marble_from_config
+
+Dataset = Iterable[Tuple[float, float]]
+
+
+def benchmark_training_configs(
+    dataset: Dataset,
+    config_paths: List[str | os.PathLike],
+    *,
+    snapshot: str | None = None,
+    epochs: int = 1,
+) -> Tuple[Dict[str, float], str]:
+    """Train and evaluate MARBLE models for each configuration.
+
+    Parameters
+    ----------
+    dataset:
+        Iterable of ``(input, target)`` pairs used for both training and validation.
+    config_paths:
+        List of paths to YAML configuration files. Each file is evaluated
+        independently. The best performing configuration will be renamed to
+        ``best_config.yaml`` within its directory.
+    snapshot:
+        Optional checkpoint path. When provided, each MARBLE instance will load
+        this checkpoint before training, ensuring identical initial state across
+        configurations.
+    epochs:
+        Number of epochs to train for each configuration. Defaults to ``1``.
+
+    Returns
+    -------
+    Tuple containing a mapping of configuration paths to final validation loss
+    and the path of the best configuration renamed to ``best_config.yaml``.
+    """
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if hasattr(torch, "set_default_device"):
+        torch.set_default_device(device)
+    results: Dict[str, float] = {}
+
+    for cfg in config_paths:
+        cfg_path = Path(cfg)
+        marble = create_marble_from_config(str(cfg_path))
+        brain = marble.get_brain()
+        if snapshot is not None:
+            brain.load_checkpoint(snapshot)
+        brain.train(dataset, epochs=epochs, validation_examples=dataset)
+        loss = float(brain.validate(dataset))
+        results[str(cfg_path)] = loss
+        print(f"{cfg_path.name}: {loss:.6f}")
+        del marble
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    cfg_names = list(results.keys())
+    for i, a in enumerate(cfg_names):
+        for b in cfg_names[i + 1 :]:
+            diff = results[a] - results[b]
+            print(f"{Path(a).name} vs {Path(b).name}: {diff:+.6f}")
+
+    best_cfg = min(results, key=results.get)
+    best_path = Path(best_cfg)
+    target = best_path.with_name("best_config.yaml")
+    if target.exists():
+        target.unlink()
+    os.rename(best_path, target)
+    print(f"Best configuration: {best_path.name} -> {target.name}")
+    return results, str(target)
+
+
+__all__ = ["benchmark_training_configs"]

--- a/tests/test_config_training_benchmark.py
+++ b/tests/test_config_training_benchmark.py
@@ -1,0 +1,26 @@
+import torch
+from pathlib import Path
+
+import pytest
+
+from benchmark_config_training import benchmark_training_configs
+
+
+@pytest.mark.parametrize(
+    "device",
+    [torch.device("cpu")] + ([torch.device("cuda")] if torch.cuda.is_available() else []),
+)
+def test_benchmark_training_configs(tmp_path, device):
+    if hasattr(torch, "set_default_device"):
+        torch.set_default_device(device)
+    dataset = [(0.0, 0.0), (1.0, 1.0)]
+    cfg1 = tmp_path / "config1.yaml"
+    cfg2 = tmp_path / "config2.yaml"
+    base = "brain:\n  manual_seed: 0\n"
+    cfg1.write_text(base + "neuronenblitz:\n  learning_rate: 0.01\n")
+    cfg2.write_text(base + "neuronenblitz:\n  learning_rate: 0.02\n")
+    results, best_path = benchmark_training_configs(dataset, [str(cfg1), str(cfg2)])
+    assert str(cfg1) in results and str(cfg2) in results
+    assert (tmp_path / "best_config.yaml").exists()
+    assert Path(best_path).name == "best_config.yaml"
+    assert not (cfg1.exists() and cfg2.exists())


### PR DESCRIPTION
## Summary
- add benchmark_training_configs to evaluate and compare multiple YAML configs
- document configuration benchmarking workflow in TUTORIAL
- test configuration benchmarking including best-config renaming

## Testing
- `pytest tests/test_config_training_benchmark.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6892fb06ddd08327b388db224e0c9024