### PR TITLE
Add JAX backend abstraction and refactor message passing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1246,14 +1246,14 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 319. [ ] Integrate JAX backend for differentiability.
     - [x] Create backend abstraction layer (`tensor_backend.py`) with functions like `matmul`, `sigmoid`, and `relu`.
     - [x] Implement NumPy and JAX backend versions.
-    - [ ] Refactor Mandelbrot seed generation (`core/init_seed.py`) to use backend functions.
-        - [ ] Replace direct NumPy operations with backend wrappers.
-        - [ ] Ensure random seeds are produced via the selected backend.
-        - [ ] Add unit tests confirming identical seeds across backends.
-    - [ ] Update message passing (`core/message_passing.py`) to rely on the abstraction.
-        - [ ] Swap low-level tensor ops for backend calls.
-        - [ ] Enable runtime selection of NumPy or JAX paths.
-        - [ ] Verify message delivery equivalence with tests.
+    - [x] Refactor Mandelbrot seed generation (`core/init_seed.py`) to use backend functions.
+        - [x] Replace direct NumPy operations with backend wrappers.
+        - [x] Ensure random seeds are produced via the selected backend.
+        - [x] Add unit tests confirming identical seeds across backends.
+    - [x] Update message passing (`core/message_passing.py`) to rely on the abstraction.
+        - [x] Swap low-level tensor ops for backend calls.
+        - [x] Enable runtime selection of NumPy or JAX paths.
+        - [x] Verify message delivery equivalence with tests.
     - [x] Add `core.backend` to `config.yaml` with fallback to NumPy and document in `yaml-manual.txt` and `CONFIGURABLE_PARAMETERS.md`.
     - [x] Test Mandelbrot output consistency across backends.
 

--- a/config.yaml
+++ b/config.yaml
@@ -63,6 +63,7 @@ evolution:
 # Core
 # =====
 core:
+  backend: numpy               # Tensor backend: "numpy" or "jax"
   xmin: -2.0                    # Mandelbrot minimum x value
   xmax: 1.0                     # Mandelbrot maximum x value
   ymin: -1.5                    # Mandelbrot minimum y value

