### PR TITLE
Implement pretraining and clustering parameters

### DIFF
--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -14,3 +14,5 @@ No failing tests.
 - tests/test_hybrid_memory_kuzu.py::test_kuzu_memory_separate_from_topology: RuntimeError: Catalog exception: function DATETIME does not exist [resolved]
 - tests/test_pipeline_cache_stress.py::test_cache_stress_cpu: assert 1.3928057014807302 < 1 [resolved]
 - tests/test_theory_of_mind_beliefs.py::test_memory_slot_creation_and_retrieval: AssertionError [resolved]
+- tests/test_pretraining_and_clustering.py::test_pretraining_epochs_runs_once: AttributeError: 'range' object has no attribute 'set_postfix' [resolved]
+- tests/test_pretraining_and_clustering.py::test_pretraining_epochs_runs_once: AttributeError: '_DummyPbar' object has no attribute 'close' [resolved]

--- a/config_schema.py
+++ b/config_schema.py
@@ -21,6 +21,8 @@ CONFIG_SCHEMA = {
                 "use_mixed_precision": {"type": "boolean"},
                 "quantization_bits": {"type": "integer", "minimum": 0, "maximum": 16},
                 "default_growth_tier": {"type": "string"},
+                "pretraining_epochs": {"type": "integer", "minimum": 0},
+                "min_cluster_k": {"type": "integer", "minimum": 1},
                 "attention_gating": {
                     "type": "object",
                     "properties": {

--- a/marble_core.py
+++ b/marble_core.py
@@ -2090,6 +2090,8 @@ class Core:
     def cluster_neurons(self, k=3):
         if not self.neurons:
             return
+        min_k = int(self.params.get("min_cluster_k", 1))
+        k = int(max(k, min_k))
         processed_vals = []
         for n in self.neurons:
             val = n.value
@@ -2104,7 +2106,7 @@ class Core:
         values = np.array(processed_vals, dtype=float)
         values[~np.isfinite(values)] = 0.0
         k = int(min(k, len(values)))
-        if k == 0:
+        if k < 1:
             return
         centers = [np.random.choice(values)]
         for _ in range(1, k):

--- a/tests/test_pretraining_and_clustering.py
+++ b/tests/test_pretraining_and_clustering.py
@@ -1,0 +1,63 @@
+import marble_brain
+from marble_brain import Brain
+
+
+class DummyNB:
+    def __init__(self):
+        self.calls = []
+        self.global_activation_count = 0
+
+    def train(self, data, epochs=1, dream_buffer=None):
+        self.calls.append((list(data), epochs))
+
+    def modulate_plasticity(self, ctx):
+        pass
+
+
+class DummyCore:
+    def __init__(self, pre_epochs=0, min_k=1):
+        self.params = {"pretraining_epochs": pre_epochs, "min_cluster_k": min_k}
+        self.neurons = []
+        self.synapses = []
+
+    def get_usage_by_tier(self, tier):
+        return 0.0
+
+    def cluster_neurons(self, k):
+        self.cluster_called_with = k
+
+    def relocate_clusters(self, high, medium):
+        pass
+
+
+class _DummyPbar(list):
+    def __init__(self, iterable):
+        super().__init__(iterable)
+
+    def set_postfix(self, *a, **k):
+        pass
+
+    def close(self):
+        pass
+
+
+marble_brain.tqdm = lambda x, **k: _DummyPbar(x)
+
+
+def test_pretraining_epochs_runs_once():
+    core = DummyCore(pre_epochs=2)
+    nb = DummyNB()
+    brain = Brain(core, nb, None, metrics_visualizer=None, dream_enabled=False)
+    brain.train([(0.1, 0.2)], epochs=1)
+    assert nb.calls[0] == ([(0.1, 0.1)], 2)
+    assert nb.calls[1] == ([(0.1, 0.2)], 1)
+    brain.train([(0.2, 0.3)], epochs=1)
+    assert nb.calls[2] == ([(0.2, 0.3)], 1)
+
+
+def test_min_cluster_k_enforced():
+    core = DummyCore(min_k=3)
+    nb = DummyNB()
+    brain = Brain(core, nb, None, metrics_visualizer=None, dream_enabled=False, cluster_k=2)
+    brain.train([(0.1, 0.2)], epochs=1)
+    assert core.cluster_called_with == 3

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -402,9 +402,15 @@ core:
   early_cleanup_enabled: If ``true``, unused neurons are removed before normal
     cleanup intervals, reducing memory usage.
   pretraining_epochs: Number of unsupervised epochs to run before regular
-    training begins.
+    training begins. During this phase the system performs an autoencoding
+    warm-up where each input is used as its own target, stabilising weights
+    prior to supervised updates. Set to ``0`` to disable. Recommended range is
+    ``0``–``10`` depending on dataset size.
   min_cluster_k: Smallest number of clusters allowed when ``cluster_neurons``
-    is invoked automatically.
+    is invoked automatically. This lower bound prevents the topology from
+    collapsing into a single cluster. If the network contains fewer neurons
+    than ``min_cluster_k`` the number of neurons is used instead. Typical
+    values are between ``2`` and ``10``.
   diffusion_steps: Number of denoising iterations performed during diffusion
     sampling. Values above ``1`` produce smoother results but increase
     computation time.


### PR DESCRIPTION
## Summary
- enable optional unsupervised warm‑up via `core.pretraining_epochs`
- enforce `core.min_cluster_k` across neuron clustering
- validate new parameters in schema and update manual; add regression tests

## Testing
- `pytest tests/test_pretraining_and_clustering.py -q`
- `pytest tests/test_neuron_clustering.py -q`
- `pytest tests/test_lobe_manager.py -q`
- `pytest tests/test_usage_profiler.py -q`
- `pytest tests/test_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68942d18c67c8327ad890af1068ef375