### PR TITLE
Implement attention gating parameters

### DIFF
--- a/config_schema.py
+++ b/config_schema.py
@@ -20,6 +20,15 @@ CONFIG_SCHEMA = {
                 },
                 "use_mixed_precision": {"type": "boolean"},
                 "quantization_bits": {"type": "integer", "minimum": 0, "maximum": 16},
+                "attention_gating": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {"type": "boolean"},
+                        "mode": {"type": "string"},
+                        "frequency": {"type": "number", "minimum": 0},
+                        "chaos": {"type": "number", "minimum": 0, "maximum": 4},
+                    },
+                },
             },
         },
         "neuronenblitz": {"type": "object"},

--- a/tests/test_message_passing.py
+++ b/tests/test_message_passing.py
@@ -9,6 +9,7 @@ import tensor_backend as tb
 
 from marble_base import MetricsVisualizer
 from marble_core import Core, perform_message_passing
+from core.message_passing import AttentionModule
 import marble_core
 from tests.test_core_functions import minimal_params
 
@@ -138,6 +139,30 @@ def test_attention_causal_blocks_future_messages():
     blocked = np.allclose(core2.neurons[1].representation, 0.0)
 
     assert changed and blocked
+
+
+def test_attention_gating_sine_changes_weights():
+    tb.set_backend("numpy")
+    am = AttentionModule(
+        temperature=1.0,
+        gating_cfg={"enabled": True, "mode": "sine", "frequency": 0.5},
+    )
+    q = np.ones(2)
+    keys = [np.ones(2), np.ones(2)]
+    w = am.compute(q, keys)
+    assert w[0] < w[1]
+
+
+def test_attention_gating_chaos_varies_over_calls():
+    tb.set_backend("numpy")
+    am = AttentionModule(
+        temperature=1.0, gating_cfg={"enabled": True, "mode": "chaos", "chaos": 3.9}
+    )
+    q = np.ones(2)
+    keys = [np.ones(2), np.ones(2)]
+    w1 = am.compute(q, keys)
+    w2 = am.compute(q, keys)
+    assert not np.allclose(w1, w2)
 
 
 def test_representation_activation_relu():


### PR DESCRIPTION
## Summary
- Add attention gating with sine and chaotic modes to message passing
- Validate new attention_gating options in config schema
- Test attention gating behaviors for sine and chaos modes

## Testing
- `pytest tests/test_message_passing.py`
- `pytest tests/test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_689398dec97c83278fcbe4384e10b5c5