### PR TITLE
Implement logging configuration

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -4,6 +4,7 @@ import yaml
 
 import tensor_backend as tb
 from config_schema import validate_config_schema
+from logging_utils import configure_structured_logging
 from marble_core import TIER_REGISTRY, MemorySystem
 from marble_main import MARBLE
 from meta_parameter_controller import MetaParameterController
@@ -72,6 +73,20 @@ def create_marble_from_config(
     if overrides:
         _deep_update(cfg, overrides)
     validate_global_config(cfg)
+
+    log_cfg = cfg.get("logging", {})
+    configure_structured_logging(
+        log_cfg.get("structured", False),
+        log_cfg.get("log_file"),
+        level=log_cfg.get("level", "INFO"),
+        format=log_cfg.get("format", "%(levelname)s:%(name)s:%(message)s"),
+        datefmt=log_cfg.get("datefmt", "%Y-%m-%d %H:%M:%S"),
+        propagate=log_cfg.get("propagate", False),
+        rotate=log_cfg.get("rotate", False),
+        max_bytes=log_cfg.get("max_bytes", 10_000_000),
+        backup_count=log_cfg.get("backup_count", 5),
+        encoding=log_cfg.get("encoding", "utf-8"),
+    )
 
     plugin_dirs = cfg.get("plugins", [])
     if plugin_dirs:

--- a/tests/test_logging_config_integration.py
+++ b/tests/test_logging_config_integration.py
@@ -1,0 +1,20 @@
+import json
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from config_loader import create_marble_from_config
+
+
+def test_logging_config_applied(tmp_path):
+    cfg_path = tmp_path / "cfg.yaml"
+    log_file = tmp_path / "log.jsonl"
+    cfg_path.write_text(f"logging:\n  structured: true\n  log_file: '{log_file}'\n")
+    create_marble_from_config(str(cfg_path))
+    logging.getLogger().info("hello")
+    text = log_file.read_text(encoding="utf-8").strip()
+    obj = json.loads(text)
+    assert obj["msg"] == "hello"
+    assert obj["level"] == "INFO"


### PR DESCRIPTION
## Summary
- honor `logging` section in config by wiring YAML settings into the logging setup
- exercise logging configuration end-to-end with a dedicated test

## Testing
- `pytest tests/test_logging_utils.py`
- `pytest tests/test_config.py`
- `pytest tests/test_logging_config_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_6893739e47a08327976bb709d1671a26