### PR TITLE
Add MCP tool bridge and MessageBus reply support

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -51,6 +51,8 @@ Each entry is listed under its section heading.
 ## tool_manager
 - enabled
 - policy
+- mode
+- agent_id
 - tools (mapping of tool identifiers to parameter dictionaries)
 
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -3240,7 +3240,9 @@ model trains.
 
 This project demonstrates how the new ``ToolManagerPlugin`` allows MARBLE to
 autonomously call external services such as web search APIs and graph
-databases.
+databases. The plugin supports a ``"mcp"`` mode that listens on the
+``MessageBus`` for requests originating from the :class:`MCPToolBridge`, making
+it possible to invoke MARBLE tools from external MCP clients.
 
 1. **Download a dataset** to populate the database used by the
    ``DatabaseQueryTool``. Here we use the classic Iris flower dataset:

--- a/config.yaml
+++ b/config.yaml
@@ -48,6 +48,8 @@ pipeline:
 tool_manager:
   enabled: false        # When true the ToolManagerPlugin allows external tool use
   policy: "heuristic"    # Strategy for selecting tools; only "heuristic" is currently available
+  mode: "direct"         # "direct" executes immediately; "mcp" listens on the MessageBus
+  agent_id: "tool_manager"  # Identifier used when communicating via the MessageBus
   tools:                # Mapping of tool names to configuration dictionaries
     web_search: {}
     database_query:

--- a/mcp_tool_bridge.py
+++ b/mcp_tool_bridge.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+"""Bridge exposing MARBLE tools via an MCP compatible HTTP endpoint."""
+
+import asyncio
+import threading
+import uuid
+from typing import Any
+from queue import Empty
+
+from aiohttp import web
+
+from event_bus import global_event_bus
+from message_bus import MessageBus
+
+
+class MCPToolBridge:
+    """Asynchronous server translating MCP tool requests to the MessageBus.
+
+    Requests received on ``/mcp/tool`` are forwarded to the configured
+    ``MessageBus`` ``target``. The bridge waits for a corresponding reply
+    containing the same ``request_id`` and returns the tool result to the HTTP
+    client. This allows external MCP clients to access MARBLE tools while the
+    tool execution remains decoupled inside the ``ToolManagerPlugin``.
+    """
+
+    def __init__(
+        self,
+        bus: MessageBus,
+        *,
+        target: str = "tool_manager",
+        host: str = "localhost",
+        port: int = 8766,
+        agent_id: str = "mcp_tool_bridge",
+    ) -> None:
+        self.bus = bus
+        self.target = target
+        self.host = host
+        self.port = port
+        self.agent_id = agent_id
+        self.bus.register(self.agent_id)
+        self.app = web.Application()
+        self.app.router.add_post("/mcp/tool", self._handle_tool)
+        self.runner: web.AppRunner | None = None
+        self.loop: asyncio.AbstractEventLoop | None = None
+        self.thread: threading.Thread | None = None
+
+    async def _handle_tool(self, request: web.Request) -> web.Response:
+        data: dict[str, Any] = await request.json() if request.can_read_body else {}
+        query = str(data.get("query", ""))
+        request_id = data.get("id", str(uuid.uuid4()))
+        self.bus.send(
+            self.agent_id,
+            self.target,
+            {"request_id": request_id, "query": query},
+        )
+        try:
+            while True:
+                msg = self.bus.receive(self.agent_id, timeout=5)
+                if msg.content.get("request_id") == request_id:
+                    break
+        except Empty:
+            return web.json_response({"error": "timeout"}, status=504)
+        global_event_bus.publish("mcp_tool_request", {"query": query})
+        return web.json_response(
+            {"tool": msg.content.get("tool"), "result": msg.content.get("result")}
+        )
+
+    async def _start(self) -> None:
+        self.runner = web.AppRunner(self.app)
+        await self.runner.setup()
+        site = web.TCPSite(self.runner, self.host, self.port)
+        await site.start()
+
+    def start(self) -> None:
+        if self.thread is None:
+            self.loop = asyncio.new_event_loop()
+
+            def runner() -> None:
+                asyncio.set_event_loop(self.loop)
+                self.loop.run_until_complete(self._start())
+                self.loop.run_forever()
+
+            self.thread = threading.Thread(target=runner, daemon=True)
+            self.thread.start()
+            global_event_bus.publish(
+                "mcp_tool_bridge_start", {"host": self.host, "port": self.port}
+            )
+
+    async def _stop(self) -> None:
+        if self.runner is not None:
+            await self.runner.cleanup()
+            self.runner = None
+
+    def stop(self) -> None:
+        if self.thread and self.loop:
+            fut = asyncio.run_coroutine_threadsafe(self._stop(), self.loop)
+            try:
+                fut.result(5)
+            except Exception:
+                pass
+            self.loop.call_soon_threadsafe(self.loop.stop)
+            self.thread.join(timeout=5)
+            self.thread = None
+            self.loop = None
+            global_event_bus.publish(
+                "mcp_tool_bridge_stop", {"host": self.host, "port": self.port}
+            )

