### PR TITLE
Implement missing config parameters and defaults

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import torch
 import yaml
 
 import tensor_backend as tb
@@ -13,7 +14,6 @@ from plugin_system import load_plugins
 from remote_hardware import load_remote_tier_plugin
 from remote_offload import RemoteBrainClient, RemoteBrainServer
 from torrent_offload import BrainTorrentClient, BrainTorrentTracker
-import torch
 
 DEFAULT_CONFIG_FILE = Path(__file__).resolve().parent / "config.yaml"
 
@@ -284,7 +284,10 @@ def create_marble_from_config(
     if ac_cfg.get("enabled", False):
         from attention_codelets import activate as activate_codelets
 
-        activate_codelets(coalition_size=ac_cfg.get("coalition_size", 1))
+        activate_codelets(
+            coalition_size=ac_cfg.get("coalition_size", 1),
+            salience_weight=core_params.get("salience_weight", 1.0),
+        )
     if qbits:
         from model_quantization import quantize_core_weights
 

--- a/tests/test_attention_salience.py
+++ b/tests/test_attention_salience.py
@@ -1,7 +1,10 @@
 import importlib
 
+import yaml
+
 import attention_codelets
 import global_workspace
+from config_loader import create_marble_from_config, load_config
 
 
 def test_attention_salience_adjustment():
@@ -22,3 +25,14 @@ def test_attention_salience_adjustment():
     assert coalition[0].content == "low"
     attention_codelets.broadcast_coalition(coalition)
     assert gw.queue[-1].content["content"] == "low"
+
+
+def test_salience_weight_from_config(tmp_path):
+    importlib.reload(attention_codelets)
+    cfg = load_config()
+    cfg["attention_codelets"] = {"enabled": True, "coalition_size": 1}
+    cfg["core"]["salience_weight"] = 2.5
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    create_marble_from_config(str(cfg_path))
+    assert attention_codelets._salience_weight == 2.5

--- a/tests/test_message_passing.py
+++ b/tests/test_message_passing.py
@@ -1,16 +1,16 @@
+import math
 import os
 import random
 import sys
-import math
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import numpy as np
-import tensor_backend as tb
 
+import marble_core
+import tensor_backend as tb
+from core.message_passing import AttentionModule
 from marble_base import MetricsVisualizer
 from marble_core import Core, perform_message_passing
-from core.message_passing import AttentionModule
-import marble_core
 from tests.test_core_functions import minimal_params
 
 
@@ -238,6 +238,21 @@ def test_representation_variance_metric_updated():
         n.representation = np.random.rand(4)
     perform_message_passing(core, metrics_visualizer=mv)
     assert mv.metrics["representation_variance"], "Metric not updated"
+
+
+def test_show_message_progress(monkeypatch):
+    params = minimal_params()
+    params["show_message_progress"] = True
+    core = Core(params)
+    called = {"flag": False}
+
+    def fake_pmp(*args, **kwargs):
+        called["flag"] = kwargs.get("show_progress", False)
+        return 0.0
+
+    monkeypatch.setattr(marble_core, "perform_message_passing", fake_pmp)
+    core.run_message_passing()
+    assert called["flag"] is True
 
 
 def test_gating_blocks_zero_signal():

--- a/tests/test_synapse_dropout_batchnorm.py
+++ b/tests/test_synapse_dropout_batchnorm.py
@@ -1,13 +1,12 @@
-import random
 import numpy as np
-import torch
-from marble_core import Core, Synapse, SYNAPSE_TYPES
+
+from marble_core import Core, Synapse
 from tests.test_core_functions import minimal_params
 
 
 def test_dropout_synapse_zeroes_output():
     params = minimal_params()
-    core = Core(params)
+    Core(params)
     syn = Synapse(0, 1, synapse_type="dropout", dropout_prob=1.0)
     out = syn.transmit(1.0)
     assert out == 0.0
@@ -15,11 +14,27 @@ def test_dropout_synapse_zeroes_output():
 
 def test_batchnorm_synapse_normalises():
     params = minimal_params()
-    core = Core(params)
+    Core(params)
     syn = Synapse(0, 1, synapse_type="batchnorm", momentum=1.0)
-    out1 = syn.transmit(np.array([1.0, 2.0]))
+    syn.transmit(np.array([1.0, 2.0]))
     out2 = syn.transmit(np.array([3.0, 4.0]))
     mean = np.array([3.0, 4.0]).mean()
     var = np.array([3.0, 4.0]).var()
-    expected = ((np.array([3.0, 4.0]) - mean) / np.sqrt(var + 1e-5))
+    expected = (np.array([3.0, 4.0]) - mean) / np.sqrt(var + 1e-5)
     np.testing.assert_allclose(out2, expected)
+
+
+def test_add_synapse_uses_config_dropout():
+    params = minimal_params()
+    params["synapse_dropout_prob"] = 0.25
+    core = Core(params)
+    syn = core.add_synapse(0, 1, synapse_type="dropout")
+    assert syn.dropout_prob == 0.25
+
+
+def test_add_synapse_uses_config_batchnorm_momentum():
+    params = minimal_params()
+    params["synapse_batchnorm_momentum"] = 0.3
+    core = Core(params)
+    syn = core.add_synapse(0, 1, synapse_type="batchnorm")
+    assert syn.momentum == 0.3

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -301,12 +301,14 @@ core:
     automatic differentiation with GPU/CPU fallback. Defaults to ``"numpy"``.
   message_passing_dropout: Fraction of messages dropped during propagation to
     regularize learning. ``0.0`` disables dropout.
-  synapse_dropout_prob: Probability of zeroing out connections of synapses
-    configured with the ``dropout`` type. ``0.0`` leaves all such synapses
-    active while ``1.0`` disables them completely on every transmission.
-  synapse_batchnorm_momentum: Momentum used by ``batchnorm`` synapses when
+  synapse_dropout_prob: Default probability applied to newly created synapses
+    of type ``"dropout"``. ``0.0`` leaves all such synapses active while ``1.0``
+    disables them completely on every transmission. Intermediate values randomly
+    silence connections with the given probability.
+  synapse_batchnorm_momentum: Default momentum for ``batchnorm`` synapses when
     updating their running mean and variance. Values close to ``1.0`` adapt
-    quickly while lower values provide smoother statistics.
+    quickly while lower values provide smoother statistics. Must lie within
+    ``0.0``–``1.0``.
   representation_activation: Activation function used by the internal MLP for
     message passing. Typical values are ``"tanh"`` or ``"relu"``.
   apply_layer_norm: When true the hidden layer of ``_simple_mlp`` is normalised
@@ -339,7 +341,9 @@ core:
     ``"uniform"`` and ``"normal"`` with the same semantics as
     ``weight_init_type``.
   show_message_progress: When ``true`` ``perform_message_passing`` renders a
-    progress bar so long operations provide visual feedback.
+    progress bar using :mod:`tqdm` so long operations provide visual feedback.
+    Requires the optional ``tqdm`` dependency and is controlled via
+    ``core.show_message_progress``. Defaults to ``false``.
   message_passing_beta: Secondary mixing factor controlling how quickly new
     representations replace old ones when ``alpha`` alone is insufficient.
   attention_temperature: Softmax temperature used by the attention module


### PR DESCRIPTION
## Summary
- support `synapse_dropout_prob`, `synapse_batchnorm_momentum`, and `show_message_progress` within the core
- pass `salience_weight` from YAML into attention codelets
- document new behaviour and add regression tests

## Testing
- `pre-commit run --files marble_core.py config_loader.py yaml-manual.txt tests/test_synapse_dropout_batchnorm.py tests/test_message_passing.py tests/test_attention_salience.py`
- `pytest tests/test_synapse_dropout_batchnorm.py`
- `pytest tests/test_message_passing.py`
- `pytest tests/test_attention_salience.py`


------
https://chatgpt.com/codex/tasks/task_e_6893ba1eac708327925c8c959e35581c