### PR TITLE
Add dataset-based knowledge transfer via serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ pipeline. Invalid or corrupted pairs can be removed at any time with
 ``BitTensorDataset.prune_invalid`` which accepts a callback to check decoded
 objects.
 
+Serialised datasets can also act as a lightweight interchange format for
+knowledge transfer. The helper ``transfer_dataset_knowledge`` round-trips a
+``BitTensorDataset`` through JSON and trains a target ``Neuronenblitz`` on
+CPU or GPU, making it easy to ship training examples from one model to
+another regardless of hardware.
+
 ### Streaming Dataset Step
 
 ``StreamingDatasetStep`` wraps a ``BitTensorDataset`` iterator and prefetches

--- a/TODO.md
+++ b/TODO.md
@@ -775,11 +775,11 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [x] Implement Register custom loss modules through the plugin system with CPU/GPU support.
    - [x] Add tests validating Register custom loss modules through the plugin system.
    - [x] Document Register custom loss modules through the plugin system in README and TUTORIAL.
-226. [ ] Transfer knowledge between models using dataset serialisation features.
-   - [ ] Outline design for Transfer knowledge between models using dataset serialisation features.
-   - [ ] Implement Transfer knowledge between models using dataset serialisation features with CPU/GPU support.
-   - [ ] Add tests validating Transfer knowledge between models using dataset serialisation features.
-   - [ ] Document Transfer knowledge between models using dataset serialisation features in README and TUTORIAL.
+226. [x] Transfer knowledge between models using dataset serialisation features.
+   - [x] Outline design for Transfer knowledge between models using dataset serialisation features.
+   - [x] Implement Transfer knowledge between models using dataset serialisation features with CPU/GPU support.
+   - [x] Add tests validating Transfer knowledge between models using dataset serialisation features.
+   - [x] Document Transfer knowledge between models using dataset serialisation features in README and TUTORIAL.
 227. [ ] Refresh vocabulary encodings mid-training when datasets evolve.
    - [ ] Outline design for Refresh vocabulary encodings mid-training when datasets evolve.
    - [ ] Implement Refresh vocabulary encodings mid-training when datasets evolve with CPU/GPU support.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -150,6 +150,24 @@ Set ``dataloader.tokenizer_type: bert_wordpiece`` or ``tokenizer_json`` in
 project example assumes a ``dataloader`` prepared this way and passes it to
 ``load_dataset``.
 
+### Transferring knowledge between models
+
+Serialized datasets are a convenient medium for moving training examples from
+one model to another. A ``BitTensorDataset`` can be converted to JSON on the
+source machine and reloaded on CPU or GPU for the target. The helper
+``transfer_dataset_knowledge`` performs this round trip and trains a target
+``Neuronenblitz``:
+
+```python
+from transfer_learning import transfer_dataset_knowledge
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+
+core = Core(params)
+nb = Neuronenblitz(core)
+transfer_dataset_knowledge(dataset, nb, device="cuda" if torch.cuda.is_available() else "cpu")
+```
+
 ### Project: Streaming Dataset Pipeline
 
 This project demonstrates how to process a streaming dataset through a pipeline.

--- a/tests/test_dataset_transfer.py
+++ b/tests/test_dataset_transfer.py
@@ -1,0 +1,34 @@
+import pytest
+import torch
+
+from bit_tensor_dataset import BitTensorDataset
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from tests.test_core_functions import minimal_params
+from transfer_learning import transfer_dataset_knowledge
+
+
+def _make_dataset(device):
+    pairs = [(float(i), float(i + 1)) for i in range(3)]
+    return BitTensorDataset(pairs, device=device)
+
+
+def test_transfer_dataset_between_models_cpu():
+    ds = _make_dataset("cpu")
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    ds2 = transfer_dataset_knowledge(ds, nb, device="cpu")
+    assert len(nb.training_history) == len(ds2)
+    assert all(inp.device.type == "cpu" for inp, _ in ds2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_transfer_dataset_between_models_gpu():
+    ds = _make_dataset("cuda")
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    ds2 = transfer_dataset_knowledge(ds, nb, device="cuda")
+    assert len(nb.training_history) == len(ds2)
+    assert all(inp.device.type == "cuda" for inp, _ in ds2)

--- a/transfer_learning.py
+++ b/transfer_learning.py
@@ -1,10 +1,16 @@
+import torch
+
+from bit_tensor_dataset import BitTensorDataset
 from marble_core import Core, perform_message_passing
 from marble_neuronenblitz import Neuronenblitz
+
 
 class TransferLearner:
     """Fine-tune a pretrained network while freezing a subset of synapses."""
 
-    def __init__(self, core: Core, nb: Neuronenblitz, freeze_fraction: float = 0.5) -> None:
+    def __init__(
+        self, core: Core, nb: Neuronenblitz, freeze_fraction: float = 0.5
+    ) -> None:
         if not 0.0 <= freeze_fraction <= 1.0:
             raise ValueError("freeze_fraction must be between 0 and 1")
         self.core = core
@@ -26,3 +32,41 @@ class TransferLearner:
         for _ in range(int(epochs)):
             for inp, tgt in examples:
                 self.train_step(float(inp), float(tgt))
+
+
+def transfer_dataset_knowledge(
+    dataset: BitTensorDataset,
+    nb: Neuronenblitz,
+    *,
+    device: str | torch.device | None = None,
+) -> BitTensorDataset:
+    """Train ``nb`` using a dataset round-tripped through JSON serialisation.
+
+    The function serialises ``dataset`` to JSON via :meth:`BitTensorDataset.to_json`
+    and reconstructs it on ``device`` using :meth:`BitTensorDataset.from_json`.
+    Each decoded pair is then supplied to :meth:`Neuronenblitz.train_example`,
+    enabling knowledge transfer between models regardless of hardware.
+
+    Parameters
+    ----------
+    dataset:
+        Source dataset containing ``(input, target)`` pairs.
+    nb:
+        Target ``Neuronenblitz`` instance that will be trained.
+    device:
+        Device for the reloaded dataset. When ``None`` the dataset is restored on
+        CPU unless a GPU is available.
+
+    Returns
+    -------
+    BitTensorDataset
+        The reloaded dataset used during training.
+    """
+
+    json_str = dataset.to_json()
+    ds = BitTensorDataset.from_json(json_str, device=device)
+    for inp_tensor, tgt_tensor in ds:
+        inp = ds.decode_tensor(inp_tensor)
+        tgt = ds.decode_tensor(tgt_tensor)
+        nb.train_example(float(inp), float(tgt))
+    return ds


### PR DESCRIPTION
## Summary
- add `transfer_dataset_knowledge` helper to round-trip `BitTensorDataset` through JSON and train a target model on CPU or GPU
- cover dataset knowledge transfer with new tests
- document serialized knowledge transfer and mark TODO entry complete

## Testing
- `pytest tests/test_dataset_transfer.py::test_transfer_dataset_between_models_cpu -q`
- `pytest tests/test_dataset_transfer.py::test_transfer_dataset_between_models_gpu -q` (skipped: CUDA not available)


------
https://chatgpt.com/codex/tasks/task_e_6892fe25b6108327ab2c8e703e4d9954