### PR TITLE
feat: stream neuronenblitz shards and secure remote server

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,11 @@ When a ``Pipeline`` or ``HighLevelPipeline`` is executed with a
 ``Neuronenblitz`` instance, these streamed batches are fed directly into
 training. Each shard is moved to the active CPU or GPU before invoking
 ``Neuronenblitz.train`` so large datasets can be learned from without keeping
-all pairs in memory.
+all pairs in memory. For standalone training the
+:class:`~marble_neuronenblitz.Neuronenblitz` class provides
+``train_streaming_shards`` which consumes an iterable of
+``BitTensorDataset`` shards using background prefetching to keep the model
+responsive.
 
 Both ``Neuronenblitz.train`` and the higher level ``train_marble_system`` helper
 accept custom ``loss_fn`` and ``validation_fn`` callables.  ``loss_fn``
@@ -330,7 +334,9 @@ standard learning code unchanged.
 For heterogeneous hardware, ``remote_offload.RemoteBrainServer`` and
 ``RemoteBrainClient`` allow parts of a brain to run on another machine. Values
 are compressed with ``DataCompressor`` and transmitted over HTTP with optional
-authentication.
+authentication. ``RemoteBrainServer`` can serve HTTPS when
+``network.remote_server.ssl_enabled`` is set, using the certificate and key
+files specified in ``ssl_cert_file`` and ``ssl_key_file``.
 
 Both the HTTP client and the gRPC-based ``GrpcRemoteTier`` include retry
 handlers that automatically recover from transient network or hardware glitches.

--- a/TODO.md
+++ b/TODO.md
@@ -727,11 +727,11 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [x] Implement Integrate HighLevelPipeline with the forthcoming Neuronenblitz improvements with CPU/GPU support.
    - [x] Add tests validating Integrate HighLevelPipeline with the forthcoming Neuronenblitz improvements.
    - [x] Document Integrate HighLevelPipeline with the forthcoming Neuronenblitz improvements in README and TUTORIAL.
