### PR TITLE
Add asynchronous MCP server with event bus integration

### DIFF
--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -16,4 +16,4 @@ No failing tests.
 - tests/test_theory_of_mind_beliefs.py::test_memory_slot_creation_and_retrieval: AssertionError [resolved]
 - tests/test_pretraining_and_clustering.py::test_pretraining_epochs_runs_once: AttributeError: 'range' object has no attribute 'set_postfix' [resolved]
 - tests/test_pretraining_and_clustering.py::test_pretraining_epochs_runs_once: AttributeError: '_DummyPbar' object has no attribute 'close' [resolved]
-- tests/test_marble_interface.py::test_save_and_load_marble: TypeError: cannot pickle '_thread.lock' object
+- tests/test_marble_interface.py::test_save_and_load_marble: TypeError: cannot pickle '_thread.lock' object [resolved]

--- a/marble_main.py
+++ b/marble_main.py
@@ -312,6 +312,7 @@ class MARBLE:
         state["hybrid_memory"] = None
         state["autograd_layer"] = None
         state["dataloader"] = None
+        state["tensor_sync_service"] = None
         return state
 
     def __setstate__(self, state):
@@ -335,6 +336,10 @@ class MARBLE:
             self.benchmark_manager = BenchmarkManager(self)
         else:
             self.benchmark_manager.marble = self