--- a/config_schema.py
+++ b/config_schema.py
@@ -6,6 +6,7 @@ CONFIG_SCHEMA = {
         "core": {
             "type": "object",
             "properties": {
+                "backend": {"type": "string"},
                 "representation_size": {"type": "integer", "minimum": 1},
                 "message_passing_alpha": {"type": "number", "minimum": 0, "maximum": 1},
                 "message_passing_beta": {"type": "number", "minimum": 0, "maximum": 1},

--- a/core/init_seed.py
+++ b/core/init_seed.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import functools
+from typing import Any, Dict
+
+import numpy as np
+
+import tensor_backend as tb
+
+
+@functools.lru_cache(maxsize=32)
+def compute_mandelbrot(
+    xmin: float,
+    xmax: float,
+    ymin: float,
+    ymax: float,
+    width: int,
+    height: int,
+    max_iter: int = 256,
+    *,
+    escape_radius: float = 2.0,
+    power: int = 2,
+    as_numpy: bool = False,
+):
+    """Return a Mandelbrot set fragment using the active tensor backend."""
+    xp = tb.xp()
+    x = xp.linspace(xmin, xmax, width)
+    y = xp.linspace(ymin, ymax, height)
+    X, Y = xp.meshgrid(x, y)
+    C = X + 1j * Y
+    Z = xp.zeros_like(C, dtype=xp.complex64)
+    mandel = xp.zeros(C.shape, dtype=xp.int32)
+    esc_sq = escape_radius * escape_radius
+    for i in range(int(max_iter)):
+        mask = (Z.real * Z.real + Z.imag * Z.imag) <= esc_sq
+        if not bool(xp.any(mask)):
+            break
+        Z = xp.where(mask, Z ** power + C, Z)
+        mandel = xp.where(mask, i, mandel)
+    if as_numpy:
+        return tb.to_numpy(mandel)
+    return mandel
+
+
+def generate_seed(params: Dict[str, Any]) -> np.ndarray:
+    """Generate initial neuron values based on Mandelbrot seeds.
+
+    Parameters
+    ----------
+    params:
+        Configuration dictionary containing Mandelbrot bounds and noise level.
+        Expected keys include ``xmin``, ``xmax``, ``ymin``, ``ymax``, ``width``,
+        ``height`` and optional ``max_iter``, ``mandelbrot_escape_radius``,
+        ``mandelbrot_power`` and ``init_noise_std``.
+    """
+    arr = compute_mandelbrot(
+        params["xmin"],
+        params["xmax"],
+        params["ymin"],
+        params["ymax"],
+        params["width"],
+        params["height"],
+        params.get("max_iter", 256),
+        escape_radius=params.get("mandelbrot_escape_radius", 2.0),
+        power=params.get("mandelbrot_power", 2),
+        as_numpy=False,
+    )
+    noise_std = params.get("init_noise_std", 0.0)
+    if noise_std:
+        noise = tb.randn(arr.shape)
+        arr = arr + noise * noise_std
+    return tb.to_numpy(arr)

--- a/core/message_passing.py
+++ b/core/message_passing.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+
+import tensor_backend as tb
+from marble_base import MetricsVisualizer
+
+try:  # optional dependency for progress bar
+    from tqdm import tqdm  # type: ignore
+except Exception:  # pragma: no cover - tqdm not installed
+    tqdm = None
+
+
+class AttentionModule:
+    """Compute attention weights for message passing."""
+
+    def __init__(self, temperature: float = 1.0) -> None:
+        self.temperature = temperature
+
+    def compute(self, query: np.ndarray, keys: list[np.ndarray]) -> Any:
+        xp = tb.xp()
+        if not keys:
+            return xp.array([])
+        q = xp.nan_to_num(query, nan=0.0, posinf=0.0, neginf=0.0)
+        ks = xp.stack([xp.nan_to_num(k, nan=0.0, posinf=0.0, neginf=0.0) for k in keys])
+        dots = ks @ q / max(self.temperature, 1e-6)
+        exp = xp.exp(dots - xp.max(dots))
+        return exp / xp.sum(exp)
+
+
+def perform_message_passing(
+    core,
+    alpha: float | None = None,
+    metrics_visualizer: "MetricsVisualizer | None" = None,
+    attention_module: "AttentionModule | None" = None,
+    *,
+    global_phase: float | None = None,
+    show_progress: bool = False,
+) -> float:
+    """Propagate representations across synapses using attention and backend ops."""
+    xp = tb.xp()
+    if alpha is None:
+        alpha = core.params.get("message_passing_alpha", 0.5)
+    if attention_module is None:
+        temp = core.params.get("attention_temperature", 1.0)
+        attention_module = AttentionModule(temperature=temp)
+    if global_phase is None:
+        global_phase = getattr(core, "global_phase", 0.0)
+
+    beta = core.params.get("message_passing_beta", 1.0)
+    dropout = core.params.get("message_passing_dropout", 0.0)
+    activation = core.params.get("representation_activation", "tanh")
+    attn_dropout = core.params.get("attention_dropout", 0.0)
+    energy_thr = core.params.get("energy_threshold", 0.0)
+    noise_std = core.params.get("representation_noise_std", 0.0)
+
+    new_reps = [n.representation.copy() for n in core.neurons]
+    old_reps = [n.representation.copy() for n in core.neurons]
+    targets = core.neurons
+    pbar = None
+    if show_progress:
+        if tqdm is None:
+            raise RuntimeError("tqdm is required for progress display")
+        pbar = tqdm(targets, desc="MsgPass", ncols=80)
+        targets = pbar
+    for target in targets:
+        if target.energy < energy_thr:
+            continue
+        incoming = [
+            s
+            for s in core.synapses
+            if s.target == target.id and core.neurons[s.source].energy >= energy_thr
+        ]
+        if not incoming:
+            continue
+        neigh_reps = []
+        for s in incoming:
+            if dropout > 0 and float(tb.rand(())) < dropout:
+                continue
+            w = s.effective_weight(global_phase=global_phase)
+            neigh_reps.append(core.neurons[s.source].representation * w)
+            s.apply_side_effects(core, core.neurons[s.source].representation)
+        if not neigh_reps:
+            continue
+        target_rep = target.representation
+        attn = attention_module.compute(target_rep, neigh_reps)
+        if attn.size == 0:
+            continue
+        if attn_dropout > 0:
+            mask = tb.rand(attn.shape) >= attn_dropout
+            if not bool(xp.any(mask)):
+                continue
+            attn = attn * mask
+            sum_attn = attn.sum()
+            if float(tb.to_numpy(sum_attn)) == 0.0:
+                continue
+            attn = attn / sum_attn
+        agg = sum(attn[i] * neigh_reps[i] for i in range(len(neigh_reps)))
+        ln_enabled = core.params.get("apply_layer_norm", True)
+        mp_enabled = core.params.get("use_mixed_precision", False)
+        from marble_core import _simple_mlp  # local import to avoid cycle
+
+        interm = alpha * target.representation + (1 - alpha) * _simple_mlp(
+            agg, activation, apply_layer_norm=ln_enabled, mixed_precision=mp_enabled
+        )
+        mag = float(tb.to_numpy(xp.linalg.norm(agg)))
+        gate = 1.0 - math.exp(-mag)
+        if alpha == 0:
+            gate = 1.0 if mag > 0 else 0.0
+        interm = gate * interm + (1 - gate) * target.representation
+        updated = beta * interm + (1 - beta) * target.representation
+        if noise_std > 0:
+            updated = updated + tb.randn(updated.shape) * noise_std
+        new_reps[target.id] = updated
+    for idx, rep in enumerate(new_reps):
+        core.neurons[idx].representation = rep
+    diffs = [
+        float(tb.to_numpy(xp.linalg.norm(new_reps[i] - old_reps[i])))
+        for i in range(len(new_reps))
+    ]
+    avg_change = sum(diffs) / len(diffs) if diffs else 0.0
+    if metrics_visualizer is not None:
+        rep_matrix = xp.stack([n.representation for n in core.neurons])
+        variance = float(tb.to_numpy(xp.var(rep_matrix)))
+        metrics_visualizer.update(
+            {
+                "message_passing_change": avg_change,
+                "representation_variance": variance,
+            }
+        )
+    if pbar is not None:
+        pbar.close()
+    return avg_change

--- a/tests/test_activation_utils.py
+++ b/tests/test_activation_utils.py
@@ -1,11 +1,12 @@
 import os
-from marble_core import Core
+import tensor_backend as tb
+from marble_core import Core, perform_message_passing
 from tests.test_core_functions import minimal_params
-from marble_core import perform_message_passing
 from activation_visualization import plot_activation_heatmap
 
 
 def test_activation_heatmap(tmp_path):
+    tb.set_backend("numpy")
     params = minimal_params()
     core = Core(params)
     perform_message_passing(core)

--- a/tests/test_attention_module.py
+++ b/tests/test_attention_module.py
@@ -1,10 +1,12 @@
 import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import numpy as np
+import tensor_backend as tb
 from marble_core import AttentionModule
 
 
 def test_attention_weights_sum_to_one():
+    tb.set_backend("numpy")
     am = AttentionModule(temperature=1.0)
     query = np.array([1.0, 0.0])
     keys = [np.array([1.0, 0.0]), np.array([0.0, 1.0])]
@@ -14,6 +16,7 @@ def test_attention_weights_sum_to_one():
 
 
 def test_attention_temperature_effect():
+    tb.set_backend("numpy")
     query = np.array([1.0, 0.0])
     keys = [np.array([1.0, 0.0]), np.array([0.0, 1.0])]
     high = AttentionModule(temperature=10.0)

--- a/tests/test_backend_equivalence.py
+++ b/tests/test_backend_equivalence.py
@@ -1,0 +1,48 @@
+import os, sys
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import tensor_backend as tb
+from core import init_seed
+from marble_core import Core, perform_message_passing
+from tests.test_core_functions import minimal_params
+
+
+def test_mandelbrot_seed_consistency():
+    params = minimal_params()
+    params.update({"width": 4, "height": 4, "max_iter": 10, "init_noise_std": 0.0})
+    tb.set_backend("numpy")
+    seed_np = init_seed.generate_seed(params)
+    try:
+        tb.set_backend("jax")
+    except ImportError:
+        pytest.skip("JAX not installed")
+    seed_jax = init_seed.generate_seed(params)
+    assert np.allclose(seed_np, seed_jax)
+    tb.set_backend("numpy")
+
+
+def test_message_passing_backend_equivalence():
+    params = minimal_params()
+    params["init_noise_std"] = 0.0
+    params["representation_noise_std"] = 0.0
+    tb.set_backend("numpy")
+    core_np = Core(params)
+    base_reps = [n.representation.copy() for n in core_np.neurons]
+    perform_message_passing(core_np)
+    after_np = [n.representation.copy() for n in core_np.neurons]
+    try:
+        tb.set_backend("jax")
+    except ImportError:
+        pytest.skip("JAX not installed")
+    xp = tb.xp()
+    core_jax = Core(params)
+    for n, rep in zip(core_jax.neurons, base_reps):
+        n.representation = xp.asarray(rep)
+    perform_message_passing(core_jax)
+    after_jax = [tb.to_numpy(n.representation) for n in core_jax.neurons]
+    for a, b in zip(after_np, after_jax):
+        assert np.allclose(a, b)
+    tb.set_backend("numpy")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@ def test_load_config_defaults():
     assert cfg["core"]["width"] == 30
     assert cfg["core"]["representation_size"] == 4
     assert cfg["core"]["message_passing_alpha"] == 0.5
+    assert cfg["core"]["backend"] == "numpy"
     assert cfg["core"]["file_tier_path"] == "data/marble_file_tier.dat"
     assert "neuronenblitz" in cfg
     assert cfg["core"]["init_noise_std"] == 0.0

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -4,8 +4,10 @@ import numpy as np
 import random
 import pytest
 from marble_imports import cp
+import tensor_backend as tb
 import marble_core
 from marble_core import compute_mandelbrot, DataLoader, Core
+tb.set_backend("numpy")
 from marble_neuronenblitz import Neuronenblitz
 from marble_brain import Brain
 

--- a/tests/test_deterministic.py
+++ b/tests/test_deterministic.py
@@ -2,12 +2,14 @@ import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import numpy as np
+import tensor_backend as tb
 from marble_core import Core, perform_message_passing
 from tests.test_core_functions import minimal_params
 
 
 def test_message_passing_deterministic():
     seed = 123
+    tb.set_backend("numpy")
     p1 = minimal_params()
     p1['random_seed'] = seed
     core1 = Core(p1)

--- a/tests/test_mandelbrot_caching.py
+++ b/tests/test_mandelbrot_caching.py
@@ -1,7 +1,9 @@
+import tensor_backend as tb
 from marble_core import compute_mandelbrot
 
 
 def test_mandelbrot_cache_hits():
+    tb.set_backend("numpy")
     compute_mandelbrot.cache_clear()
     compute_mandelbrot(-2, 1, -1.5, 1.5, 4, 4)
     before = compute_mandelbrot.cache_info().hits

--- a/tests/test_mandelbrot_numpy.py
+++ b/tests/test_mandelbrot_numpy.py
@@ -1,8 +1,10 @@
 import numpy as np
+import tensor_backend as tb
 from marble_core import compute_mandelbrot
 
 
 def test_compute_mandelbrot_as_numpy():
+    tb.set_backend("numpy")
     arr = compute_mandelbrot(-2, 1, -1.5, 1.5, 3, 3, as_numpy=True)
     assert isinstance(arr, np.ndarray)
     assert arr.shape == (3, 3)

--- a/tests/test_message_passing.py
+++ b/tests/test_message_passing.py
@@ -5,6 +5,7 @@ import math
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import numpy as np
+import tensor_backend as tb
 
 from marble_base import MetricsVisualizer
 from marble_core import Core, perform_message_passing
@@ -13,6 +14,7 @@ from tests.test_core_functions import minimal_params
 
 
 def test_message_passing_updates_representation():
+    tb.set_backend("numpy")
     np.random.seed(0)
     params = minimal_params()
     core = Core(params)
@@ -27,6 +29,7 @@ def test_message_passing_updates_representation():
 
 
 def test_message_passing_alpha_configurable():
+    tb.set_backend("numpy")
     np.random.seed(0)
     params = minimal_params()
     params["message_passing_alpha"] = 1.0
@@ -41,6 +44,7 @@ def test_message_passing_alpha_configurable():
 
 
 def test_message_passing_no_nan(recwarn):
+    tb.set_backend("numpy")
     np.random.seed(0)
     params = minimal_params()
     core = Core(params)
@@ -54,6 +58,7 @@ def test_message_passing_no_nan(recwarn):
 
 def test_energy_threshold_blocks_neurons():
     params = minimal_params()
+    tb.set_backend("numpy")
     params["energy_threshold"] = 1.0
     core = Core(params)
     for n in core.neurons:
@@ -66,6 +71,7 @@ def test_energy_threshold_blocks_neurons():
 
 
 def test_representation_noise_applied():
+    tb.set_backend("numpy")
     np.random.seed(0)
     params = minimal_params()
     params["representation_noise_std"] = 0.5
@@ -79,6 +85,7 @@ def test_representation_noise_applied():
 
 
 def test_message_passing_dropout():
+    tb.set_backend("numpy")
     random.seed(0)
     np.random.seed(0)
     params = minimal_params()
@@ -93,6 +100,7 @@ def test_message_passing_dropout():
 
 
 def test_attention_dropout_blocks_all_messages():
+    tb.set_backend("numpy")
     random.seed(0)
     np.random.seed(0)
     params = minimal_params()
@@ -107,6 +115,7 @@ def test_attention_dropout_blocks_all_messages():
 
 
 def test_representation_activation_relu():
+    tb.set_backend("numpy")
     np.random.seed(0)
     params = minimal_params()
     params["message_passing_alpha"] = 0.0
@@ -120,6 +129,7 @@ def test_representation_activation_relu():
 
 
 def test_message_passing_beta_effect():
+    tb.set_backend("numpy")
     np.random.seed(0)
     params = minimal_params()
     params["message_passing_beta"] = 0.0
@@ -134,6 +144,7 @@ def test_message_passing_beta_effect():
 
 
 def test_run_message_passing_iterations():
+    tb.set_backend("numpy")
     np.random.seed(0)
     params = minimal_params()
     params["message_passing_iterations"] = 2
@@ -167,6 +178,7 @@ def test_layer_norm_functionality():
 
 
 def test_representation_variance_metric_updated():
+    tb.set_backend("numpy")
     np.random.seed(0)
     params = minimal_params()
     core = Core(params)
@@ -179,6 +191,7 @@ def test_representation_variance_metric_updated():
 
 def test_gating_blocks_zero_signal():
     params = minimal_params()
+    tb.set_backend("numpy")
     core = Core(params)
     for n in core.neurons:
         n.representation = np.random.rand(4)
@@ -192,6 +205,7 @@ def test_gating_blocks_zero_signal():
 
 def test_global_phase_rate_updates_phase():
     params = minimal_params()
+    tb.set_backend("numpy")
     params["global_phase_rate"] = 0.5
     core = Core(params)
     initial = core.global_phase

--- a/tests/test_message_passing_benchmark.py
+++ b/tests/test_message_passing_benchmark.py
@@ -3,11 +3,13 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+import tensor_backend as tb
 from marble_core import Core, benchmark_message_passing
 from tests.test_core_functions import minimal_params
 
 
 def test_benchmark_message_passing_returns_tuple():
+    tb.set_backend("numpy")
     params = minimal_params()
     core = Core(params)
     iters, sec = benchmark_message_passing(core, iterations=2, warmup=1)

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -1,6 +1,7 @@
 import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import tempfile
+import tensor_backend as tb
 from marble_core import Core, perform_message_passing
 from marble_utils import (
     export_core_to_onnx,
@@ -22,6 +23,7 @@ def test_graph_pruning():
 
 def test_export_import_neuron_state(tmp_path):
     params = minimal_params()
+    tb.set_backend("numpy")
     core = Core(params)
     perform_message_passing(core)
     path = tmp_path / "state.json"
@@ -55,6 +57,7 @@ def test_metrics_aggregator():
     assert metrics["loss"] == 2.0
 
 def test_message_passing_progress(monkeypatch):
+    tb.set_backend("numpy")
     params = minimal_params()
     core = Core(params)
     updates = []
@@ -69,6 +72,6 @@ def test_message_passing_progress(monkeypatch):
         def close(self):
             updates.append(True)
 
-    monkeypatch.setattr("marble_core.tqdm", lambda *a, **k: Dummy())
+    monkeypatch.setattr("core.message_passing.tqdm", lambda *a, **k: Dummy())
     perform_message_passing(core, show_progress=True)
     assert updates

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -180,6 +180,13 @@ evolution:
     to the number of local CPU cores.
 
 core:
+  backend: Selects the tensor computation library used throughout MARBLE's core
+    operations. ``numpy`` provides maximum compatibility and is the default
+    choice. ``jax`` enables differentiable execution and JIT compilation when the
+    JAX library is installed. Both backends run on CPU or GPU depending on the
+    environment. Switching this parameter changes the behaviour of seed
+    generation and message passing at runtime, allowing like-for-like experiments
+    across backends.
   xmin: Minimum X coordinate for the Mandelbrot seed. Defines the left boundary
     of the complex plane used when initializing neuron values.
   xmax: Maximum X coordinate for the seed. Together with ``xmin`` this sets the


### PR DESCRIPTION
## Summary
- Extend tensor backend with JAX and NumPy implementations supporting seeded random generation and array module access.
- Introduce core.init_seed and core.message_passing modules using backend operations for Mandelbrot seeding and message passing.
- Expose `core.backend` configuration option documented in YAML manual and schema.

## Testing
- `pytest tests/test_tensor_backend.py`
- `pytest tests/test_tensor_backend_pool.py`
- `pytest tests/test_attention_module.py`
- `pytest tests/test_message_passing.py`
- `pytest tests/test_message_passing_benchmark.py`
- `pytest tests/test_new_features.py`
- `pytest tests/test_activation_utils.py`
- `pytest tests/test_deterministic.py`
- `pytest tests/test_core_functions.py`
- `pytest tests/test_config.py`
- `pytest tests/test_mandelbrot_numpy.py`
- `pytest tests/test_mandelbrot_caching.py`
- `pytest tests/test_backend_equivalence.py`


------
https://chatgpt.com/codex/tasks/task_e_689339b2b32c83278003935ea3ba04a5