### PR TITLE
Add BitTensorStreamingDataset

### DIFF
--- a/bit_tensor_streaming_dataset.py
+++ b/bit_tensor_streaming_dataset.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Iterator
+
+import torch
+from torch.utils.data import IterableDataset
+
+from bit_tensor_dataset import BitTensorDataset
+
+
+class BitTensorStreamingDataset(IterableDataset):
+    """Stream ``(input, target)`` pairs as bit tensors.
+
+    This dataset converts each item from ``data_stream`` to the bit-tensor
+    representation used by :class:`BitTensorDataset` and yields encoded pairs
+    on-the-fly. Unlike :class:`BitTensorDataset` no data is stored in memory;
+    each record is processed lazily as the stream is consumed. When
+    ``batch_size`` is greater than ``1`` the dataset yields stacked batches of
+    that size. The final batch may contain fewer samples if the stream is not a
+    multiple of ``batch_size``.
+
+    Parameters
+    ----------
+    data_stream:
+        Iterable producing ``(input, target)`` pairs.
+    batch_size:
+        Number of samples yielded together. ``1`` streams single records.
+    All additional keyword arguments are forwarded to :class:`BitTensorDataset`
+    to control vocabulary, compression and device placement.
+    """
+
+    def __init__(
+        self,
+        data_stream: Iterable[tuple[Any, Any]],
+        *,
+        batch_size: int = 1,
+        **kwargs: Any,
+    ) -> None:
+        self.data_stream = data_stream
+        self.batch_size = int(batch_size)
+        if self.batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        # Reuse BitTensorDataset for encoding logic
+        self.encoder = BitTensorDataset([], **kwargs)
+
+    def __iter__(self) -> Iterator[tuple[torch.Tensor, torch.Tensor]]:
+        it = iter(self.data_stream)
+        if self.batch_size == 1:
+            for inp, tgt in it:
+                yield self.encoder.encode_object(inp), self.encoder.encode_object(tgt)
+        else:
+            inputs: list[torch.Tensor] = []
+            targets: list[torch.Tensor] = []
+            for inp, tgt in it:
+                inputs.append(self.encoder.encode_object(inp))
+                targets.append(self.encoder.encode_object(tgt))
+                if len(inputs) == self.batch_size:
+                    yield torch.stack(inputs), torch.stack(targets)
+                    inputs.clear()
+                    targets.clear()
+            if inputs:
+                yield torch.stack(inputs), torch.stack(targets)

--- a/tests/test_bit_tensor_streaming_dataset.py
+++ b/tests/test_bit_tensor_streaming_dataset.py
@@ -1,0 +1,28 @@
+import torch
+
+from bit_tensor_streaming_dataset import BitTensorStreamingDataset
+
+
+def pair_stream(n=3):
+    for i in range(n):
+        yield {"input": i}, {"target": i + 1}
+
+
+def test_streaming_single_records():
+    ds = BitTensorStreamingDataset(pair_stream(3), batch_size=1)
+    items = list(ds)
+    assert len(items) == 3
+    for inp, tgt in items:
+        assert inp.shape[1] == 8
+        assert tgt.shape[1] == 8
+        assert isinstance(inp, torch.Tensor)
+
+
+def test_streaming_batches():
+    ds = BitTensorStreamingDataset(pair_stream(5), batch_size=2)
+    batches = list(ds)
+    assert len(batches) == 3
+    first_inputs, first_targets = batches[0]
+    assert first_inputs.shape[0] == 2
+    last_inputs, _ = batches[-1]
+    assert last_inputs.shape[0] == 1


### PR DESCRIPTION
## Summary
- add BitTensorStreamingDataset for on-the-fly encoding of streamed (input, target) pairs with optional batching
- add unit tests exercising streaming dataset single record and batched usage

## Testing
- `pre-commit run --files bit_tensor_streaming_dataset.py tests/test_bit_tensor_streaming_dataset.py`
- `pytest tests/test_bit_tensor_streaming_dataset.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894964b45888327b242f505d87ef3d1