### PR TITLE
feat: enforce step memory quotas and dataset undo history

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -33,6 +33,8 @@ Each entry is listed under its section heading.
 ## pipeline
 - async_enabled
 - cache_dir
+- default_step_memory_limit_mb
+- memory_limit_mb (step field limiting memory in MB)
 - macro (step field allowing a list of sub-steps)
 - tier (step field selecting a remote hardware tier)
 - depends_on (step field listing prerequisite step names)

--- a/TODO.md
+++ b/TODO.md
@@ -1173,21 +1173,23 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 306. [x] Provide a dedicated test harness for bit tensor functions.
     - [x] Create helper class for generating datasets.
     - [x] Integrate harness with existing tests.
-307. [ ] Enforce memory quotas per pipeline step.
-    - [ ] Introduce configuration parameter for per-step memory limit.
-    - [ ] Instrument steps to track allocated memory.
-    - [ ] Abort or queue step when quota exceeded.
-    - [ ] Add tests simulating quota breaches.
+307. [x] Enforce memory quotas per pipeline step.
+    - [x] Introduce configuration parameter for per-step memory limit.
+    - [x] Instrument steps to track allocated memory.
+    - [x] Abort or queue step when quota exceeded.
+    - [x] Add tests simulating quota breaches.
 308. [ ] Precompile compute graphs to accelerate training.
     - [ ] Implement graph caching for repeated computations.
     - [ ] Add precompilation phase in training initialization.
     - [ ] Provide CLI flag to toggle precompilation.
     - [ ] Benchmark speed improvements on sample models.
 309. [ ] Offer multi-step undo for dataset modifications via core services.
-    - [ ] Track modification history with unique IDs.
-    - [ ] Implement undo stack supporting multiple levels.
+    - [x] Track modification history with unique IDs.
+    - [x] Implement undo stack supporting multiple levels.
     - [ ] Expose CLI and GUI controls to revert operations.
-    - [ ] Add tests covering undo and redo logic.
+        - [x] Expose CLI controls to revert operations.
+        - [ ] Expose GUI controls to revert operations.
+    - [x] Add tests covering undo and redo logic.
 310. [ ] Update remote datasets incrementally during long experiments.
     - [ ] Detect dataset changes and compute delta patches.
     - [ ] Sync remote storage with incremental updates.

--- a/config.yaml
+++ b/config.yaml
@@ -35,6 +35,7 @@ topology_graph:
 pipeline:
   async_enabled: false  # Execute HighLevelPipeline steps asynchronously when true
   cache_dir: null       # Directory for cached step outputs; defaults to pipeline_cache_gpu or pipeline_cache_cpu
+  default_step_memory_limit_mb: null  # Maximum memory per step in megabytes; null disables enforcement
 
 tool_manager:
   enabled: false        # When true the ToolManagerPlugin allows external tool use

--- a/config_schema.py
+++ b/config_schema.py
@@ -79,6 +79,15 @@ CONFIG_SCHEMA = {
                 "log_file": {"type": ["string", "null"]},
             },
         },
