### PR TITLE
Support ND tensor autograd and configurable MARBLE mixing

### DIFF
--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -16,3 +16,4 @@ No failing tests.
 - tests/test_theory_of_mind_beliefs.py::test_memory_slot_creation_and_retrieval: AssertionError [resolved]
 - tests/test_pretraining_and_clustering.py::test_pretraining_epochs_runs_once: AttributeError: 'range' object has no attribute 'set_postfix' [resolved]
 - tests/test_pretraining_and_clustering.py::test_pretraining_epochs_runs_once: AttributeError: '_DummyPbar' object has no attribute 'close' [resolved]
+- tests/test_marble_interface.py::test_save_and_load_marble: TypeError: cannot pickle '_thread.lock' object

--- a/marble_main.py
+++ b/marble_main.py
@@ -310,6 +310,8 @@ class MARBLE:
         state["metrics_visualizer"] = None
         state["benchmark_manager"] = None
         state["hybrid_memory"] = None
+        state["autograd_layer"] = None
+        state["dataloader"] = None
         return state
 
     def __setstate__(self, state):
@@ -321,6 +323,8 @@ class MARBLE:
                 pass
         if self.metrics_visualizer is None:
             self.metrics_visualizer = MetricsVisualizer()
+        if self.dataloader is None:
+            self.dataloader = DataLoader()
         if self.hybrid_memory is not None:
             try:
                 self.hybrid_memory.core = self.core


### PR DESCRIPTION
## Summary
- Extend MarbleAutogradFunction to handle N-dimensional tensors and accumulate gradients per element
- Allow TransparentMarbleLayer to mix MARBLE output with inputs via configurable weight
- Harden MARBLE serialization by stripping autograd layers and dataloaders during pickling

## Testing
- `pytest tests/test_autograd_layer.py -q`
- `pytest tests/test_transparent_layer.py -q`
- ❌ `pytest tests/test_marble_interface.py::test_save_and_load_marble -q` *(fails: TypeError: cannot pickle '_thread.lock' object)*

------
https://chatgpt.com/codex/tasks/task_e_68944765ad9083278d1e5bb7a8fd8cfd