### PR TITLE
feat: add self-distillation training

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -550,6 +550,7 @@ Each entry is listed under its section heading.
 - epochs
 - inner_steps
 - meta_lr
+- distill_alpha
 ## transfer_learning
 - enabled
 - epochs

--- a/TODO.md
+++ b/TODO.md
@@ -1348,22 +1348,22 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
         - [ ] Unit test memory slot creation and retrieval.
         - [ ] Validate attention selects correct belief states.
 
-325. [ ] Implement self-distillation over time.
-    - [ ] Save `logits.pkl` after each epoch.
-        - [ ] Hook training loop to capture logits.
-        - [ ] Serialize logits with epoch metadata.
-    - [ ] Add `self_distill_loss = KL(current_logits, previous_logits)` to the loss function with weight `meta_learning.distill_alpha`.
-        - [ ] Implement KL divergence term.
-        - [ ] Introduce `distill_alpha` parameter in config and docs.
-    - [ ] Visualize alignment of predictions over time.
-        - [ ] Plot KL divergence per epoch.
-        - [ ] Display visualization in Streamlit dashboard.
-    - [ ] Document distillation parameter in YAML manual and tutorial.
-        - [ ] Describe purpose and recommended ranges.
-        - [ ] Add tutorial section with example usage.
-    - [ ] Add tests for self-distillation loss.
-        - [ ] Unit test loss calculation with synthetic logits.
-        - [ ] Ensure training uses previous epoch logits when available.
+325. [x] Implement self-distillation over time.
+    - [x] Save `logits.pkl` after each epoch.
+        - [x] Hook training loop to capture logits.
+        - [x] Serialize logits with epoch metadata.
+    - [x] Add `self_distill_loss = KL(current_logits, previous_logits)` to the loss function with weight `meta_learning.distill_alpha`.
+        - [x] Implement KL divergence term.
+        - [x] Introduce `distill_alpha` parameter in config and docs.
+    - [x] Visualize alignment of predictions over time.
+        - [x] Plot KL divergence per epoch.
+        - [x] Display visualization in Streamlit dashboard.
+    - [x] Document distillation parameter in YAML manual and tutorial.
+        - [x] Describe purpose and recommended ranges.
+        - [x] Add tutorial section with example usage.
+    - [x] Add tests for self-distillation loss.
+        - [x] Unit test loss calculation with synthetic logits.
+        - [x] Ensure training uses previous epoch logits when available.
 
 326. [x] Create in-context learning prompt system.
     - [x] Add `PromptMemory` to cache recent `(input, output)` pairs.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -844,6 +844,28 @@ This project covers **autograd integration** and the **PyTorch challenge** mecha
 4. **Generate text** once training completes by calling `advanced_gpt.generate_text(marble.brain, 'Once upon a time')`.
 5. **Optionally distill** the knowledge to a smaller network with `DistillationTrainer` by loading a saved model and training a student brain against it.
 
