### PR TITLE
Add prompt memory persistence and Streamlit toggle

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1365,22 +1365,22 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
         - [ ] Unit test loss calculation with synthetic logits.
         - [ ] Ensure training uses previous epoch logits when available.
 
-326. [ ] Create in-context learning prompt system.
-    - [ ] Add `PromptMemory` to cache recent `(input, output)` pairs.
+326. [x] Create in-context learning prompt system.
+    - [x] Add `PromptMemory` to cache recent `(input, output)` pairs.
         - [x] Define `PromptMemory` class skeleton.
         - [x] Implement bounded queue with eviction policy.
         - [x] Add methods for retrieval and composite prompt generation.
         - [x] Provide serialization for stored pairs.
-    - [ ] Modify inference to use `prompt + input` as composite query.
+    - [x] Modify inference to use `prompt + input` as composite query.
         - [x] Concatenate prompts with new inputs before inference.
         - [x] Handle empty or oversized prompt caches gracefully.
-    - [ ] Add GUI control for toggling prompt injection.
-        - [ ] Create Streamlit toggle linked to inference pipeline.
-        - [ ] Persist user preference between sessions.
-    - [ ] Store prompts persistently with timestamps.
-        - [ ] Save prompt memory to disk on shutdown.
+    - [x] Add GUI control for toggling prompt injection.
+        - [x] Create Streamlit toggle linked to inference pipeline.
+        - [x] Persist user preference between sessions.
+    - [x] Store prompts persistently with timestamps.
+        - [x] Save prompt memory to disk on shutdown.
         - [x] Include timestamps for chronological retrieval.
-    - [ ] Write tests for prompt cache behavior.
+    - [x] Write tests for prompt cache behavior.
         - [x] Verify FIFO eviction policy.
         - [x] Test inference output when prompts are applied.
 

--- a/prompt_memory.py
+++ b/prompt_memory.py
@@ -1,7 +1,7 @@
 import json
 from collections import deque
 from time import time
-from typing import Deque, Dict, List, Tuple
+from typing import Any, Deque, Dict, List, Tuple
 
 
 class PromptMemory:
@@ -15,7 +15,7 @@ class PromptMemory:
 
     def __init__(self, max_size: int = 10):
         self.max_size = max_size
-        self._data: Deque[Dict[str, str]] = deque(maxlen=max_size)
+        self._data: Deque[Dict[str, Any]] = deque(maxlen=max_size)
 
     def __len__(self) -> int:
         """Return the number of stored records."""
@@ -29,9 +29,9 @@ class PromptMemory:
         """Return stored `(input, output)` pairs ignoring timestamps."""
         return [(item["input"], item["output"]) for item in list(self._data)]
 
-    def get_records(self) -> List[Dict[str, str]]:
-        """Return full records including timestamps."""
-        return list(self._data)
+    def get_records(self) -> List[Dict[str, Any]]:
+        """Return full records sorted by ``timestamp``."""
+        return sorted(self._data, key=lambda r: r["timestamp"])
 
     def get_prompt(self) -> str:
         """Concatenate stored pairs into a prompt string."""
@@ -82,7 +82,8 @@ class PromptMemory:
         memory = cls(max_size=max_size)
         try:
             with open(path, "r", encoding="utf-8") as f:
-                data: List[Dict[str, str]] = json.load(f)
+                data: List[Dict[str, Any]] = json.load(f)
+            data = sorted(data, key=lambda r: r.get("timestamp", 0))
             for pair in data[-max_size:]:
                 memory._data.append(pair)
         except FileNotFoundError:

--- a/tests/test_streamlit_gui.py
+++ b/tests/test_streamlit_gui.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import warnings
+from unittest import mock
 
 import optuna
 from _pytest.warning_types import PytestDeprecationWarning
@@ -77,6 +78,25 @@ def test_stats_tab_metrics():
     at = stats_tab.button[0].click().run(timeout=20)
     stats_tab = next(t for t in at.tabs if t.label == "System Stats")
     assert len(stats_tab.metric) == 2
+
+
+def test_prompt_toggle_persistence(tmp_path):
+    mem = tmp_path / "mem.json"
+    pref = tmp_path / "pref.json"
+    env = {
+        "PROMPT_MEMORY_PATH": str(mem),
+        "PROMPT_PREF_PATH": str(pref),
+    }
+    with mock.patch.dict(os.environ, env, clear=False):
+        at = AppTest.from_file("streamlit_playground.py").run(timeout=15)
+        at = at.sidebar.button[0].click().run(timeout=30)
+        assert at.toggle[0].value is False
+        at.toggle[0].set_value(True).run(timeout=15)
+
+    with mock.patch.dict(os.environ, env, clear=False):
+        at2 = AppTest.from_file("streamlit_playground.py").run(timeout=15)
+        at2 = at2.sidebar.button[0].click().run(timeout=30)
+        assert at2.toggle[0].value is True
 
 
 def test_metrics_tab_plot():

--- a/web_api.py
+++ b/web_api.py
@@ -18,12 +18,19 @@ class InferenceServer:
         host: str = "localhost",
         port: int = 5000,
         prompt_memory: PromptMemory | None = None,
+        prompt_path: str | None = None,
         api_token: str | None = None,
     ) -> None:
         self.brain = brain
         self.host = host
         self.port = port
-        self.prompt_memory = prompt_memory
+        self.prompt_path = prompt_path
+        if prompt_memory is not None:
+            self.prompt_memory = prompt_memory
+        elif prompt_path is not None:
+            self.prompt_memory = PromptMemory.load(prompt_path)
+        else:
+            self.prompt_memory = None
         self.api_token = api_token
         self.app = Flask(__name__)
         self.thread: threading.Thread | None = None
@@ -76,6 +83,11 @@ class InferenceServer:
 
     def stop(self) -> None:
         if self.thread is not None:
+            if self.prompt_memory is not None and self.prompt_path is not None:
+                try:
+                    self.prompt_memory.serialize(self.prompt_path)
+                except Exception:
+                    pass
             try:
                 import requests
 


### PR DESCRIPTION
## Summary
- extend PromptMemory with timestamp sorting and JSON persistence helpers
- support prompt-memory injection in inference pipeline and web API
- add Streamlit toggle for prompt injection with persisted user preference

## Testing
- `pytest tests/test_prompt_memory.py`
- `pytest tests/test_web_api.py`
- `pytest tests/test_streamlit_gui.py::test_prompt_toggle_persistence`


------
https://chatgpt.com/codex/tasks/task_e_68930c1e25108327bb8b34d705d7a308