### PR TITLE
Add live Kùzu experiment tracking

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -34,7 +34,7 @@ Each entry is listed under its section heading.
 ## plugins
 - (list of module import paths to load)
 
-## topology_graph
+## live_kuzu
 - enabled
 - db_path
 

--- a/README.md
+++ b/README.md
@@ -991,6 +991,13 @@ remote dashboards to display real-time step updates alongside metrics.
 Dataset utilities likewise publish `dataset_load_start` and `dataset_load_end`
 events so interfaces can surface dataset activity next to pipeline progress.
 
+The repository also ships with a `KuzuExperimentTracker` that stores both
+metrics and training events inside a local Kùzu graph database. Enable the
+tracker and live topology mirroring by setting `live_kuzu.enabled: true` in
+`config.yaml`. During training all metrics from `MetricsVisualizer` as well as
+pipeline progress events are written to `live_kuzu.db_path`, which can then be
+explored interactively using [Kùzu Explorer](https://kuzudb.com/).
+
 ## Dataset Versioning and Replication
 
 Datasets can be tracked over time with `dataset_versioning`. The

--- a/config.yaml
+++ b/config.yaml
@@ -36,9 +36,9 @@ plugins: []           # Additional plugin modules to load
 scheduler:
   plugin: thread       # Asynchronous task scheduler plugin (thread or asyncio)
 
-topology_graph:
-  enabled: false        # Mirror core topology into a persistent Kùzu graph
-  db_path: "topology.kuzu"  # Filesystem path of the Kùzu database
+live_kuzu:
+  enabled: false        # Stream topology and training metrics into a live Kùzu database
+  db_path: "live.kuzu"  # Filesystem path of the Kùzu database
 
 pipeline:
   async_enabled: false  # Execute HighLevelPipeline steps asynchronously when true

--- a/config_schema.py
+++ b/config_schema.py
@@ -182,7 +182,7 @@ CONFIG_SCHEMA = {
                 },
             },
         },
-        "topology_graph": {
+        "live_kuzu": {
             "type": "object",
             "properties": {
                 "enabled": {"type": "boolean"},

--- a/marble_main.py
+++ b/marble_main.py
@@ -52,6 +52,7 @@ class MARBLE:
             "csv_log_path": None,
             "json_log_path": None,
             "anomaly_std_threshold": 3.0,
+            "tracker": None,
         }
         if mv_params is not None:
             mv_defaults.update(mv_params)
@@ -74,6 +75,7 @@ class MARBLE:
                 csv_log_path=mv_defaults["csv_log_path"],
                 json_log_path=mv_defaults["json_log_path"],
                 anomaly_std_threshold=mv_defaults["anomaly_std_threshold"],
+                tracker=mv_defaults["tracker"],
             )
         self.metrics_dashboard = None
         if (

--- a/tests/test_kuzu_experiment_tracker.py
+++ b/tests/test_kuzu_experiment_tracker.py
@@ -1,0 +1,28 @@
+import torch
+from experiment_tracker import KuzuExperimentTracker, attach_tracker_to_events
+from marble_base import MetricsVisualizer
+from pipeline import Pipeline
+from event_bus import PROGRESS_EVENT
+
+
+def sample_step(device: str) -> str:
+    t = torch.tensor([1.0], device=device)
+    return t.device.type
+
+
+def test_kuzu_tracker_gpu_compatible(tmp_path):
+    db = tmp_path / "exp.kuzu"
+    tracker = KuzuExperimentTracker(str(db))
+    mv = MetricsVisualizer(tracker=tracker)
+    mv.update({"loss": 0.5})
+    detach = attach_tracker_to_events(tracker, events=[PROGRESS_EVENT])
+    pipe = Pipeline()
+    dev = "cuda" if torch.cuda.is_available() else "cpu"
+    pipe.add_step(func="sample_step", module=__name__, params={"device": dev})
+    result = pipe.execute()[0]
+    detach()
+    rows = tracker.db.execute("MATCH (m:Metric) RETURN count(m) AS cnt")
+    assert rows[0]["cnt"] == 1
+    rows = tracker.db.execute("MATCH (e:Event) RETURN count(e) AS cnt")
+    assert rows[0]["cnt"] >= 1
+    assert result == dev

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -83,18 +83,15 @@ scheduler:
     performed by the scheduled function. The scheduler can also be overridden at
     runtime using the ``--scheduler-plugin`` CLI flag.
 
-topology_graph:
-  enabled: Activates live topology tracking backed by a persistent Kùzu graph.
-    When ``true`` every change to the neuron or synapse structure is mirrored
-    into a local Kùzu database. External tools can query this graph to observe
-    how MARBLE grows during training. Disable when graph logging is not
-    required to avoid additional overhead.
-  db_path: Filesystem location where the Kùzu database is stored. The path may
-    be relative or absolute; when the file does not exist it is created. The
-    database contains one node per neuron and a ``SYNAPSE`` relationship for
-    every connection, allowing full reconstruction of the topology at any time.
-    Ensure the directory has sufficient free space as large networks can
-    generate substantial graph data.
+live_kuzu:
+  enabled: When set to ``true`` MARBLE streams both its evolving network
+    topology and all logged training metrics into a persistent Kùzu database.
+    This allows real-time inspection with tools like Kùzu Explorer while
+    training continues on the GPU. Disable to avoid the extra disk I/O.
+  db_path: Filesystem location for the Kùzu database. A new database is created
+    if the path does not yet exist. The database stores neuron and synapse
+    nodes alongside ``Metric`` and ``Event`` records, so ensure the directory
+    has enough free space for long training runs.
 
 pipeline:
   async_enabled: When set to ``true`` the ``HighLevelPipeline`` executes its


### PR DESCRIPTION
## Summary
- add `live_kuzu` config section for streaming topology and metrics to a Kùzu database
- implement `KuzuExperimentTracker` and integrate it into training startup
- document live Kùzu usage and provide GPU-safe tracker tests

## Testing
- `pytest tests/test_config.py -q`
- `pytest tests/test_experiment_tracker_event_logging.py -q`
- `pytest tests/test_experiment_tracker.py -q`
- `pytest tests/test_topology_kuzu_live_update.py -q`
- `pytest tests/test_kuzu_experiment_tracker.py -q`
- `pytest tests/test_streamlit_progress.py::test_progress_desktop -q`
- `pytest tests/test_streamlit_progress.py::test_progress_mobile -q`


------
https://chatgpt.com/codex/tasks/task_e_6894758a406c832781d7285fb58da700