+### Self-Distillation Over Time
+
+To encourage the model to refine its own predictions across epochs, enable
+``meta_learning.distill_alpha`` in ``config.yaml`` and train with
+``advanced_gpt.train_advanced_gpt``'s ``distill_alpha`` parameter:
+
+```python
+dataset, vocab = advanced_gpt.load_text_dataset(cfg['gpt']['dataset_path'])
+model, losses, kls = advanced_gpt.train_advanced_gpt(
+    dataset,
+    vocab_size=len(vocab),
+    block_size=cfg['gpt']['block_size'],
+    epochs=3,
+    distill_alpha=0.2,
+)
+print(kls)
+```
+
+This saves ``logits.pkl`` after each epoch and returns a list of KL divergence
+values that can be visualised in the Streamlit dashboard to inspect how model
+predictions align over time.
+
 **Complete Example**
 ```python
 # project5_gpt_training.py

--- a/config.yaml
+++ b/config.yaml
@@ -525,6 +525,7 @@ meta_learning:
   epochs: 1
   inner_steps: 1
   meta_lr: 0.1
+  distill_alpha: 0.0
 transfer_learning:
   enabled: false
   epochs: 1

--- a/config_loader.py
+++ b/config_loader.py
@@ -252,7 +252,7 @@ def create_marble_from_config(
             gpt_cfg.get("vocab_size", 50),
             gpt_cfg.get("block_size", 8),
         )
-        marble.gpt_model, _ = train_advanced_gpt(
+        marble.gpt_model, _, _ = train_advanced_gpt(
             dataset,
             vocab_size=gpt_cfg.get("vocab_size", 50),
             block_size=gpt_cfg.get("block_size", 8),
@@ -262,5 +262,6 @@ def create_marble_from_config(
             epochs=gpt_cfg.get("num_train_steps", 1),
             lr=gpt_cfg.get("learning_rate", 1e-3),
             batch_size=gpt_cfg.get("batch_size", 1),
+            distill_alpha=cfg.get("meta_learning", {}).get("distill_alpha", 0.0),
         )
     return marble

--- a/tests/test_advanced_gpt.py
+++ b/tests/test_advanced_gpt.py
@@ -17,7 +17,7 @@ def test_train_advanced_gpt_reduces_loss(tmp_path):
     txt = tmp_path / "tiny.txt"
     txt.write_text("abcdefg" * 2)
     data, vocab = load_text_dataset(str(txt), vocab_size=10, block_size=3)
-    _, losses = train_advanced_gpt(
+    _, losses, _ = train_advanced_gpt(
         data,
         vocab_size=len(vocab),
         block_size=3,
@@ -28,6 +28,7 @@ def test_train_advanced_gpt_reduces_loss(tmp_path):
         lr=0.05,
         batch_size=2,
         seed=0,
+        logits_path=str(tmp_path / "logits.pkl"),
     )
     assert losses[-1] <= losses[0]
 
@@ -36,7 +37,7 @@ def test_train_advanced_gpt_gradient_clipping(tmp_path):
     txt = tmp_path / "tiny.txt"
     txt.write_text("abcdefgh" * 2)
     data, vocab = load_text_dataset(str(txt), vocab_size=10, block_size=3)
-    _, _, norms = train_advanced_gpt(
+    _, _, _, norms = train_advanced_gpt(
         data,
         vocab_size=len(vocab),
         block_size=3,
@@ -49,5 +50,6 @@ def test_train_advanced_gpt_gradient_clipping(tmp_path):
         seed=1,
         max_grad_norm=0.25,
         return_grad_norms=True,
+        logits_path=str(tmp_path / "logits.pkl"),
     )
     assert norms and all(n <= 0.25 + 1e-6 for n in norms)

--- a/tests/test_self_distillation.py
+++ b/tests/test_self_distillation.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import pickle
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import numpy as np
+from advanced_gpt import kl_divergence, Tensor, train_advanced_gpt, load_text_dataset
+
+
+def test_kl_divergence_matches_numpy():
+    current = Tensor(np.array([[0.5, 1.0]], dtype=np.float32))
+    prev = np.array([[0.1, -0.2]], dtype=np.float32)
+    loss = kl_divergence(current, prev)
+    p = np.exp(current.data - np.max(current.data, axis=-1, keepdims=True))
+    p = p / p.sum(axis=-1, keepdims=True)
+    q = np.exp(prev - np.max(prev, axis=-1, keepdims=True))
+    q = q / q.sum(axis=-1, keepdims=True)
+    ref = np.sum(p * (np.log(p + 1e-8) - np.log(q + 1e-8)))
+    assert np.isclose(loss.data, ref)
+
+
+def test_training_uses_previous_logits(tmp_path):
+    txt = tmp_path / "tiny.txt"
+    txt.write_text("abcdefg" * 2)
+    data, vocab = load_text_dataset(str(txt), vocab_size=10, block_size=3)
+    _, losses, kls = train_advanced_gpt(
+        data,
+        vocab_size=len(vocab),
+        block_size=3,
+        num_layers=1,
+        num_heads=1,
+        hidden_dim=16,
+        epochs=2,
+        lr=0.05,
+        batch_size=2,
+        seed=0,
+        distill_alpha=0.5,
+        logits_path=str(tmp_path / "logits.pkl"),
+    )
+    assert len(kls) == 2
+    assert kls[0] == 0.0
+    assert kls[1] > 0.0
+    with open(tmp_path / "logits.pkl", "rb") as f:
+        logs = pickle.load(f)
+    assert len(logs) == 2 and logs[1]["epoch"] == 1

--- a/tests/test_streamlit_playground.py
+++ b/tests/test_streamlit_playground.py
@@ -13,6 +13,7 @@ import pandas as pd
 import yaml
 from PIL import Image
 from plotly.graph_objs import Figure
+from streamlit.testing.v1 import AppTest
 
 import streamlit_playground as sp
 from streamlit_playground import (
@@ -776,3 +777,15 @@ def test_optuna_helpers(tmp_path):
     yaml_cfg = optuna_best_config(loaded)
     assert isinstance(hist, Figure) and isinstance(imps, Figure)
     assert "x" in yaml_cfg
+
+
+def test_self_distillation_expander(tmp_path):
+    data = [
+        {"epoch": 0, "logits": [[[0.0, 1.0]]]},
+        {"epoch": 1, "logits": [[[0.1, 0.9]]]}
+    ]
+    import pickle
+    with open("logits.pkl", "wb") as f:
+        pickle.dump(data, f)
+    at = AppTest.from_file("streamlit_playground.py").run(timeout=10)
+    assert at is not None

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -1307,6 +1307,11 @@ meta_learning:
     before the meta update is applied. Typically between 1 and 5.
   meta_lr: Step size used when blending task weights back into the
     primary network. Values around ``0.1`` work well for most setups.
+  distill_alpha: Weight for self-distillation loss. Set between ``0.0`` and
+    ``1.0`` to blend the KL divergence between current and previous epoch
+    logits into the training objective. ``0.0`` disables distillation while
+    values like ``0.1``–``0.5`` encourage gradual alignment of predictions
+    over time.
 transfer_learning:
   # Fine-tune a pretrained model while keeping a portion of synapses fixed.
   # ``freeze_fraction`` controls what percentage of synapses are marked as


### PR DESCRIPTION
## Summary
- support KL-based self-distillation in AdvancedGPT training loop and save per-epoch logits
- expose `distill_alpha` setting in meta_learning config and docs
- show KL divergence history in Streamlit dashboard

## Testing
- `pytest tests/test_advanced_gpt.py -q`
- `pytest tests/test_self_distillation.py -q`
- `pytest tests/test_streamlit_playground.py -q`
- `pytest tests/test_streamlit_gui.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689316afe93483279faf6a90d0a7e020