### PR TITLE
Add script to identify unused configurable parameters

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1510,3 +1510,6 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 - [x] Persist replay buffers and neuromodulatory state in model snapshots.
 - [x] Create integration tests verifying dreaming state survives save/load cycles.
 - [x] Benchmark learning performance with and without dream consolidation.
+334. [ ] Audit config.yaml for unused parameters and implement missing ones.
+    - [ ] Identify parameters defined in config.yaml but not referenced in code.
+    - [ ] Implement missing parameters or prune outdated ones.

--- a/scripts/find_unimplemented_params.py
+++ b/scripts/find_unimplemented_params.py
@@ -1,0 +1,66 @@
+import pathlib
+import re
+import subprocess
+from typing import List
+
+PARAM_LINE = re.compile(r"^\s*-\s*([\w\.]+)")
+
+
+def parse_parameters(md_path: pathlib.Path) -> List[str]:
+    """Extract parameter names from CONFIGURABLE_PARAMETERS.md."""
+    params: List[str] = []
+    for line in md_path.read_text().splitlines():
+        match = PARAM_LINE.match(line)
+        if match:
+            name = match.group(1).split(":", 1)[0].strip()
+            if name:
+                params.append(name)
+    return params
+
+
+def search_param(param: str, root: pathlib.Path) -> bool:
+    """Return True if *param* is found in code under *root* (excluding markdown)."""
+    # search using ripgrep
+    result = subprocess.run(
+        [
+            "rg",
+            param,
+            "-l",
+            "--glob",
+            "!CONFIGURABLE_PARAMETERS.md",
+            "--glob",
+            "!*.md",
+        ],
+        cwd=root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    return bool(result.stdout.strip())
+
+
+def find_unimplemented(
+    md_path: pathlib.Path, root: pathlib.Path | None = None
+) -> List[str]:
+    """Return parameters present in md_path but absent from code."""
+    if root is None:
+        root = md_path.parent
+    params = parse_parameters(md_path)
+    missing = []
+    for p in params:
+        token = p.split(".")[-1]
+        if not search_param(token, root):
+            missing.append(p)
+    return missing
+
+
+def main() -> None:
+    repo_root = pathlib.Path(__file__).resolve().parent.parent
+    md_path = repo_root / "CONFIGURABLE_PARAMETERS.md"
+    missing = find_unimplemented(md_path, repo_root)
+    for p in missing:
+        print(p)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_find_unimplemented_params.py
+++ b/tests/test_find_unimplemented_params.py
@@ -1,0 +1,13 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+from find_unimplemented_params import find_unimplemented
+
+
+def test_find_unimplemented_params(tmp_path):
+    md = tmp_path / "CONFIGURABLE_PARAMETERS.md"
+    md.write_text("## section\n- present\n- missing\n")
+    (tmp_path / "code.py").write_text("present=1\n")
+    missing = find_unimplemented(md, tmp_path)
+    assert missing == ["missing"]


### PR DESCRIPTION
## Summary
- add `find_unimplemented_params` script to scan `CONFIGURABLE_PARAMETERS.md` entries against repository code and list missing keys
- provide unit test verifying parameter detection logic on synthetic example
- note TODO item to audit `config.yaml` for unused parameters in future

## Testing
- `pre-commit run --files scripts/find_unimplemented_params.py tests/test_find_unimplemented_params.py TODO.md`
- `pytest tests/test_find_unimplemented_params.py`

------
https://chatgpt.com/codex/tasks/task_e_689472b273a88327bb5249d201f65151