-217. [ ] Support streaming dataset shards during Neuronenblitz training to keep the model responsive.
-   - [ ] Outline design for Support streaming dataset shards during Neuronenblitz training to keep the model responsive.
-   - [ ] Implement Support streaming dataset shards during Neuronenblitz training to keep the model responsive with CPU/GPU support.
-   - [ ] Add tests validating Support streaming dataset shards during Neuronenblitz training to keep the model responsive.
-   - [ ] Document Support streaming dataset shards during Neuronenblitz training to keep the model responsive in README and TUTORIAL.
+217. [x] Support streaming dataset shards during Neuronenblitz training to keep the model responsive.
+   - [x] Outline design for Support streaming dataset shards during Neuronenblitz training to keep the model responsive.
+   - [x] Implement Support streaming dataset shards during Neuronenblitz training to keep the model responsive with CPU/GPU support.
+   - [x] Add tests validating Support streaming dataset shards during Neuronenblitz training to keep the model responsive.
+   - [x] Document Support streaming dataset shards during Neuronenblitz training to keep the model responsive in README and TUTORIAL.
 218. [x] Allow learning modules to be swapped in and out through a plugin interface.
    - [x] Outline design for Allow learning modules to be swapped in and out through a plugin interface.
    - [x] Implement Allow learning modules to be swapped in and out through a plugin interface with CPU/GPU support.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -275,6 +275,18 @@ processing.
    print("Trained on", len(nb.training_history), "batches")
    ```
 
+5. **Stream shards directly into Neuronenblitz** without building a pipeline:
+
+   ```python
+   shards = [
+       BitTensorDataset([(i, i + 1) for i in range(0, 4)], device="cpu"),
+       BitTensorDataset([(i, i + 1) for i in range(4, 8)], device="cpu"),
+   ]
+   nb = Neuronenblitz(Core({}))
+   nb.train_streaming_shards(shards, batch_size=2, device="cuda")
+   print("Examples processed:", len(nb.training_history))
+   ```
+
 ### Customising Steps with Hooks
 
 The :class:`pipeline.Pipeline` supports registering callables that run before
@@ -731,10 +743,15 @@ from marble import DataLoader
 
 # Run this on the remote machine
 server = RemoteBrainServer(port=8000)
+# For HTTPS supply certificate and key:
+# server = RemoteBrainServer(port=8000, ssl_enabled=True,
+#                            ssl_cert_file="server.crt", ssl_key_file="server.key")
 server.start()
 
 # On the training machine
 cfg = load_config()
+# Use "https://" and disable verification for self-signed certs
+# client = RemoteBrainClient('https://remote_host:8000', ssl_verify=False)
 client = RemoteBrainClient('http://remote_host:8000')
 marble = MARBLE(cfg['core'], remote_client=client)
 from sklearn.datasets import load_digits

--- a/config_loader.py
+++ b/config_loader.py
@@ -215,6 +215,11 @@ def create_marble_from_config(
             port=server_cfg.get("port", 8000),
             remote_url=server_cfg.get("remote_url"),
             auth_token=server_cfg.get("auth_token"),
+            ssl_enabled=server_cfg.get("ssl_enabled", False),
+            ssl_cert_file=server_cfg.get("ssl_cert_file"),
+            ssl_key_file=server_cfg.get("ssl_key_file"),
+            compression_level=server_cfg.get("compression_level", 6),
+            compression_enabled=server_cfg.get("compression_enabled", True),
         )
         remote_server.start()
 

--- a/config_schema.py
+++ b/config_schema.py
@@ -195,7 +195,16 @@ CONFIG_SCHEMA = {
                 "remote_server": {
                     "type": "object",
                     "properties": {
+                        "enabled": {"type": "boolean"},
+                        "host": {"type": "string"},
+                        "port": {"type": "integer", "minimum": 1},
+                        "remote_url": {"type": ["string", "null"]},
                         "auth_token": {"type": ["string", "null"]},
+                        "ssl_enabled": {"type": "boolean"},
+                        "ssl_cert_file": {"type": ["string", "null"]},
+                        "ssl_key_file": {"type": ["string", "null"]},
+                        "compression_level": {"type": "integer", "minimum": 0, "maximum": 9},
+                        "compression_enabled": {"type": "boolean"},
                     },
                 },
                 "remote_client": {

--- a/tests/test_multiprocessing_dataset.py
+++ b/tests/test_multiprocessing_dataset.py
@@ -1,5 +1,5 @@
-import torch
 import pytest
+import torch
 
 from process_manager import ProcessManager, SharedDataset
 

--- a/tests/test_nb_streaming_shards.py
+++ b/tests/test_nb_streaming_shards.py
@@ -1,0 +1,26 @@
+import pytest
+import torch
+from marble_neuronenblitz import Neuronenblitz
+from marble_core import Core
+from bit_tensor_dataset import BitTensorDataset
+
+
+def make_shard(start: int) -> BitTensorDataset:
+    pairs = [
+        (torch.tensor([i], dtype=torch.float32), torch.tensor([i + 1], dtype=torch.float32))
+        for i in range(start, start + 4)
+    ]
+    return BitTensorDataset(pairs, device="cpu")
+
+def test_train_streaming_shards_cpu():
+    shards = [make_shard(0), make_shard(4)]
+    nb = Neuronenblitz(Core({}))
+    nb.train_streaming_shards(shards, batch_size=2, device="cpu")
+    assert len(nb.training_history) > 0
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_train_streaming_shards_gpu():
+    shards = [make_shard(0)]
+    nb = Neuronenblitz(Core({}))
+    nb.train_streaming_shards(shards, batch_size=2, device="cuda")
+    assert len(nb.training_history) > 0


### PR DESCRIPTION
## Summary
- secure `RemoteBrainServer` with optional HTTPS and expose related config knobs
- stream `BitTensorDataset` shards directly through `Neuronenblitz.train_streaming_shards`
- document shard streaming and HTTPS support; fix multiprocessing test import

## Testing
- `pytest tests/test_multiprocessing_dataset.py -q`
- `pytest tests/test_remote_offloading.py -q`
- `pytest tests/test_nb_streaming_shards.py -q`
- `pytest tests/test_config.py -q`
- `pytest tests/test_config_additional.py -q`
- `pytest tests/test_highlevel_pipeline_neuronenblitz.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68948d2e76588327842799d172cac3c7