### PR TITLE
Add autograd and conversion round-trip tests

### DIFF
--- a/tests/test_conversion_roundtrip.py
+++ b/tests/test_conversion_roundtrip.py
@@ -1,0 +1,37 @@
+import os
+import sys
+
+import torch
+import torch.nn as nn
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from marble_to_pytorch import convert_core
+from pytorch_to_marble import convert_model
+
+
+class SimpleMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(4, 3),
+            nn.ReLU(),
+            nn.Linear(3, 2),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+
+def test_round_trip_linear_model():
+    torch.manual_seed(0)
+    model = SimpleMLP()
+    model.input_size = 4
+    x = torch.randn(1, 4)
+    with torch.no_grad():
+        expected = model(x)
+    core = convert_model(model)
+    rebuilt = convert_core(core)
+    with torch.no_grad():
+        got = rebuilt(x)
+    assert torch.allclose(got, expected, atol=1e-4)

--- a/tests/test_marble_autograd_layer.py
+++ b/tests/test_marble_autograd_layer.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+import torch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from marble import DataLoader
+from marble_autograd import MarbleAutogradLayer
+from marble_brain import Brain
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from tests.test_core_functions import minimal_params
+
+
+def test_autograd_forward_and_backward():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader())
+    layer = MarbleAutogradLayer(brain, learning_rate=0.1)
+
+    x = torch.tensor([0.1, 0.2], requires_grad=True)
+    weights_before = [syn.weight for syn in core.synapses]
+    out = layer(x)
+    assert out.shape == x.shape
+    out.sum().backward()
+    assert torch.allclose(x.grad, torch.ones_like(x))
+    weights_after = [syn.weight for syn in core.synapses]
+    assert any(a != b for a, b in zip(weights_after, weights_before))


### PR DESCRIPTION
## Summary
- add unit test for MarbleAutogradLayer verifying forward output, gradient flow, and weight updates
- test round-trip conversion PyTorch -> Marble core -> PyTorch to ensure functional equivalence

## Testing
- `pytest tests/test_marble_autograd_layer.py::test_autograd_forward_and_backward -q`
- `pytest tests/test_conversion_roundtrip.py::test_round_trip_linear_model -q`


------
https://chatgpt.com/codex/tasks/task_e_689457bb21408327a68a048c1a7a5158