--- a/tests/test_mcp_tool_bridge.py
+++ b/tests/test_mcp_tool_bridge.py
@@ -1,0 +1,38 @@
+import asyncio
+import time
+from unittest.mock import patch
+
+import aiohttp
+import torch
+
+from message_bus import MessageBus
+from tool_manager_plugin import ToolManagerPlugin
+from tool_plugins import register_tool
+from web_search_tool import WebSearchTool
+from mcp_tool_bridge import MCPToolBridge
+
+
+def test_mcp_tool_bridge_roundtrip():
+    bus = MessageBus()
+    register_tool("web_search", WebSearchTool)
+    with patch("web_search_tool.WebSearchTool.execute", return_value={"ok": 1}):
+        manager = ToolManagerPlugin(tools={"web_search": {}}, mode="mcp", bus=bus)
+        manager.initialise(torch.device("cpu"))
+        manager.execute(torch.device("cpu"))
+        bridge = MCPToolBridge(bus, host="localhost", port=5084)
+        bridge.start()
+        time.sleep(0.2)
+        try:
+            async def _request():
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(
+                        "http://localhost:5084/mcp/tool", json={"query": "search"}
+                    ) as resp:
+                        assert resp.status == 200
+                        data = await resp.json()
+                        assert data["tool"] == "web_search"
+                        assert data["result"] == {"ok": 1}
+            asyncio.run(_request())
+        finally:
+            bridge.stop()
+            manager.teardown()

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -15,6 +15,17 @@ def test_message_exchange():
     assert msg2.content == {"all": 1}
 
 
