### PR TITLE
Use config defaults for evolution trainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,6 +936,28 @@ scores = cross_validate(train, metric, dataset, folds=5, seed=42)
 print('scores', scores)
 ```
 
+## Evolutionary Hyperparameter Search
+
+Explore configuration spaces using evolutionary strategies. The
+`evolution_trainer.run_evolution` helper constructs an
+`EvolutionTrainer` and fills missing arguments from the `evolution`
+section of `config.yaml`. The search executes on CPU or GPU depending
+on availability.
+
+```python
+from evolution_trainer import run_evolution
+
+def train(cfg, steps, device):
+    import torch
+    x = torch.tensor(cfg["x"], device=device)
+    target = torch.tensor(1.0, device=device)
+    return torch.abs(x - target).item()
+
+space = {"x": {"type": "float", "min": 0.0, "max": 2.0, "sigma": 0.2}}
+best = run_evolution({"x": 0.5}, train, space)
+print('best fitness', best.fitness)
+```
+
 ## Experiment Tracking
 
 The `experiment_tracker` module provides a simple abstraction for logging metrics

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -626,6 +626,22 @@ tasks.
    ```
    Mutations add noise to synapses while pruning removes the least useful ones.
 10. **Enable dreaming** by setting `dream_enabled: true` in `config.yaml`. Parameters like `dream_num_cycles`, `dream_interval`, `dream_replay_buffer_size`, `dream_replay_batch_size`, `dream_instant_buffer_size`, and `dream_housekeeping_threshold` control how frequently dream cycles run, how many past experiences they consolidate, how long recent memories stay in the instant buffer, and the salience required to keep memories during housekeeping.
+11. **Search hyperparameters** automatically using evolutionary strategies:
+    ```python
+    from evolution_trainer import run_evolution
+
+    def fitness(cfg, steps, device):
+        import torch
+        x = torch.tensor(cfg["x"], device=device)
+        target = torch.tensor(1.0, device=device)
+        return torch.abs(x - target).item()
+
+    space = {"x": {"type": "float", "min": 0.0, "max": 2.0, "sigma": 0.2}}
+    best = run_evolution({"x": 0.5}, fitness, space)
+    print("best", best.fitness)
+    ```
+    The helper pulls defaults such as population size from the `evolution` section of
+    `config.yaml` and runs on CPU or GPU automatically.
 
 **Complete Example**
 ```python

--- a/tests/test_evolution_config.py
+++ b/tests/test_evolution_config.py
@@ -1,0 +1,48 @@
+import yaml
+import evolution_trainer as et
+import config_loader
+
+
+def _train(cfg, steps, device):
+    return 0.0
+
+
+def test_run_evolution_defaults_from_config(tmp_path, monkeypatch):
+    cfg = config_loader.load_config()
+    cfg['evolution'] = {
+        'population_size': 3,
+        'selection_size': 1,
+        'generations': 2,
+        'steps_per_candidate': 1,
+        'mutation_rate': 0.5,
+        'parallelism': 1,
+    }
+    cfg_path = tmp_path / 'cfg.yaml'
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    monkeypatch.setattr(config_loader, 'DEFAULT_CONFIG_FILE', cfg_path)
+
+    captured = {}
+    orig_init = et.EvolutionTrainer.__init__
+
+    def spy_init(self, base_config, train_func, mutation_space, population_size, selection_size, generations, *, mutation_rate=0.1, steps_per_candidate=5, parallelism=None):
+        captured['population_size'] = population_size
+        captured['selection_size'] = selection_size
+        captured['generations'] = generations
+        captured['steps_per_candidate'] = steps_per_candidate
+        captured['mutation_rate'] = mutation_rate
+        captured['parallelism'] = parallelism
+        orig_init(self, base_config, train_func, mutation_space, population_size, selection_size, generations, mutation_rate=mutation_rate, steps_per_candidate=steps_per_candidate, parallelism=parallelism)
+
+    monkeypatch.setattr(et.EvolutionTrainer, '__init__', spy_init)
+    monkeypatch.setattr(et.EvolutionTrainer, 'evolve', lambda self: et.Candidate(0, {}))
+
+    et.run_evolution({'x': 0.0}, _train, {'x': {'type': 'float', 'min': 0.0, 'max': 1.0, 'sigma': 0.1}})
+
+    assert captured == {
+        'population_size': 3,
+        'selection_size': 1,
+        'generations': 2,
+        'steps_per_candidate': 1,
+        'mutation_rate': 0.5,
+        'parallelism': 1,
+    }

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -223,6 +223,12 @@ evolution:
     of available devices the evaluations queue until resources free up. Defaults
     to the number of local CPU cores.
 
+  To launch an evolutionary search with these defaults call
+  ``evolution_trainer.run_evolution`` providing a base configuration, a
+  training function and a mutation space. Any omitted arguments are
+  populated from this section of ``config.yaml`` and the search runs on
+  CPU or GPU depending on availability.
+
 core:
   backend: Selects the tensor computation library used throughout MARBLE's core
     operations. ``numpy`` provides maximum compatibility and is the default


### PR DESCRIPTION
## Summary
- add `run_evolution` helper that reads defaults from the `evolution` section of `config.yaml`
- document evolutionary search usage and defaults in README, yaml-manual, and tutorial
- test that `run_evolution` loads parameters from configuration

## Testing
- `pytest tests/test_evolution_trainer.py`
- `pytest tests/test_evolution_trainer_integration.py`
- `pytest tests/test_evolution_config.py`


------
https://chatgpt.com/codex/tasks/task_e_689435ac49208327ae162bbfda67ee92