+        "pipeline": {
+            "type": "object",
+            "properties": {
+                "default_step_memory_limit_mb": {
+                    "type": ["number", "null"],
+                    "minimum": 0,
+                }
+            },
+        },
         "scheduler": {
             "type": "object",
             "properties": {"plugin": {"type": "string"}},

--- a/dataset_history_cli.py
+++ b/dataset_history_cli.py
@@ -1,0 +1,77 @@
+import argparse
+
+import torch
+
+from bit_tensor_dataset import BitTensorDataset
+
+
+def _load(path: str) -> BitTensorDataset:
+    return torch.load(path, weights_only=False)
+
+
+def _save(ds: BitTensorDataset, path: str) -> None:
+    torch.save(ds, path)
+
+
+def list_history(path: str) -> list[str]:
+    ds = _load(path)
+    return ds.history_ids()
+
+
+def undo_cmd(path: str, steps: int, output: str) -> None:
+    ds = _load(path)
+    ds.undo(steps)
+    _save(ds, output)
+
+
+def redo_cmd(path: str, steps: int, output: str) -> None:
+    ds = _load(path)
+    ds.redo(steps)
+    _save(ds, output)
+
+
+def revert_cmd(path: str, snapshot_id: str, output: str) -> None:
+    ds = _load(path)
+    ds.revert_to(snapshot_id)
+    _save(ds, output)
+
+
+def _main() -> None:  # pragma: no cover - CLI entry
+    parser = argparse.ArgumentParser(description="Dataset history management")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_hist = sub.add_parser("history", help="List snapshot IDs")
+    p_hist.add_argument("dataset")
+
+    p_undo = sub.add_parser("undo", help="Undo modifications")
+    p_undo.add_argument("dataset")
+    p_undo.add_argument("output")
+    p_undo.add_argument("--steps", type=int, default=1)
+
+    p_redo = sub.add_parser("redo", help="Redo modifications")
+    p_redo.add_argument("dataset")
+    p_redo.add_argument("output")
+    p_redo.add_argument("--steps", type=int, default=1)
+
+    p_rev = sub.add_parser("revert", help="Revert to a snapshot ID")
+    p_rev.add_argument("dataset")
+    p_rev.add_argument("snapshot_id")
+    p_rev.add_argument("output")
+
+    args = parser.parse_args()
+
+    if args.cmd == "history":
+        ids = list_history(args.dataset)
+        print("\n".join(ids))
+    elif args.cmd == "undo":
+        undo_cmd(args.dataset, args.steps, args.output)
+    elif args.cmd == "redo":
+        redo_cmd(args.dataset, args.steps, args.output)
+    elif args.cmd == "revert":
+        revert_cmd(args.dataset, args.snapshot_id, args.output)
+    else:  # pragma: no cover - defensive
+        parser.error("Unknown command")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    _main()

--- a/memory_manager.py
+++ b/memory_manager.py
@@ -1,12 +1,39 @@
 class MemoryManager:
-    """Simple memory manager tracking upcoming allocations."""
+    """Track and enforce memory usage for pipeline steps."""
 
-    def __init__(self):
-        self.reservations = []
+    def __init__(self, step_quota_mb: float | None = None) -> None:
+        self.reservations: list[int] = []
+        self.step_quota_mb = step_quota_mb
+        self.step_usage: dict[str, int] = {}
 
     def notify_allocation(self, size: int) -> None:
         """Record a future allocation in bytes."""
         self.reservations.append(size)
+
+    def notify_step_usage(
+        self, step_name: str, size_bytes: int, limit_mb: float | None = None
+    ) -> None:
+        """Record actual memory consumed by ``step_name``.
+
+        Parameters
+        ----------
+        step_name:
+            Identifier of the executed step.
+        size_bytes:
+            Number of bytes allocated while executing the step.
+        limit_mb:
+            Optional override for the memory limit in megabytes. When ``None``
+            the manager's ``step_quota_mb`` value is used. Exceeding the limit
+            raises :class:`MemoryError`.
+        """
+
+        self.step_usage[step_name] = size_bytes
+        limit = limit_mb if limit_mb is not None else self.step_quota_mb
+        if limit is not None and size_bytes > limit * 1024**2:
+            raise MemoryError(
+                f"Step '{step_name}' exceeded memory limit of {limit} MB with "
+                f"{size_bytes / 1024 ** 2:.2f} MB"
+            )
 
     def total_reserved(self) -> int:
         return sum(self.reservations)

--- a/pipeline_schema.py
+++ b/pipeline_schema.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """JSON schema for validating pipeline step configurations.
 
 Each step must define a ``name`` and either a ``func``, ``plugin`` or
@@ -7,6 +5,8 @@ Each step must define a ``name`` and either a ``func``, ``plugin`` or
 as well.  :func:`validate_step_schema` raises ``jsonschema.ValidationError`` if
 a step does not conform to the expected structure.
 """
+
+from __future__ import annotations
 
 import jsonschema
 
@@ -20,6 +20,7 @@ STEP_SCHEMA: dict = {
         "plugin": {"type": "string"},
         "depends_on": {"type": "array", "items": {"type": "string"}},
         "tier": {"type": "string"},
+        "memory_limit_mb": {"type": ["number", "null"], "minimum": 0},
         "branches": {
             "type": "array",
             "items": {

--- a/tests/test_dataset_history_cli.py
+++ b/tests/test_dataset_history_cli.py
@@ -1,0 +1,24 @@
+import torch
+
+from bit_tensor_dataset import BitTensorDataset
+from dataset_history_cli import list_history, redo_cmd, revert_cmd, undo_cmd
+
+
+def test_history_and_revert(tmp_path):
+    ds = BitTensorDataset([(1, 2)])
+    ds.add_pair(3, 4)
+    ids = ds.history_ids()
+    assert len(ids) == 2
+    path = tmp_path / "ds.pt"
+    torch.save(ds, path)
+    undo_cmd(str(path), 1, str(path))
+    ds_undo = torch.load(path, weights_only=False)
+    assert ds_undo.raw_data == [(1, 2)]
+    redo_cmd(str(path), 1, str(path))
+    ds_redo = torch.load(path, weights_only=False)
+    assert ds_redo.raw_data == [(1, 2), (3, 4)]
+    revert_cmd(str(path), ids[0], str(path))
+    ds_revert = torch.load(path, weights_only=False)
+    assert ds_revert.raw_data == [(1, 2)]
+    hist = list_history(str(path))
+    assert ids[0] in hist and ids[1] in hist

--- a/tests/test_memory_quota.py
+++ b/tests/test_memory_quota.py
@@ -1,0 +1,27 @@
+import pytest
+import torch
+
+from memory_manager import MemoryManager
+from pipeline import Pipeline
+
+
+def allocate_large() -> torch.Tensor:
+    # ~16MB tensor on float32
+    return torch.zeros((1024, 1024, 4))
+
+
+def test_memory_quota_exceeded():
+    pipe = Pipeline(
+        [
+            {
+                "name": "alloc",
+                "func": "allocate_large",
+                "module": "tests.test_memory_quota",
+                "memory_limit_mb": 1,
+            }
+        ]
+    )
+    mgr = MemoryManager()
+    with pytest.raises(MemoryError):
+        pipe.execute(memory_manager=mgr)
+    assert mgr.step_usage["alloc"] > 0

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -100,6 +100,12 @@ pipeline:
     is chosen automatically: ``pipeline_cache_gpu`` when a CUDA device is
     available or ``pipeline_cache_cpu`` otherwise. Use ``HighLevelPipeline.clear_cache()``
     to remove cached files when space is needed.
+  default_step_memory_limit_mb: Global cap on the additional memory each step
+    may allocate, measured in megabytes. The pipeline records CPU and GPU
+    allocations for every step and raises a ``MemoryError`` when the usage
+    exceeds this limit. Set to ``null`` to disable enforcement. Individual
+    steps can override the global quota by providing a ``memory_limit_mb``
+    field in their step definition.
   macro: A step may include a ``macro`` field containing a list of sub-step
     dictionaries. These sub-steps execute sequentially and return a list of
     results, allowing complex workflows to be bundled into a single step within
@@ -118,6 +124,10 @@ pipeline:
     GPU device and returns the result to the parent pipeline. Use this for
     experimental or unstable operations to prevent crashes from affecting the
     main run.
+  memory_limit_mb: Optional field specifying the maximum additional memory in
+    megabytes that the step is permitted to allocate. It overrides
+    ``default_step_memory_limit_mb`` and causes a ``MemoryError`` when the
+    allocation is exceeded.
 
 tool_manager:
   enabled: Toggle that activates the ``ToolManagerPlugin``. When ``true`` the


### PR DESCRIPTION
## Summary
- enforce per-step memory quotas with MemoryManager and pipeline instrumentation
- track dataset modifications with unique snapshot IDs and CLI undo/redo
- document new `default_step_memory_limit_mb` parameter and update TODO

## Testing
- `pytest tests/test_memory_quota.py -q`
- `pytest tests/test_dataset_history_cli.py -q`
- `pytest tests/test_memory_manager_integration.py -q`
- `pytest tests/test_bit_tensor_dataset.py -q`
- `pytest tests/test_resource_estimation.py -q`
- `pytest tests/test_dataset_events.py -q`
- `pytest tests/test_pipeline_utils.py -q`
- `pytest tests/test_pipeline_resume_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68934ad470248327b684dd885e94946a