+def test_message_reply():
+    bus = MessageBus()
+    bus.register("a")
+    bus.register("b")
+    bus.send("a", "b", {"ping": 1})
+    incoming = bus.receive("b", timeout=1.0)
+    bus.reply(incoming, {"pong": 2})
+    reply = bus.receive("a", timeout=1.0)
+    assert reply.content["pong"] == 2
+
+
 def test_environment_simulation_no_deadlock():
     bus = MessageBus()
     agents = {

--- a/tool_manager_plugin.py
+++ b/tool_manager_plugin.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Pipeline plugin that routes queries to external tools."""
 
-from typing import Dict
+from typing import Dict, Optional
 
 import torch
 
@@ -14,6 +14,9 @@ from tool_plugins import (
     load_tool_plugins,
     register_tool,
 )
+from message_bus import MessageBus
+from queue import Empty
+import threading
 
 
 class HeuristicToolPolicy:
@@ -32,10 +35,25 @@ class HeuristicToolPolicy:
 class ToolManagerPlugin(PipelinePlugin):
     """Meta-plugin that delegates a query to one of several tools."""
 
-    def __init__(self, tools: Dict[str, Dict], policy: str = "heuristic") -> None:
-        super().__init__(tools=tools, policy=policy)
+    def __init__(
+        self,
+        tools: Dict[str, Dict],
+        policy: str = "heuristic",
+        *,
+        mode: str = "direct",
+        bus: Optional[MessageBus] = None,
+        agent_id: str = "tool_manager",
+    ) -> None:
+        super().__init__(tools=tools, policy=policy, mode=mode, agent_id=agent_id)
         self.tool_configs = tools
         self.policy_name = policy
+        self.mode = mode
+        self.bus = bus
+        self.agent_id = agent_id
+        self._thread: Optional[threading.Thread] = None
+        self._running = False
+        self._device: Optional[torch.device] = None
+        self._marble = None
 
     def initialise(self, device: torch.device, marble=None) -> None:
         load_tool_plugins()
@@ -56,19 +74,59 @@ class ToolManagerPlugin(PipelinePlugin):
             self._policy = HeuristicToolPolicy()
         else:  # pragma: no cover - future policies
             raise ValueError(f"Unknown policy {self.policy_name}")
+        self._device = device
+        self._marble = marble
+        if self.mode == "mcp":
+            if self.bus is None:
+                raise ValueError("MessageBus required in mcp mode")
+            self.bus.register(self.agent_id)
 
-    def execute(self, device: torch.device, marble=None, query: str = ""):
-        if not query:
-            raise ValueError("query must be supplied")
+    def _run_tool(self, query: str):
         tool_name = self._policy.select(query, self._tools)
         result = self._tools[tool_name].execute(
-            device, marble=marble, query=query
+            self._device if self._device is not None else torch.device("cpu"),
+            marble=self._marble,
+            query=query,
         )
+        return tool_name, result
+
+    def _bus_loop(self) -> None:
+        assert self.bus is not None
+        while self._running:
+            try:
+                msg = self.bus.receive(self.agent_id, timeout=0.1)
+            except Empty:
+                continue
+            query = msg.content.get("query", "")
+            tool_name, result = self._run_tool(query)
+            self.bus.reply(
+                msg,
+                {
+                    "request_id": msg.content.get("request_id"),
+                    "tool": tool_name,
+                    "result": result,
+                },
+            )
+
+    def execute(self, device: torch.device, marble=None, query: str = ""):
+        if self.mode == "mcp":
+            if not self._running:
+                self._running = True
+                self._thread = threading.Thread(target=self._bus_loop, daemon=True)
+                self._thread.start()
+            return {"mode": "mcp", "agent_id": self.agent_id}
+        if not query:
+            raise ValueError("query must be supplied")
+        tool_name, result = self._run_tool(query)
         return {"tool": tool_name, "result": result}
 
     def teardown(self) -> None:
         for tool in self._tools.values():
             tool.teardown()
+        if self.mode == "mcp" and self._thread is not None:
+            self._running = False
+            self._thread.join(timeout=1)
+            self._thread = None
 
 
 def register(register_fn=register_plugin) -> None:

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -148,6 +148,15 @@ tool_manager:
     tool whose :meth:`can_handle` method returns ``True``. Other policies may be
     added in the future and should be referenced here by name. Invalid values
     raise a configuration error.
+  mode: Controls how the manager accepts queries. ``"direct"`` executes a
+    single query supplied to :meth:`execute`. ``"mcp"`` enables integration with
+    the :class:`MessageBus`, listening for incoming tool requests from
+    components such as :class:`MCPToolBridge` and replying with tool outputs.
+    Use ``"mcp"`` when exposing MARBLE tools to external MCP clients.
+  agent_id: Identifier used on the :class:`MessageBus` when ``mode`` is
+    ``"mcp"``. Multiple managers can run concurrently provided each uses a
+    unique ``agent_id``. The identifier is also used by bridges to address
+    messages to the correct manager instance.
   tools: Mapping of tool identifiers to configuration dictionaries. Each key
     must correspond to a registered tool plugin and its value supplies keyword
     arguments passed to the tool's constructor. For example:


### PR DESCRIPTION
## Summary
- add MessageBus.reply for bidirectional messaging
- implement MCPToolBridge to expose tool endpoint via HTTP and MessageBus
- extend ToolManagerPlugin with mcp mode and update configuration/docs

## Testing
- `pytest tests/test_tool_manager_plugin.py -q`
- `pytest tests/test_multi_agent.py -q`
- `pytest tests/test_mcp_tool_bridge.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689469ab52848327ab1fd62e1ff8725d