### PR TITLE
Integrate tool manager and sync service configuration

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -3269,25 +3269,26 @@ databases.
          db_path: "iris.kuzu"
    ```
 
-4. **Invoke tools from Python**. The manager chooses the appropriate plugin
-   based on the query:
+4. **Invoke tools from Python**. After creating a MARBLE instance with this
+   configuration the manager is available via ``marble.tool_manager``:
 
    ```python
    import torch
-   from tool_manager_plugin import ToolManagerPlugin
+   from config_loader import create_marble_from_config
 
-   manager = ToolManagerPlugin(
-       tools={"web_search": {}, "database_query": {"db_path": "iris.kuzu"}}
-   )
-   manager.initialise(torch.device("cpu"))
-   print(manager.execute(torch.device("cpu"), query="search the web for Iris setosa"))
+   marble = create_marble_from_config("config.yaml")
    print(
-       manager.execute(
+       marble.tool_manager.execute(
+           torch.device("cpu"), query="search the web for Iris setosa"
+       )
+   )
+   print(
+       marble.tool_manager.execute(
            torch.device("cpu"),
            query="database: MATCH (f:Flower) RETURN count(f) AS flowers",
        )
    )
-   manager.teardown()
+   marble.tool_manager.teardown()
    ```
 
 The first call performs a web search while the second queries the Kùzu database.

--- a/tests/test_sync_service_config.py
+++ b/tests/test_sync_service_config.py
@@ -1,0 +1,14 @@
+import yaml
+
+from config_loader import create_marble_from_config, load_config
+
+
+def test_sync_service_from_config(tmp_path):
+    cfg = load_config()
+    cfg["sync"] = {"interval_ms": 5}
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+
+    marble = create_marble_from_config(str(cfg_path))
+    assert hasattr(marble, "tensor_sync_service")
+    assert abs(marble.tensor_sync_service.interval - 0.005) < 1e-9

--- a/tests/test_tool_manager_config.py
+++ b/tests/test_tool_manager_config.py
@@ -1,0 +1,41 @@
+import yaml
+from pathlib import Path
+import torch
+
+from config_loader import create_marble_from_config, load_config
+
+
+def test_tool_manager_loaded_from_config(tmp_path, monkeypatch):
+    cfg = load_config()
+    cfg["tool_manager"] = {
+        "enabled": True,
+        "policy": "heuristic",
+        "tools": {
+            "web_search": {},
+            "database_query": {"db_path": str(tmp_path / "db.kuzu")},
+        },
+    }
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+
+    called = {}
+
+    def fake_ws(self, device, marble=None, query=""):
+        called["web"] = True
+        return {"ok": 1}
+
+    def fake_db(self, device, marble=None, query=""):
+        called["db"] = True
+        return [{"x": 1}]
+
+    monkeypatch.setattr("web_search_tool.WebSearchTool.execute", fake_ws)
+    monkeypatch.setattr("database_query_tool.DatabaseQueryTool.execute", fake_db)
+
+    marble = create_marble_from_config(str(cfg_path))
+    res1 = marble.tool_manager.execute(torch.device("cpu"), query="search the web")
+    assert res1["tool"] == "web_search"
+    assert called["web"]
+    res2 = marble.tool_manager.execute(torch.device("cpu"), query="database stats")
+    assert res2["tool"] == "database_query"
+    assert called["db"]
+    marble.tool_manager.teardown()

--- a/tool_manager_plugin.py
+++ b/tool_manager_plugin.py
@@ -7,7 +7,13 @@ from typing import Dict
 import torch
 
 from pipeline_plugins import PipelinePlugin, register_plugin
-from tool_plugins import TOOL_REGISTRY, ToolPlugin, get_tool, load_tool_plugins
+from tool_plugins import (
+    TOOL_REGISTRY,
+    ToolPlugin,
+    get_tool,
+    load_tool_plugins,
+    register_tool,
+)
 
 
 class HeuristicToolPolicy:
@@ -37,7 +43,9 @@ class ToolManagerPlugin(PipelinePlugin):
         for name, cfg in self.tool_configs.items():
             if name not in TOOL_REGISTRY:
                 try:
-                    __import__(f"{name}_tool")
+                    mod = __import__(f"{name}_tool")
+                    if hasattr(mod, "register"):
+                        mod.register(register_tool)
                 except ImportError as exc:  # pragma: no cover - user error
                     raise ImportError(f"Tool '{name}' is not registered") from exc
             cls = get_tool(name)

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -161,7 +161,9 @@ tool_manager:
 
     The manager initialises each listed tool during pipeline start-up and
     forwards queries to the selected tool at runtime. Results are returned to the
-    pipeline for further processing or integration into model responses.
+    pipeline for further processing or integration into model responses. When
+    enabled the initialised manager is exposed on the MARBLE instance as
+    ``marble.tool_manager`` for direct use in custom scripts.
 
 cross_validation:
   folds: Number of partitions used during k-fold evaluation. Each fold serves as a
@@ -188,7 +190,9 @@ sync:
     applies updates atomically per device. Lower values (100–500) keep model
     parameters closely aligned but increase communication overhead. Higher values
     (1000–10000) reduce network usage at the cost of more stale updates. Must be
-    a positive integer. Defaults to ``1000``.
+    a positive integer. Defaults to ``1000``. When specified, MARBLE constructs a
+    :class:`TensorSyncService` available as ``marble.tensor_sync_service`` which
+    keeps any registered tensors synchronised on CPU or GPU devices.
 
 evolution:
   population_size: Number of candidate configurations evaluated in each


### PR DESCRIPTION
## Summary
- Wire up tool_manager configuration to instantiate ToolManagerPlugin and expose it via `marble.tool_manager`
- Start TensorSyncService using new sync.interval_ms option
- Auto-register tool plugins on demand
- Document and tutorial updates; added coverage tests

## Testing
- `pytest tests/test_tool_manager_plugin.py`
- `pytest tests/test_tool_manager_config.py`
- `pytest tests/test_sync_service_config.py`
- `pytest tests/test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68937bdf2354832787132269e78cce14