+        if self.tensor_sync_service is None:
+            from tensor_sync_service import TensorSyncService
+
+            self.tensor_sync_service = TensorSyncService()
 
 
 def insert_into_torch_model(

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any
+
+import torch
+from aiohttp import web
+
+from event_bus import global_event_bus
+from prompt_memory import PromptMemory
+
+
+class MCPServer:
+    """Asynchronous MCP server exposing MARBLE inference routes.
+
+    The server translates MCP ``inference`` and ``context`` messages into
+    calls on ``brain.neuronenblitz.dynamic_wander``. Incoming requests are
+    executed in background threads to avoid blocking the event loop and will
+    utilise the GPU when available.
+    """
+
+    def __init__(
+        self,
+        brain,
+        host: str = "localhost",
+        port: int = 8765,
+        prompt_memory: PromptMemory | None = None,
+        prompt_path: str | None = None,
+    ) -> None:
+        self.brain = brain
+        self.host = host
+        self.port = port
+        self.prompt_path = prompt_path
+        if prompt_memory is not None:
+            self.prompt_memory = prompt_memory
+        elif prompt_path is not None:
+            self.prompt_memory = PromptMemory.load(prompt_path)
+        else:
+            self.prompt_memory = None
+
+        self.app = web.Application()
+        self.app.router.add_post("/mcp/infer", self._handle_infer)
+        self.app.router.add_post("/mcp/context", self._handle_context)
+        self.runner: web.AppRunner | None = None
+        self.loop: asyncio.AbstractEventLoop | None = None
+        self.thread: threading.Thread | None = None
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    def _run_wander(self, value: float) -> tuple[float, str]:
+        """Run dynamic_wander on the appropriate device."""
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        tensor = torch.tensor([value], device=device)
+        out, _ = self.brain.neuronenblitz.dynamic_wander(float(tensor.item()))
+        return out, device
+
+    async def _handle_infer(self, request: web.Request) -> web.Response:
+        data: dict[str, Any] = await request.json() if request.can_read_body else {}
+        if "text" in data:
+            text = str(data.get("text", ""))
+            composite = (
+                self.prompt_memory.composite_with(text)
+                if self.prompt_memory is not None
+                else text
+            )
+            value = sum(ord(c) for c in composite) / max(len(composite), 1)
+            output, device = await asyncio.to_thread(self._run_wander, value)
+            if self.prompt_memory is not None:
+                self.prompt_memory.add(text, str(output))
+        else:
+            value = float(data.get("input", 0.0))
+            output, device = await asyncio.to_thread(self._run_wander, value)
+        global_event_bus.publish(
+            "mcp_request", {"route": "infer", "device": device, "value": value}
+        )
+        return web.json_response({"output": output})
+
+    async def _handle_context(self, request: web.Request) -> web.Response:
+        data: dict[str, Any] = await request.json() if request.can_read_body else {}
+        text = str(data.get("text", ""))
+        composite = (
+            self.prompt_memory.composite_with(text)
+            if self.prompt_memory is not None
+            else text
+        )
+        value = sum(ord(c) for c in composite) / max(len(composite), 1)
+        output, device = await asyncio.to_thread(self._run_wander, value)
+        if self.prompt_memory is not None:
+            self.prompt_memory.add(text, str(output))
+        global_event_bus.publish(
+            "mcp_request", {"route": "context", "device": device, "value": value}
+        )
+        return web.json_response({"output": output})
+
+    # ------------------------------------------------------------------
+    async def _start(self) -> None:
+        self.runner = web.AppRunner(self.app)
+        await self.runner.setup()
+        site = web.TCPSite(self.runner, self.host, self.port)
+        await site.start()
+
+    def start(self) -> None:
+        if self.thread is None:
+            self.loop = asyncio.new_event_loop()
+
+            def runner() -> None:
+                asyncio.set_event_loop(self.loop)
+                self.loop.run_until_complete(self._start())
+                self.loop.run_forever()
+
+            self.thread = threading.Thread(target=runner, daemon=True)
+            self.thread.start()
+            global_event_bus.publish(
+                "mcp_server_start", {"host": self.host, "port": self.port}
+            )
+
+    async def _stop(self) -> None:
+        if self.runner is not None:
+            await self.runner.cleanup()
+            self.runner = None
+
+    def stop(self) -> None:
+        if self.thread and self.loop:
+            if self.prompt_memory is not None and self.prompt_path is not None:
+                try:
+                    self.prompt_memory.serialize(self.prompt_path)
+                except Exception:
+                    pass
+            fut = asyncio.run_coroutine_threadsafe(self._stop(), self.loop)
+            try:
+                fut.result(5)
+            except Exception:
+                pass
+            self.loop.call_soon_threadsafe(self.loop.stop)
+            self.thread.join(timeout=5)
+            self.thread = None
+            self.loop = None
+            global_event_bus.publish(
+                "mcp_server_stop", {"host": self.host, "port": self.port}
+            )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,58 @@
+import asyncio
+import aiohttp
+import time
+
+from marble_brain import Brain
+from marble_core import Core, DataLoader
+from marble_neuronenblitz import Neuronenblitz
+from prompt_memory import PromptMemory
+from tests.test_core_functions import minimal_params
+
+from mcp_server import MCPServer
+
+
+def test_mcp_server_infer():
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader())
+    server = MCPServer(brain, host="localhost", port=5080)
+    server.start()
+    time.sleep(0.5)
+    try:
+        async def _request():
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    "http://localhost:5080/mcp/infer", json={"input": 0.1}
+                ) as resp:
+                    assert resp.status == 200
+                    data = await resp.json()
+                    assert "output" in data
+                    assert isinstance(data["output"], float)
+        asyncio.run(_request())
+    finally:
+        server.stop()
+
+
+def test_mcp_server_context(tmp_path):
+    params = minimal_params()
+    core = Core(params)
+    nb = Neuronenblitz(core)
+    brain = Brain(core, nb, DataLoader())
+    memory = PromptMemory(max_size=2)
+    server = MCPServer(brain, host="localhost", port=5081, prompt_memory=memory)
+    server.start()
+    time.sleep(0.5)
+    try:
+        async def _request():
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    "http://localhost:5081/mcp/context", json={"text": "hello"}
+                ) as resp:
+                    assert resp.status == 200
+                    data = await resp.json()
+                    assert "output" in data
+        asyncio.run(_request())
+        assert memory.get_pairs()[0][0] == "hello"
+    finally:
+        server.stop()


### PR DESCRIPTION
## Summary
- allow MARBLE systems to be serialised by clearing tensor sync service state
- introduce `MCPServer` using aiohttp for async inference and context handling
- exercise new MCP server via dedicated tests

## Testing
- `pytest tests/test_mcp_server.py::test_mcp_server_infer -q`
- `pytest tests/test_mcp_server.py::test_mcp_server_context -q`
- `pytest tests/test_marble_interface.py::test_save_and_load_marble -q`


------
https://chatgpt.com/codex/tasks/task_e_68945ea3b79c8327a74e24de0a91b817