### PR TITLE
Support HuggingFace streaming datasets in BitTensorStreamingDataset

### DIFF
--- a/examples/hf_streaming_bit_tensor.py
+++ b/examples/hf_streaming_bit_tensor.py
@@ -1,0 +1,26 @@
+"""Example of wrapping a HuggingFace streaming dataset with
+``BitTensorStreamingDataset``.
+
+The script downloads a tiny dataset without caching and streams it through the
+wrapper, yielding encoded tensors on demand.
+"""
+
+from datasets import load_dataset
+
+from bit_tensor_streaming_dataset import BitTensorStreamingDataset
+
+
+def main() -> None:
+    ds = load_dataset(
+        "hf-internal-testing/fixtures_mixed",
+        split="train",
+        streaming=True,
+    )
+    stream_ds = BitTensorStreamingDataset(ds, virtual_batch_size=2)
+    first_batch = stream_ds.get_virtual_batch(0)
+    for idx, (inp, tgt) in enumerate(first_batch):
+        print(f"sample {idx}:", inp.shape, tgt.shape)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bit_tensor_streaming_hf_integration.py
+++ b/tests/test_bit_tensor_streaming_hf_integration.py
@@ -1,0 +1,13 @@
+import datasets
+
+from bit_tensor_streaming_dataset import BitTensorStreamingDataset
+
+
+def test_hf_iterable_dataset_integration():
+    hf_ds = datasets.Dataset.from_dict(
+        {"input": [0, 1, 2, 3], "target": [1, 2, 3, 4]}
+    ).to_iterable_dataset()
+    ds = BitTensorStreamingDataset(hf_ds, virtual_batch_size=2)
+    batch = ds.get_virtual_batch(1)
+    decoded = [ds.encoder.decode_tensor(x[0]) for x in batch]
+    assert decoded == [2, 3]


### PR DESCRIPTION
## Summary
- extend `BitTensorStreamingDataset` to work with HuggingFace streaming datasets using `skip`/`take`
- add integration test with `datasets` iterable dataset and update streaming dataset tests
- document usage via new example script wrapping a HF streaming dataset

## Testing
- `pytest tests/test_bit_tensor_streaming_dataset.py`
- `pytest tests/test_bit_tensor_streaming_hf_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_6894b1f1231c8327a99639979abb3118