### PR TITLE
Add text-to-music streaming example and tests

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -3517,6 +3517,34 @@ inspect the results within the Streamlit playground.
    * *Best Configuration* – expander listing the top-performing parameters with a
      download button to export them as ``best_params.yaml`` for future runs.
 
+## Project 24 – Text-to-Music Training
+
+**Goal:** Train a MARBLE system to generate music from textual metadata using the
+`sleeping-ai/Udio-24MX1` dataset.
+
+1. **Install dependencies and run the example**:
+
+   ```bash
+   pip install -r requirements.txt
+   python examples/project24_text_to_music.py
+   ```
+
+2. **Inside the script** the dataset is streamed and wrapped so metadata becomes
+   the input and raw audio the target:
+
+   ```python
+   hf_stream = load_dataset("sleeping-ai/Udio-24MX1", split="train", streaming=True)
+   formatted_stream = hf_stream.map(format_record, remove_columns=hf_stream.column_names)
+   dataset = BitTensorStreamingDataset(formatted_stream, virtual_batch_size=2)
+   HighLevelPipeline().marble_interface.new_marble_system().marble_interface.train_marble_system(
+       train_examples=dataset, epochs=1
+   ).execute()
+   ```
+
+   The `format_record` function packs the `lyrics`, `prompt`, `tags`, and
+   `duration` fields into the input while decoding the referenced `song_path`
+   into the audio waveform target.
+
 ## Project 99 – Custom Loss Module Plugin
 
 **Goal:** Register a custom loss function through the plugin system and use it

--- a/examples/project24_text_to_music.py
+++ b/examples/project24_text_to_music.py
@@ -1,0 +1,46 @@
+import os, sys, io, requests
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import torchaudio
+from datasets import load_dataset
+
+from highlevel_pipeline import HighLevelPipeline
+from bit_tensor_streaming_dataset import BitTensorStreamingDataset
+
+def _decode_audio(url: str) -> list[float]:
+    """Download ``url`` and decode into a mono float waveform."""
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    audio_buf = io.BytesIO(resp.content)
+    waveform, _ = torchaudio.load(audio_buf)
+    return waveform.mean(dim=0).tolist()
+
+def main() -> None:
+    hf_stream = load_dataset(
+        "sleeping-ai/Udio-24MX1", split="train", streaming=True
+    )
+
+    def format_record(record: dict) -> dict:
+        audio = _decode_audio(record["song_path"])
+        return {
+            "input": {
+                "lyrics": record.get("lyrics", ""),
+                "prompt": record.get("prompt", ""),
+                "tags": record.get("tags", []),
+                "duration": record.get("duration", 0.0),
+            },
+            "target": audio,
+        }
+
+    formatted_stream = hf_stream.map(format_record, remove_columns=hf_stream.column_names)
+    dataset = BitTensorStreamingDataset(formatted_stream, virtual_batch_size=2)
+
+    pipeline = (
+        HighLevelPipeline()
+        .marble_interface.new_marble_system()
+        .marble_interface.train_marble_system(train_examples=dataset, epochs=1)
+    )
+    pipeline.execute()
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_text_to_music_example.py
+++ b/tests/test_text_to_music_example.py
@@ -1,0 +1,51 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from datasets import Dataset
+import torch
+
+from bit_tensor_streaming_dataset import BitTensorStreamingDataset
+from highlevel_pipeline import HighLevelPipeline
+
+
+def _dummy_dataset():
+    data = [{
+        "lyrics": "la la",
+        "prompt": "happy",
+        "tags": ["test"],
+        "duration": 1.0,
+        "audio": [0.0, 0.1, 0.2, 0.3],
+    }]
+    ds = Dataset.from_list(data)
+
+    def format_record(rec):
+        return {
+            "input": {
+                "lyrics": rec["lyrics"],
+                "prompt": rec["prompt"],
+                "tags": rec["tags"],
+                "duration": rec["duration"],
+            },
+            "target": rec["audio"],
+        }
+
+    return ds.map(format_record, remove_columns=ds.column_names)
+
+
+def test_streaming_wrapper_encodes_tensor():
+    ds = _dummy_dataset()
+    stream = BitTensorStreamingDataset(ds)
+    inp, tgt = next(iter(stream))
+    assert isinstance(inp, torch.Tensor)
+    assert isinstance(tgt, torch.Tensor)
+
+
+def test_pipeline_executes_with_stream():
+    ds = _dummy_dataset()
+    stream = BitTensorStreamingDataset(ds)
+    pipeline = (
+        HighLevelPipeline()
+        .marble_interface.new_marble_system()
+        .marble_interface.train_marble_system(train_examples=stream, epochs=1)
+    )
+    pipeline.execute()


### PR DESCRIPTION
## Summary
- Stream Udio-24MX1 dataset and train MARBLE via HighLevelPipeline in new example
- Cover BitTensorStreamingDataset text-to-music workflow with unit tests
- Document text-to-music training pipeline in tutorial

## Testing
- `pytest tests/test_text_to_music_example.py::test_streaming_wrapper_encodes_tensor -q`
- `pytest tests/test_text_to_music_example.py::test_pipeline_executes_with_stream -q`

------
https://chatgpt.com/codex/tasks/task_e_6894c2542ecc8327820fabdf84f8d9f2