### PR TITLE
Support configurable growth tier

### DIFF
--- a/config_schema.py
+++ b/config_schema.py
@@ -20,6 +20,7 @@ CONFIG_SCHEMA = {
                 },
                 "use_mixed_precision": {"type": "boolean"},
                 "quantization_bits": {"type": "integer", "minimum": 0, "maximum": 16},
+                "default_growth_tier": {"type": "string"},
                 "attention_gating": {
                     "type": "object",
                     "properties": {

--- a/marble_brain.py
+++ b/marble_brain.py
@@ -409,7 +409,10 @@ class Brain:
             else:
                 chosen = "ram"
         else:
-            chosen = "vram"
+            default = self.core.params.get("default_growth_tier", "vram")
+            if default not in TIER_REGISTRY:
+                default = "vram"
+            chosen = default
 
         print(
             f"[Brain] Growth decision: '{chosen}' tier (VRAM: {vram_usage:.2f}MB/{vram_limit}MB, age: {vram_neuron_age:.1f}s)"

--- a/marble_core.py
+++ b/marble_core.py
@@ -1911,6 +1911,15 @@ class Core:
 
     def choose_new_tier(self):
         available_tiers = sorted(TIER_REGISTRY.values(), key=lambda t: t.order)
+
+        # Honour an explicitly configured preferred tier first
+        preferred = self.params.get("default_growth_tier")
+        if preferred in TIER_REGISTRY:
+            limit_key = f"{preferred.lower()}_limit_mb"
+            limit = self.params.get(limit_key, TIER_REGISTRY[preferred].limit_mb)
+            if limit is None or self.get_usage_by_tier(preferred) < limit:
+                return preferred
+
         for tier in available_tiers:
             limit_key = f"{tier.name.lower()}_limit_mb"
             limit = self.params.get(limit_key, tier.limit_mb)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,6 +36,7 @@ def test_load_config_defaults():
     assert cfg["core"]["synapse_weight_decay"] == 0.0
     assert cfg["core"]["message_passing_iterations"] == 1
     assert cfg["core"]["cluster_algorithm"] == "kmeans"
+    assert cfg["core"]["default_growth_tier"] == "vram"
     assert cfg["brain"]["save_threshold"] == 0.05
     assert cfg["meta_controller"]["history_length"] == 5
     assert cfg["neuromodulatory_system"]["initial"]["emotion"] == "neutral"

--- a/tests/test_default_growth_tier.py
+++ b/tests/test_default_growth_tier.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from marble_brain import Brain
+from marble_core import Core, DataLoader
+from marble_neuronenblitz import Neuronenblitz
+
+
+def minimal_params():
+    return {
+        "xmin": -2.0,
+        "xmax": 1.0,
+        "ymin": -1.5,
+        "ymax": 1.5,
+        "width": 3,
+        "height": 3,
+        "max_iter": 5,
+        "representation_size": 4,
+        "message_passing_alpha": 0.5,
+        "vram_limit_mb": 0.1,
+        "ram_limit_mb": 0.1,
+        "disk_limit_mb": 0.1,
+        "random_seed": 0,
+        "attention_temperature": 1.0,
+        "attention_dropout": 0.0,
+        "representation_noise_std": 0.0,
+        "weight_init_type": "uniform",
+        "weight_init_std": 1.0,
+    }
+
+
+def test_core_uses_default_growth_tier():
+    params = minimal_params()
+    params["default_growth_tier"] = "ram"
+    core = Core(params)
+    assert core.choose_new_tier() == "ram"
+
+
+def test_brain_uses_default_growth_tier():
+    params = minimal_params()
+    params["default_growth_tier"] = "ram"
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader())
+    assert brain.choose_growth_tier() == "ram"

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -291,8 +291,16 @@ core:
   init_noise_std: Standard deviation of Gaussian noise added to the initial
     Mandelbrot values. ``0.0`` keeps deterministic seeds while larger values
     create varied starting states.
-  default_growth_tier: Preferred tier used when new neurons are created and no
-    tier choice is provided explicitly.
+  default_growth_tier: Preferred memory tier used for newly created neurons when
+    ``Core.expand`` is called without an explicit ``target_tier``. Valid options
+    are names present in ``TIER_REGISTRY`` such as ``"vram"``, ``"ram"``,
+    ``"disk"`` or ``"file"`` (when the ``FileTier`` is enabled). The tier is
+    only selected if sufficient capacity remains under the corresponding
+    ``<tier>_limit_mb`` setting; otherwise the core falls back to the next tier
+    based on availability. By default the system prefers ``"vram"`` so growth
+    happens on the fastest memory when possible. Override this to ``"ram`` or
+    ``"disk"`` when operating on machines without reliable GPU memory or to
+    force new allocations to cheaper storage.
   random_seed: Seed used for random operations in the core. Keeping this fixed
     ensures reproducible initialization.
   backend: Selects the tensor math library for core operations. ``"numpy"``


### PR DESCRIPTION
## Summary
- allow `core.default_growth_tier` to select the preferred memory tier for new neurons
- document and validate the `default_growth_tier` setting
- test that core and brain honour the configured growth tier

## Testing
- `pre-commit run --files config_schema.py marble_brain.py marble_core.py tests/test_config.py tests/test_default_growth_tier.py yaml-manual.txt`
- `pytest tests/test_default_growth_tier.py -q`
- `pytest tests/test_config.py -q`
- `pytest tests/test_core_functions.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6893c56a07b0832796f867d29b2999fe