### PR TITLE
Add virtual batching to streaming dataset

### DIFF
--- a/tests/test_bit_tensor_streaming_dataset.py
+++ b/tests/test_bit_tensor_streaming_dataset.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from bit_tensor_streaming_dataset import BitTensorStreamingDataset
@@ -18,6 +19,22 @@ class MockHFStreamingDataset:
 
 def make_dataset(n=5):
     return MockHFStreamingDataset([(i, i + 1) for i in range(n)])
+
+
+class CountingHFStreamingDataset(MockHFStreamingDataset):
+    """Mock dataset that records which indices were accessed via ``select``."""
+
+    def __init__(self, data):
+        super().__init__(data)
+        self.selections: list[int] = []
+
+    def select(self, indices):
+        def gen():
+            for i in indices:
+                self.selections.append(i)
+                yield self._data[i]
+
+        return gen()
 
 
 def test_seek_operations():
@@ -55,3 +72,37 @@ def test_virtual_batches():
     # Re-access previously requested batch
     again = ds.get_virtual_batch(1, stream=False)
     assert ds.encoder.decode_tensor(again[0][0]) == 2
+
+
+@pytest.mark.parametrize("vb", [1, 2, 3])
+def test_virtual_batch_sizes(vb):
+    ds = BitTensorStreamingDataset(make_dataset(7), virtual_batch_size=vb)
+    batch = ds.get_virtual_batch(1, stream=False)
+    assert len(batch) == min(vb, 7 - vb)
+    start = vb
+    for i, (inp, _tgt) in enumerate(batch):
+        assert ds.encoder.decode_tensor(inp) == start + i
+        assert isinstance(inp, torch.Tensor)
+
+
+def test_streaming_is_lazy():
+    base = CountingHFStreamingDataset([(i, i + 1) for i in range(10)])
+    ds = BitTensorStreamingDataset(base, virtual_batch_size=3)
+    gen = ds.get_virtual_batch(1, stream=True)
+    first = next(gen)
+    assert base.selections == [3]
+    assert ds.encoder.decode_tensor(first[0]) == 3
+    rest = list(gen)
+    assert base.selections == [3, 4, 5]
+    assert len(rest) == 2
+
+
+def test_iterates_over_virtual_batches():
+    ds = BitTensorStreamingDataset(make_dataset(5), virtual_batch_size=2)
+    batches = list(iter(ds))
+    assert len(batches) == 3
+    second = batches[1]
+    decoded = [
+        ds.encoder.decode_tensor(second[0][i]) for i in range(second[0].shape[0])
+    ]
+    assert decoded == [2, 3]


### PR DESCRIPTION
## Summary
- allow BitTensorStreamingDataset to group records into virtual batches
- support lazy access to virtual batches without caching
- test streaming dataset virtual batching behavior

## Testing
- `pytest tests/test_bit_tensor_streaming_dataset.py`

------
https://chatgpt.com/codex/tasks/task_e_6894abfbde6c8327a0288b21765c57da