### PR TITLE
Add EvolutionTrainer with lineage tracking and docs

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -52,6 +52,14 @@ Each entry is listed under its section heading.
 ## sync
 - interval_ms
 
+## evolution
+- population_size
+- selection_size
+- generations
+- steps_per_candidate
+- mutation_rate
+- parallelism
+
 ## core
 - xmin
 - xmax

--- a/TODO.md
+++ b/TODO.md
@@ -1445,22 +1445,22 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
         - [ ] Unit test message exchange between two agents.
         - [ ] Validate environment simulations run without deadlocks.
 
-331. [ ] Add evolutionary learning module.
-    - [ ] Create `EvolutionTrainer` class.
-        - [ ] Implement mutation, evaluation, and selection hooks.
-        - [ ] Support parallel evaluation of candidates.
-    - [ ] Generate `N` config mutations, train each for a few steps, and evaluate fitness.
-        - [ ] Define mutation operators for numeric and categorical params.
-        - [ ] Collect fitness metrics after partial training.
-    - [ ] Select top `M` configurations and mutate again.
-        - [ ] Rank configurations by fitness.
-        - [ ] Produce next-generation configs via mutation.
-    - [ ] Log evolution tree and best lineage.
-        - [ ] Track parent-child relationships.
-        - [ ] Serialize lineage to JSON and graphs.
-    - [ ] Add tests for evolutionary training.
-        - [ ] Unit test mutation and selection logic.
-        - [ ] Integration test over multiple generations.
+331. [x] Add evolutionary learning module.
+    - [x] Create `EvolutionTrainer` class.
+        - [x] Implement mutation, evaluation, and selection hooks.
+        - [x] Support parallel evaluation of candidates.
+    - [x] Generate `N` config mutations, train each for a few steps, and evaluate fitness.
+        - [x] Define mutation operators for numeric and categorical params.
+        - [x] Collect fitness metrics after partial training.
+    - [x] Select top `M` configurations and mutate again.
+        - [x] Rank configurations by fitness.
+        - [x] Produce next-generation configs via mutation.
+    - [x] Log evolution tree and best lineage.
+        - [x] Track parent-child relationships.
+        - [x] Serialize lineage to JSON and graphs.
+    - [x] Add tests for evolutionary training.
+        - [x] Unit test mutation and selection logic.
+        - [x] Integration test over multiple generations.
 
 332. [ ] Document new configuration parameters and tutorials.
     - [ ] Update `yaml-manual.txt` with detailed explanations and examples.

--- a/config.yaml
+++ b/config.yaml
@@ -51,6 +51,14 @@ serve_model:
 sync:
   interval_ms: 1000     # Interval in milliseconds between cross-device tensor synchronization cycles
 
+evolution:
+  population_size: 4        # Number of configurations evaluated per generation
+  selection_size: 2         # Top configurations kept after each generation
+  generations: 2            # How many generations to run
+  steps_per_candidate: 1    # Training steps per candidate during evaluation
+  mutation_rate: 0.1        # Fraction of parameters mutated in each offspring
+  parallelism: 2            # Number of candidates evaluated concurrently
+
 # =====
 # Core
 # =====

--- a/config_schema.py
+++ b/config_schema.py
@@ -22,6 +22,17 @@ CONFIG_SCHEMA = {
             },
         },
         "neuronenblitz": {"type": "object"},
