### PR TITLE
feat: add seeking and virtual batches

### DIFF
--- a/bit_tensor_streaming_dataset.py
+++ b/bit_tensor_streaming_dataset.py
@@ -9,54 +9,125 @@ from bit_tensor_dataset import BitTensorDataset
 
 
 class BitTensorStreamingDataset(IterableDataset):
-    """Stream ``(input, target)`` pairs as bit tensors.
+    """Stream ``(input, target)`` pairs as bit tensors with random access.
 
-    This dataset converts each item from ``data_stream`` to the bit-tensor
-    representation used by :class:`BitTensorDataset` and yields encoded pairs
-    on-the-fly. Unlike :class:`BitTensorDataset` no data is stored in memory;
-    each record is processed lazily as the stream is consumed. When
-    ``batch_size`` is greater than ``1`` the dataset yields stacked batches of
-    that size. The final batch may contain fewer samples if the stream is not a
-    multiple of ``batch_size``.
+    The class is a lightweight wrapper around a HuggingFace dataset object that
+    exposes ``select`` for random access. Only the requested records are pulled
+    from the underlying dataset which keeps the implementation compatible with
+    ``datasets.load_dataset(..., streaming=True)``.
 
     Parameters
     ----------
-    data_stream:
-        Iterable producing ``(input, target)`` pairs.
+    dataset:
+        HuggingFace dataset object supporting ``select``. Each sample must be a
+        ``(input, target)`` tuple or a mapping with ``"input"`` and
+        ``"target"`` fields.
     batch_size:
