### PR TITLE
Tag bias neurons for converter support

### DIFF
--- a/converttodo.md
+++ b/converttodo.md
@@ -313,10 +313,10 @@
       - [x] Detect tensor device during extraction.
       - [x] Move GPU tensors to CPU when necessary.
       - [x] Preserve original device information for reconstruction.
-  - [ ] Inject bias neurons with correct values
-      - [ ] Create bias neuron nodes within graph builder.
-      - [ ] Populate bias nodes with corresponding weights.
-      - [ ] Validate bias application through unit tests.
+  - [x] Inject bias neurons with correct values
+      - [x] Create bias neuron nodes within graph builder.
+      - [x] Populate bias nodes with corresponding weights.
+      - [x] Validate bias application through unit tests.
   - [ ] Conversion CLI and API enhancements
    - [ ] Option to produce .marble snapshot directly
        - [ ] Add CLI flag enabling snapshot output.

--- a/marble_core.py
+++ b/marble_core.py
@@ -302,6 +302,7 @@ NEURON_TYPES = [
     "flatten",
     "convtranspose1d",
     "convtranspose2d",
+    "bias",
     "lstm",
     "gru",
     "layernorm",

--- a/marble_graph_builder.py
+++ b/marble_graph_builder.py
@@ -102,7 +102,9 @@ def add_fully_connected_layer(
 
     if bias is not None:
         bias_id = len(core.neurons)
-        core.neurons.append(Neuron(bias_id, value=1.0, tier="vram"))
+        core.neurons.append(
+            Neuron(bias_id, value=1.0, tier="vram", neuron_type="bias")
+        )
         for j, out_id in enumerate(out_ids):
             w = float(bias[j])
             syn = Synapse(bias_id, out_id, weight=w)

--- a/tests/test_pytorch_to_marble.py
+++ b/tests/test_pytorch_to_marble.py
@@ -852,8 +852,13 @@ def test_bias_synapses_values():
     params = minimal_params()
     core = convert_model(model, core_params=params)
     # find bias neurons (value 1.0) created by add_fully_connected_layer
-    bias_neuron_indices = [i for i, n in enumerate(core.neurons) if n.value == 1.0]
+    bias_neuron_indices = [
+        i for i, n in enumerate(core.neurons) if n.value == 1.0
+    ]
     assert len(bias_neuron_indices) == 2
+    # ensure bias neurons are tagged correctly
+    for idx in bias_neuron_indices:
+        assert core.neurons[idx].neuron_type == "bias"
     # check weights from bias neurons match layer biases
     first_bias_weight = model.seq[0].bias.detach().cpu().numpy()[0]
     syn = next(s for s in core.synapses if s.source == bias_neuron_indices[0])


### PR DESCRIPTION
## Summary
- Tag generated bias neurons with explicit `bias` type for clarity in conversion graphs
- Document bias neuron support in converter roadmap
- Test converter bias handling via new assertions

## Testing
- `pytest tests/test_pytorch_to_marble.py::test_bias_synapses_values -q`


------
https://chatgpt.com/codex/tasks/task_e_6894ca8a653883279bdba0cb37fcb3cb