+        "evolution": {
+            "type": "object",
+            "properties": {
+                "population_size": {"type": "integer", "minimum": 1},
+                "selection_size": {"type": "integer", "minimum": 1},
+                "generations": {"type": "integer", "minimum": 1},
+                "steps_per_candidate": {"type": "integer", "minimum": 1},
+                "mutation_rate": {"type": "number", "minimum": 0, "maximum": 1},
+                "parallelism": {"type": "integer", "minimum": 1},
+            },
+        },
         "brain": {
             "type": "object",
             "properties": {

--- a/evolution_trainer.py
+++ b/evolution_trainer.py
@@ -1,0 +1,172 @@
+"""Evolutionary hyperparameter optimization utilities."""
+
+from __future__ import annotations
+
+import copy
+import json
+import math
+import os
+import random
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+import networkx as nx
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+try:
+    import torch
+except Exception:  # pragma: no cover - torch may be optional
+    torch = None
+
+
+@dataclass
+class Candidate:
+    """Represents a configuration under evaluation."""
+
+    id: int
+    config: Dict[str, Any]
+    parent_id: Optional[int] = None
+    fitness: Optional[float] = None
+
+
+class EvolutionTrainer:
+    """Explore configuration space using evolutionary strategies.
+
+    The trainer maintains a population of candidate configurations. Each
+    generation mutates candidates, evaluates their fitness in parallel and
+    selects the strongest individuals to seed the next generation.
+    """
+
+    def __init__(
+        self,
+        base_config: Dict[str, Any],
+        train_func: Callable[[Dict[str, Any], int, str], float],
+        mutation_space: Dict[str, Dict[str, Any]],
+        population_size: int,
+        selection_size: int,
+        generations: int,
+        *,
+        mutation_rate: float = 0.1,
+        steps_per_candidate: int = 5,
+        parallelism: Optional[int] = None,
+    ) -> None:
+        if population_size < 1 or selection_size < 1 or generations < 1:
+            raise ValueError("population_size, selection_size and generations must be positive")
+        if not 0.0 <= mutation_rate <= 1.0:
+            raise ValueError("mutation_rate must be in [0,1]")
+        if selection_size > population_size:
+            raise ValueError("selection_size cannot exceed population_size")
+        self.base_config = copy.deepcopy(base_config)
+        self.train_func = train_func
+        self.mutation_space = mutation_space
+        self.population_size = population_size
+        self.selection_size = selection_size
+        self.generations = generations
+        self.mutation_rate = mutation_rate
+        self.steps_per_candidate = steps_per_candidate
+        self.parallelism = parallelism or os.cpu_count() or 1
+        self.device = "cuda" if torch is not None and torch.cuda.is_available() else "cpu"
+        self._candidate_counter = 0
+        self.graph = nx.DiGraph()
+        self.lineage: List[Dict[str, Any]] = []
+
+    # ------------------------------------------------------------------
+    # Mutation operators
+    # ------------------------------------------------------------------
+    def mutate(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a mutated copy of ``config`` according to ``mutation_space``."""
+        mutated = copy.deepcopy(config)
+        for key, spec in self.mutation_space.items():
+            if random.random() > self.mutation_rate:
+                continue
+            if spec.get("type") in {"float", "int"}:
+                base = float(mutated.get(key, self.base_config.get(key, 0.0)))
+                sigma = float(spec.get("sigma", 0.1))
+                new_val = base * math.exp(random.gauss(0.0, sigma))
+                if spec["type"] == "int":
+                    new_val = int(round(new_val))
+                minv = spec.get("min")
+                maxv = spec.get("max")
+                if minv is not None:
+                    new_val = max(minv, new_val)
+                if maxv is not None:
+                    new_val = min(maxv, new_val)
+                mutated[key] = new_val
+            elif spec.get("type") == "categorical":
+                options = list(spec.get("options", []))
+                if not options:
+                    continue
+                current = mutated.get(key, self.base_config.get(key))
+                choices = [o for o in options if o != current] or options
+                mutated[key] = random.choice(choices)
+            else:
+                raise ValueError(f"Unknown mutation type for {key}: {spec}")
+        return mutated
+
+    # ------------------------------------------------------------------
+    # Evaluation hooks
+    # ------------------------------------------------------------------
+    def evaluate(self, candidate: Candidate) -> float:
+        """Train ``candidate.config`` for a few steps and return fitness."""
+        fitness = float(self.train_func(candidate.config, self.steps_per_candidate, self.device))
+        candidate.fitness = fitness
+        self.graph.add_node(candidate.id, fitness=fitness)
+        if candidate.parent_id is not None:
+            self.graph.add_edge(candidate.parent_id, candidate.id)
+        self.lineage.append({
+            "id": candidate.id,
+            "parent": candidate.parent_id,
+            "fitness": fitness,
+            "config": candidate.config,
+        })
+        return fitness
+
+    # ------------------------------------------------------------------
+    # Selection hooks
+    # ------------------------------------------------------------------
+    def select(self, population: List[Candidate]) -> List[Candidate]:
+        """Return the top ``selection_size`` candidates by fitness."""
+        ranked = sorted(population, key=lambda c: c.fitness if c.fitness is not None else float("inf"))
+        return ranked[: self.selection_size]
+
+    # ------------------------------------------------------------------
+    def _next_id(self) -> int:
+        self._candidate_counter += 1
+        return self._candidate_counter
+
+    def _spawn(self, parents: List[Candidate]) -> List[Candidate]:
+        """Create a population by mutating ``parents``."""
+        new_pop: List[Candidate] = []
+        while len(new_pop) < self.population_size:
+            parent = random.choice(parents)
+            cfg = self.mutate(parent.config)
+            new_pop.append(Candidate(id=self._next_id(), config=cfg, parent_id=parent.id))
+        return new_pop
+
+    def evolve(self) -> Candidate:
+        """Run the evolutionary loop and return the best candidate."""
+        base = Candidate(id=self._next_id(), config=self.base_config, parent_id=None)
+        population = self._spawn([base])
+        population.insert(0, base)
+        for _ in range(self.generations):
+            with ThreadPoolExecutor(max_workers=self.parallelism) as ex:
+                futures = {ex.submit(self.evaluate, c): c for c in population}
+                for f in as_completed(futures):
+                    f.result()
+            parents = self.select(population)
+            if _ < self.generations - 1:
+                population = self._spawn(parents)
+            else:
+                population = parents
+        best = min(population, key=lambda c: c.fitness if c.fitness is not None else float("inf"))
+        return best
+
+    # ------------------------------------------------------------------
+    def export_lineage_json(self, path: str) -> None:
+        """Serialize lineage information to ``path``."""
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(self.lineage, f, indent=2)
+
+    def export_lineage_graph(self, path: str) -> None:
+        """Write the evolution graph to ``path`` in GraphML format."""
+        nx.write_graphml(self.graph, path)

--- a/tests/test_evolution_trainer.py
+++ b/tests/test_evolution_trainer.py
@@ -1,0 +1,35 @@
+import json
+from evolution_trainer import EvolutionTrainer, Candidate
+
+
+def _train(config, steps, device):
+    import torch
+    x = torch.tensor(config["x"], device=device, dtype=torch.float32)
+    target = torch.tensor(1.0, device=device)
+    return torch.abs(x - target).item()
+
+
+def test_mutation_and_selection():
+    base = {"x": 0.5, "choice": "a"}
+    space = {
+        "x": {"type": "float", "min": 0.0, "max": 2.0, "sigma": 0.1},
+        "choice": {"type": "categorical", "options": ["a", "b"]},
+    }
+    trainer = EvolutionTrainer(
+        base,
+        _train,
+        space,
+        population_size=4,
+        selection_size=2,
+        generations=1,
+        mutation_rate=1.0,
+        steps_per_candidate=1,
+        parallelism=1,
+    )
+    mutated = trainer.mutate(base)
+    assert 0.0 <= mutated["x"] <= 2.0
+    assert mutated["choice"] in ["a", "b"]
+    c1 = Candidate(1, base, fitness=0.2)
+    c2 = Candidate(2, base, fitness=0.1)
+    selected = trainer.select([c1, c2])
+    assert selected[0] is c2

--- a/tests/test_evolution_trainer_integration.py
+++ b/tests/test_evolution_trainer_integration.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+from evolution_trainer import EvolutionTrainer
+
+
+def _train(config, steps, device):
+    import torch
+    x = torch.tensor(config["x"], device=device, dtype=torch.float32)
+    target = torch.tensor(1.0, device=device)
+    loss = torch.abs(x - target)
+    return loss.item()
+
+
+def test_evolution_over_generations(tmp_path):
+    base = {"x": 0.0, "choice": "a"}
+    space = {
+        "x": {"type": "float", "min": 0.0, "max": 2.0, "sigma": 0.2},
+        "choice": {"type": "categorical", "options": ["a", "b"]},
+    }
+    trainer = EvolutionTrainer(
+        base,
+        _train,
+        space,
+        population_size=4,
+        selection_size=2,
+        generations=2,
+        steps_per_candidate=1,
+        mutation_rate=1.0,
+        parallelism=2,
+    )
+    best = trainer.evolve()
+    assert isinstance(best.fitness, float)
+    json_path = tmp_path / "lineage.json"
+    graph_path = tmp_path / "lineage.graphml"
+    trainer.export_lineage_json(str(json_path))
+    trainer.export_lineage_graph(str(graph_path))
+    assert json_path.is_file()
+    assert graph_path.is_file()
+    with open(json_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert any(entry["parent"] is not None for entry in data)

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -154,6 +154,31 @@ sync:
     (1000–10000) reduce network usage at the cost of more stale updates. Must be
     a positive integer. Defaults to ``1000``.
 
+evolution:
+  population_size: Number of candidate configurations evaluated in each
+    generation. Larger populations explore the search space more thoroughly but
+    require proportionally more compute. Values of ``4`` to ``32`` work well for
+    small experiments; advanced searches may scale into the hundreds.
+  selection_size: Number of top-performing candidates preserved after each
+    generation. Must be at least ``1`` and no greater than ``population_size``.
+    A larger value maintains diversity while a smaller one accelerates
+    convergence.
+  generations: Total number of evolutionary generations to run. Each generation
+    evaluates ``population_size`` candidates and spawns a new population from
+    the best ``selection_size`` individuals. Setting this between ``2`` and
+    ``20`` balances search depth with runtime.
+  steps_per_candidate: Number of training steps performed when estimating a
+    candidate's fitness. Evaluating more steps yields a more reliable fitness
+    score at the cost of additional training time. Must be a positive integer.
+  mutation_rate: Fraction of mutable parameters altered when producing an
+    offspring. ``0.0`` disables mutation while ``1.0`` mutates every parameter.
+  Typical values between ``0.05`` and ``0.3`` introduce useful diversity
+    without drifting too far from the parent configuration.
+  parallelism: Maximum number of candidates evaluated concurrently. Increase this
+    to exploit multi-core CPUs or multiple GPUs. When set higher than the number
+    of available devices the evaluations queue until resources free up. Defaults
+    to the number of local CPU cores.
+
 core:
   xmin: Minimum X coordinate for the Mandelbrot seed. Defines the left boundary
     of the complex plane used when initializing neuron values.


### PR DESCRIPTION
## Summary
- implement EvolutionTrainer with mutation, selection, parallel evaluation, and lineage export
- document new evolution config parameters and defaults
- add unit and integration tests for evolutionary training

## Testing
- `pytest tests/test_evolution_trainer.py -q`
- `pytest tests/test_evolution_trainer_integration.py -q`
- `pytest tests/test_config.py -q`
- `pytest tests/test_config_additional.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689303c03a888327b59f51ce953899db