### PR TITLE
Implement attention_causal parameter

### DIFF
--- a/core/message_passing.py
+++ b/core/message_passing.py
@@ -56,6 +56,7 @@ def perform_message_passing(
     attn_dropout = core.params.get("attention_dropout", 0.0)
     energy_thr = core.params.get("energy_threshold", 0.0)
     noise_std = core.params.get("representation_noise_std", 0.0)
+    causal = core.params.get("attention_causal", False)
 
     new_reps = [n.representation.copy() for n in core.neurons]
     old_reps = [n.representation.copy() for n in core.neurons]
@@ -72,7 +73,9 @@ def perform_message_passing(
         incoming = [
             s
             for s in core.synapses
-            if s.target == target.id and core.neurons[s.source].energy >= energy_thr
+            if s.target == target.id
+            and core.neurons[s.source].energy >= energy_thr
+            and (not causal or s.source <= target.id)
         ]
         if not incoming:
             continue


### PR DESCRIPTION
## Summary
- enforce causal masking in message passing when `core.attention_causal` is enabled
- test that future neuron messages are ignored with causal attention

## Testing
- `pytest tests/test_message_passing.py`

------
https://chatgpt.com/codex/tasks/task_e_6893767948cc8327a8be6a650c140904