### PR TITLE
feat: precompile compute graphs

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -309,6 +309,7 @@ Each entry is listed under its section heading.
 - auto_firing_enabled
 - dream_enabled
 - vram_age_threshold
+ - precompile_graphs
 - ram_age_threshold
 - status_display_interval
 - neurogenesis_interval

--- a/TODO.md
+++ b/TODO.md
@@ -1178,11 +1178,11 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
     - [x] Instrument steps to track allocated memory.
     - [x] Abort or queue step when quota exceeded.
     - [x] Add tests simulating quota breaches.
-308. [ ] Precompile compute graphs to accelerate training.
-    - [ ] Implement graph caching for repeated computations.
-    - [ ] Add precompilation phase in training initialization.
-    - [ ] Provide CLI flag to toggle precompilation.
-    - [ ] Benchmark speed improvements on sample models.
+308. [x] Precompile compute graphs to accelerate training.
+    - [x] Implement graph caching for repeated computations.
+    - [x] Add precompilation phase in training initialization.
+    - [x] Provide CLI flag to toggle precompilation.
+    - [x] Benchmark speed improvements on sample models.
 309. [ ] Offer multi-step undo for dataset modifications via core services.
     - [x] Track modification history with unique IDs.
     - [x] Implement undo stack supporting multiple levels.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -16,11 +16,14 @@ This tutorial demonstrates every major component of MARBLE through a series of p
 4. **Use the command line interface**. The `cli.py` script allows training from
    the terminal without writing custom code. Scheduler and early-stopping
    parameters can be specified on the command line. The ``--scheduler-plugin``
-   flag selects the asynchronous task scheduler (``thread`` or ``asyncio``):
+   flag selects the asynchronous task scheduler (``thread`` or ``asyncio``).
+   To remove graph compilation overhead on stable models you may add
+   ``--precompile-graphs`` which traces frequently executed operations once at
+   startup.  Example invocation:
    ```bash
    python cli.py --config config.yaml --train path/to/data.csv --epochs 10 \
        --lr-scheduler cosine --scheduler-steps 20 --early-stopping-patience 5 \
-       --scheduler-plugin thread \
+       --scheduler-plugin thread --precompile-graphs \
        --save trained_marble.pkl
    ```
    Replace the dataset path with your own CSV or JSON file. The optional

--- a/benchmark_graph_precompile.py
+++ b/benchmark_graph_precompile.py
@@ -1,0 +1,48 @@
+"""Benchmark graph precompilation versus eager execution."""
+
+from __future__ import annotations
+
+import time
+
+import torch
+
+from graph_cache import GRAPH_CACHE
+from marble_core import _simple_mlp, precompile_simple_mlp
+
+
+def benchmark_precompile(repeats: int = 1000) -> dict[str, float]:
+    """Return timing information for precompiled vs eager execution.
+
+    Parameters
+    ----------
+    repeats:
+        Number of forward passes to execute when timing.  A higher value
+        increases accuracy of the measurement but also runtime.
+    """
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    sample = torch.randn(1, 4, device=device)
+
+    GRAPH_CACHE.enable(False)
+    start = time.perf_counter()
+    for _ in range(repeats):
+        _simple_mlp(sample)
+    no_pre = time.perf_counter() - start
+
+    GRAPH_CACHE.clear()
+    precompile_simple_mlp(sample)
+    start = time.perf_counter()
+    for _ in range(repeats):
+        _simple_mlp(sample)
+    pre = time.perf_counter() - start
+
+    speedup = no_pre / pre if pre > 0 else float("inf")
+    return {"no_precompile": no_pre, "precompiled": pre, "speedup": speedup}
+
+
+if __name__ == "__main__":
+    res = benchmark_precompile()
+    print(
+        f"no precompile: {res['no_precompile']:.4f}s, precompiled: {res['precompiled']:.4f}s, "
+        f"speedup {res['speedup']:.2f}x"
+    )

