### PR TITLE
Handle Neuronenblitz train fallbacks

### DIFF
--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -16,4 +16,5 @@ No failing tests.
 - tests/test_theory_of_mind_beliefs.py::test_memory_slot_creation_and_retrieval: AssertionError [resolved]
 - tests/test_pretraining_and_clustering.py::test_pretraining_epochs_runs_once: AttributeError: 'range' object has no attribute 'set_postfix' [resolved]
 - tests/test_pretraining_and_clustering.py::test_pretraining_epochs_runs_once: AttributeError: '_DummyPbar' object has no attribute 'close' [resolved]
+- tests/test_pretraining_and_clustering.py::test_pretraining_epochs_runs_once: TypeError: DummyNB.train() got an unexpected keyword argument 'loss_fn' [resolved]
 - tests/test_marble_interface.py::test_save_and_load_marble: TypeError: cannot pickle '_thread.lock' object [resolved]

--- a/marble_brain.py
+++ b/marble_brain.py
@@ -505,12 +505,17 @@ class Brain:
                     validation_fn=validation_fn,
                 )
             except TypeError:
-                self.neuronenblitz.train(
-                    train_examples,
-                    epochs=1,
-                    loss_fn=loss_fn,
-                    validation_fn=validation_fn,
-                )
+                # Fall back gracefully for simpler implementations that do not
+                # accept ``dream_buffer`` or loss/validation callables.
+                try:
+                    self.neuronenblitz.train(
+                        train_examples,
+                        epochs=1,
+                        loss_fn=loss_fn,
+                        validation_fn=validation_fn,
+                    )
+                except TypeError:
+                    self.neuronenblitz.train(train_examples, epochs=1)
             self.neuronenblitz.modulate_plasticity(
                 self.neuromodulatory_system.get_context()
             )


### PR DESCRIPTION
## Summary
- make Brain training more robust to Neuronenblitz implementations lacking optional parameters
- document resolved unit test failures in FAILEDTESTS.md

## Testing
- `pytest tests/test_pretraining_and_clustering.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894c5f984848327a8e10c268ee83aa0