-        Number of samples yielded together. ``1`` streams single records.
-    All additional keyword arguments are forwarded to :class:`BitTensorDataset`
-    to control vocabulary, compression and device placement.
+        Number of consecutive samples yielded together when iterating.
+    virtual_batch_size:
+        Size of the batches returned by :meth:`get_virtual_batch`. When not
+        provided virtual batching is disabled.
+    kwargs:
+        Forwarded to :class:`BitTensorDataset` for encoding configuration.
     """
 
     def __init__(
         self,
-        data_stream: Iterable[tuple[Any, Any]],
+        dataset: Iterable[tuple[Any, Any]],
         *,
         batch_size: int = 1,
+        virtual_batch_size: int | None = None,
         **kwargs: Any,
     ) -> None:
-        self.data_stream = data_stream
+        if not hasattr(dataset, "select"):
+            raise TypeError("dataset must provide a 'select' method")
+        self.dataset = dataset
         self.batch_size = int(batch_size)
         if self.batch_size <= 0:
             raise ValueError("batch_size must be positive")
+        self.virtual_batch_size = (
+            int(virtual_batch_size) if virtual_batch_size is not None else None
+        )
+        if self.virtual_batch_size is not None and self.virtual_batch_size <= 0:
+            raise ValueError("virtual_batch_size must be positive")
         # Reuse BitTensorDataset for encoding logic
         self.encoder = BitTensorDataset([], **kwargs)
+        self.position = 0
 
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _normalise_record(self, record: Any) -> tuple[Any, Any]:
+        if isinstance(record, tuple):
+            return record
+        if isinstance(record, dict):
+            return record.get("input"), record.get("target")
+        raise TypeError("record must be tuple or dict with 'input'/'target'")
+
+    def _fetch_index(self, index: int) -> tuple[Any, Any]:
+        subset = self.dataset.select([index])
+        try:
+            record = next(iter(subset))
+        except StopIteration as exc:  # dataset exhausted
+            raise IndexError(index) from exc
+        return self._normalise_record(record)
+
+    # ------------------------------------------------------------------
+    # Seeking
+    def seek_to(self, index: int) -> None:
+        if index < 0:
+            raise ValueError("index must be non-negative")
+        # Validate by attempting to select the record
+        self._fetch_index(index)
+        self.position = index
+
+    def seek_forward(self, n: int) -> None:
+        self.seek_to(self.position + int(n))
+
+    def seek_backward(self, n: int) -> None:
+        self.seek_to(max(0, self.position - int(n)))
+
+    # ------------------------------------------------------------------
+    # Iteration
     def __iter__(self) -> Iterator[tuple[torch.Tensor, torch.Tensor]]:
-        it = iter(self.data_stream)
-        if self.batch_size == 1:
-            for inp, tgt in it:
-                yield self.encoder.encode_object(inp), self.encoder.encode_object(tgt)
-        else:
+        idx = self.position
+        while True:
             inputs: list[torch.Tensor] = []
             targets: list[torch.Tensor] = []
-            for inp, tgt in it:
-                inputs.append(self.encoder.encode_object(inp))
-                targets.append(self.encoder.encode_object(tgt))
-                if len(inputs) == self.batch_size:
-                    yield torch.stack(inputs), torch.stack(targets)
-                    inputs.clear()
-                    targets.clear()
-            if inputs:
+            for _ in range(self.batch_size):
+                try:
+                    inp_raw, tgt_raw = self._fetch_index(idx)
+                except IndexError:
+                    break
+                inputs.append(self.encoder.encode_object(inp_raw))
+                targets.append(self.encoder.encode_object(tgt_raw))
+                idx += 1
+            if not inputs:
+                break
+            if self.batch_size == 1:
+                yield inputs[0], targets[0]
+            else:
                 yield torch.stack(inputs), torch.stack(targets)
+        self.position = idx
+
+    # ------------------------------------------------------------------
+    # Virtual batching
+    def get_virtual_batch(
+        self, batch_index: int, *, stream: bool = False
+    ) -> Iterable[tuple[torch.Tensor, torch.Tensor]]:
+        if self.virtual_batch_size is None:
+            raise ValueError("virtual_batch_size not configured")
+        start = batch_index * self.virtual_batch_size
+        end = start + self.virtual_batch_size
+        subset = self.dataset.select(range(start, end))
+
+        def _generator() -> Iterator[tuple[torch.Tensor, torch.Tensor]]:
+            for record in subset:
+                inp_raw, tgt_raw = self._normalise_record(record)
+                yield (
+                    self.encoder.encode_object(inp_raw),
+                    self.encoder.encode_object(tgt_raw),
+                )
+
+        if stream:
+            return _generator()
+        return list(_generator())

--- a/tests/test_bit_tensor_streaming_dataset.py
+++ b/tests/test_bit_tensor_streaming_dataset.py
@@ -3,26 +3,55 @@ import torch
 from bit_tensor_streaming_dataset import BitTensorStreamingDataset
 
 
-def pair_stream(n=3):
-    for i in range(n):
-        yield {"input": i}, {"target": i + 1}
+class MockHFStreamingDataset:
+    """Minimal mock of a HuggingFace streaming dataset."""
+
+    def __init__(self, data):
+        self._data = list(data)
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def select(self, indices):
+        return (self._data[i] for i in indices if 0 <= i < len(self._data))
 
 
-def test_streaming_single_records():
-    ds = BitTensorStreamingDataset(pair_stream(3), batch_size=1)
-    items = list(ds)
-    assert len(items) == 3
-    for inp, tgt in items:
-        assert inp.shape[1] == 8
-        assert tgt.shape[1] == 8
-        assert isinstance(inp, torch.Tensor)
+def make_dataset(n=5):
+    return MockHFStreamingDataset([(i, i + 1) for i in range(n)])
 
 
-def test_streaming_batches():
-    ds = BitTensorStreamingDataset(pair_stream(5), batch_size=2)
-    batches = list(ds)
-    assert len(batches) == 3
-    first_inputs, first_targets = batches[0]
-    assert first_inputs.shape[0] == 2
-    last_inputs, _ = batches[-1]
-    assert last_inputs.shape[0] == 1
+def test_seek_operations():
+    ds = BitTensorStreamingDataset(make_dataset(), batch_size=1)
+    ds.seek_to(2)
+    inp, tgt = next(iter(ds))
+    assert ds.encoder.decode_tensor(inp) == 2
+    assert ds.encoder.decode_tensor(tgt) == 3
+    assert isinstance(inp, torch.Tensor)
+
+    ds.seek_backward(1)
+    inp, tgt = next(iter(ds))
+    assert ds.encoder.decode_tensor(inp) == 1
+    assert isinstance(inp, torch.Tensor)
+
+    ds.seek_forward(2)
+    inp, tgt = next(iter(ds))
+    assert ds.encoder.decode_tensor(inp) == 3
+    assert isinstance(inp, torch.Tensor)
+
+
+def test_virtual_batches():
+    ds = BitTensorStreamingDataset(make_dataset(), batch_size=1, virtual_batch_size=2)
+    batch = ds.get_virtual_batch(1, stream=False)
+    assert len(batch) == 2
+    first = ds.encoder.decode_tensor(batch[0][0])
+    second = ds.encoder.decode_tensor(batch[1][0])
+    assert (first, second) == (2, 3)
+    assert isinstance(batch[0][0], torch.Tensor)
+
+    streamed = list(ds.get_virtual_batch(0, stream=True))
+    assert ds.encoder.decode_tensor(streamed[0][0]) == 0
+    assert isinstance(streamed[0][0], torch.Tensor)
+
+    # Re-access previously requested batch
+    again = ds.get_virtual_batch(1, stream=False)
+    assert ds.encoder.decode_tensor(again[0][0]) == 2


### PR DESCRIPTION
## Summary
- add index tracking and seeking to `BitTensorStreamingDataset`
- introduce optional virtual batch API for random batch access
- test seeking and virtual batching with a mocked HF dataset

## Testing
- `pytest tests/test_bit_tensor_streaming_dataset.py`


------
https://chatgpt.com/codex/tasks/task_e_6894a7142e74832787b5a09b89577ee0