### PR TITLE
Add bidirectional and multilayer RNN conversion

### DIFF
--- a/converttodo.md
+++ b/converttodo.md
@@ -62,16 +62,16 @@
   - [x] Converter for ``LSTM``
   - [x] Converter for ``GRU``
   - [x] Unit tests with tiny sequences
-    - [ ] Bidirectional and multi-layer support
-      - [ ] Map forward and backward weights for bidirectional RNNs.
-        - [ ] Align parameter ordering between PyTorch and MARBLE.
-        - [ ] Validate hidden state concatenation.
-      - [ ] Handle stacked layers with appropriate parameter naming.
-        - [ ] Prefix layer indices consistently.
-        - [ ] Ensure loading preserves original hierarchy.
-      - [ ] Add tests converting multi-layer bidirectional models.
-        - [ ] Build example network with two bidirectional layers.
-        - [ ] Compare outputs against PyTorch reference.
+    - [x] Bidirectional and multi-layer support
+      - [x] Map forward and backward weights for bidirectional RNNs.
+        - [x] Align parameter ordering between PyTorch and MARBLE.
+        - [x] Validate hidden state concatenation.
+      - [x] Handle stacked layers with appropriate parameter naming.
+        - [x] Prefix layer indices consistently.
+        - [x] Ensure loading preserves original hierarchy.
+      - [x] Add tests converting multi-layer bidirectional models.
+        - [x] Build example network with two bidirectional layers.
+        - [x] Compare outputs against PyTorch reference.
     - [ ] Persistent hidden state mapping
       - [ ] Serialize initial hidden states with layer metadata.
         - [ ] Embed state tensors into converter output.


### PR DESCRIPTION
## Summary
- support multi-layer and bidirectional RNN/LSTM/GRU conversions in `pytorch_to_marble`
- cover bidirectional and stacked recurrent layers with new tests
- mark converter TODO items for bidirectional/multi-layer support as complete

## Testing
- `pre-commit run --files pytorch_to_marble.py tests/test_pytorch_to_marble.py converttodo.md`
- `pytest tests/test_pytorch_to_marble.py`

------
https://chatgpt.com/codex/tasks/task_e_68932bdb759c832787bd3d2b7f860df3