--- a/cli.py
+++ b/cli.py
@@ -81,6 +81,11 @@ def main() -> None:
         "--no-early-stop", action="store_true", help="Disable early stopping"
     )
     parser.add_argument(
+        "--precompile-graphs",
+        action="store_true",
+        help="Precompile compute graphs before training",
+    )
+    parser.add_argument(
         "--sync-config",
         nargs="+",
         metavar="DEST",
@@ -151,6 +156,8 @@ def main() -> None:
         overrides["core"]["quantization_bits"] = args.quantize
     if args.causal_attention:
         overrides["core"]["attention_causal"] = True
+    if args.precompile_graphs:
+        overrides["brain"]["precompile_graphs"] = True
     marble = create_marble_from_config(args.config, overrides=overrides)
     if args.grid_search:
         import yaml

--- a/config.yaml
+++ b/config.yaml
@@ -318,6 +318,7 @@ brain:
   auto_firing_enabled: false
   dream_enabled: true
   vram_age_threshold: 300
+  precompile_graphs: false
   ram_age_threshold: 600
   status_display_interval: 0
   neurogenesis_interval: 1

--- a/graph_cache.py
+++ b/graph_cache.py
@@ -1,0 +1,78 @@
+"""Utilities for precompiling and caching compute graphs.
+
+This module provides a lightweight cache for Torch compute graphs. When
+precompilation is enabled a callable can be traced or scripted for a
+specific input signature and reused across training iterations.  This
+avoids repeated graph construction and yields small but measurable speed
+ups on stable model structures.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Hashable, Tuple
+
+import torch
+
+
+@dataclass(frozen=True)
+class GraphKey:
+    """Key describing a compiled graph.
+
+    The key captures the input shape, dtype and device in addition to an
+    arbitrary name.  The name allows multiple callables with the same
+    input signature to coexist in the cache.
+    """
+
+    name: str
+    shape: Tuple[int, ...]
+    dtype: torch.dtype
+    device: torch.device
+    extras: Tuple[Hashable, ...] = ()
+
+
+class GraphCache:
+    """Cache of ``torch.jit`` compiled callables."""
+
+    def __init__(self) -> None:
+        self.enabled: bool = False
+        self._cache: Dict[GraphKey, Callable[[torch.Tensor], torch.Tensor]] = {}
+
+    # public API -------------------------------------------------
+    def enable(self, flag: bool) -> None:
+        """Enable or disable graph caching globally."""
+
+        self.enabled = flag
+
+    def clear(self) -> None:
+        """Remove all cached graphs."""
+
+        self._cache.clear()
+
+    def get_cache_size(self) -> int:
+        return len(self._cache)
+
+    def precompile(
+        self,
+        key: GraphKey,
+        fn: Callable[[torch.Tensor], torch.Tensor],
+        example: torch.Tensor,
+    ) -> Callable[[torch.Tensor], torch.Tensor]:
+        """Return a compiled version of ``fn`` for ``example``.
+
+        When caching is disabled the original ``fn`` is returned.  When
+        enabled the function is compiled with ``torch.jit.trace`` on the
+        provided example tensor and stored under ``key`` for reuse.
+        """
+
+        if not self.enabled:
+            return fn
+        if key not in self._cache:
+            self._cache[key] = torch.jit.trace(fn, example)
+        return self._cache[key]
+
+
+# Global cache instance used throughout the project
+GRAPH_CACHE = GraphCache()
+
+__all__ = ["GRAPH_CACHE", "GraphCache", "GraphKey"]

--- a/tests/test_graph_precompile.py
+++ b/tests/test_graph_precompile.py
@@ -1,0 +1,37 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import torch
+from tqdm import tqdm as std_tqdm
+
+from graph_cache import GRAPH_CACHE
+from marble_brain import Brain
+from marble_core import Core, DataLoader, precompile_simple_mlp
+from marble_neuronenblitz import Neuronenblitz
+from tests.test_core_functions import minimal_params
+
+
+def test_precompile_cache_reuse():
+    GRAPH_CACHE.enable(True)
+    GRAPH_CACHE.clear()
+    sample = torch.randn(1, 4)
+    precompile_simple_mlp(sample)
+    size1 = GRAPH_CACHE.get_cache_size()
+    precompile_simple_mlp(sample)
+    size2 = GRAPH_CACHE.get_cache_size()
+    assert size1 == size2 == 1
+
+
+def test_brain_initializes_precompilation():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader(), precompile_graphs=True)
+    import marble_brain as mb
+
+    mb.tqdm = std_tqdm
+    GRAPH_CACHE.clear()
+    brain.train([(0.1, 0.2)], epochs=1)
+    assert GRAPH_CACHE.get_cache_size() >= 1

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -826,6 +826,13 @@ brain:
   dream_enabled: Enables background dreaming when ``start_dreaming`` is called.
   vram_age_threshold: Age in seconds above which neurons in VRAM are considered
     old when deciding growth tiers.
+  precompile_graphs: When ``true`` the brain traces frequently executed compute
+    graphs, such as the internal message passing MLP, using ``torch.jit`` before
+    training begins.  The compiled graphs are cached for the current tensor
+    shape, device and activation settings which removes graph construction
+    overhead during every training step.  Enable this when model structure and
+    input shapes remain stable.  On very small models the overhead of
+    precompilation may outweigh the benefit, so the default is ``false``.
   ram_age_threshold: Equivalent threshold for neurons in RAM.
   status_display_interval: If greater than zero, ``display_live_status`` is
     invoked every N epochs during training.


### PR DESCRIPTION
## Summary
- add graph cache using torch.jit to reuse compiled graphs
- allow brain to precompile core MLPs during training init and expose CLI flag
- document precompilation parameter and provide benchmark & tests

## Testing
- `pytest tests/test_graph_precompile.py -q`
- `pytest tests/test_core_functions.py -q`
- `pytest tests/test_async_training.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893568400ec83278d21941f3d6b27ff