### PR TITLE
chore: expand task breakdown

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1513,3 +1513,11 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 334. [ ] Audit config.yaml for unused parameters and implement missing ones.
     - [ ] Identify parameters defined in config.yaml but not referenced in code.
     - [ ] Implement missing parameters or prune outdated ones.
+335. [ ] Implement persistent hidden state mapping in RNN converter.
+    - [ ] Define serialization schema for hidden states.
+    - [ ] Embed and restore states within converter and runtime.
+    - [ ] Write unit and integration tests for state persistence.
+336. [ ] Add dynamic attention span module to Neuronenblitz.
+    - [ ] Implement adaptive span computation and layer integration.
+    - [ ] Expose span configuration in YAML and documentation.
+    - [ ] Benchmark and test span behavior on CPU and GPU.

--- a/converttodo.md
+++ b/converttodo.md
@@ -74,14 +74,20 @@
         - [x] Compare outputs against PyTorch reference.
     - [ ] Persistent hidden state mapping
       - [ ] Serialize initial hidden states with layer metadata.
+        - [ ] Define serialization schema for hidden state tensors.
         - [ ] Embed state tensors into converter output.
         - [ ] Record correspondence to layer identifiers.
+        - [ ] Document serialization logic for future contributors.
       - [ ] Restore hidden states during MARBLE execution.
+        - [ ] Map serialized states to runtime modules.
         - [ ] Load serialized states into runtime structures.
         - [ ] Verify shapes match original expectations.
+        - [ ] Warn when states are missing or mismatched.
+        - [ ] Document runtime loading process.
       - [ ] Provide tests verifying state persistence across runs.
+        - [ ] Create minimal RNN example with saved hidden state.
         - [ ] Save model, reload, and compare hidden states.
-        - [ ] Ensure no drift after multiple executions.
+        - [ ] Reload model multiple times to check for drift.
 - [x] Normalization layers (LayerNorm, GroupNorm)
   - [x] ``LayerNorm`` converter
   - [x] ``GroupNorm`` converter

--- a/neuronenblitztodo.md
+++ b/neuronenblitztodo.md
@@ -824,13 +824,21 @@ This document lists 100 concrete ideas for enhancing the `Neuronenblitz` algorit
        - [ ] Determine signals for span adjustment.
    - [ ] Implement dynamic attention spans for context-sensitive wandering within Neuronenblitz.
        - [ ] Add module calculating attention span per step.
+           - [ ] Define span scoring function using context history.
+           - [ ] Cache recent span decisions for stability.
+           - [ ] Document algorithm within module.
        - [ ] Integrate span selection into attention layer.
+           - [ ] Expose span parameter in layer configuration.
+           - [ ] Modify forward pass to apply computed span.
+           - [ ] Update YAML manual and configs for new span options.
    - [ ] Evaluate dynamic attention spans for context-sensitive wandering on benchmark tasks and document results.
        - [ ] Benchmark on tasks requiring varying context lengths.
        - [ ] Report computational savings.
+       - [ ] Collect attention span statistics during training.
    - [ ] Create tests covering dynamic attention spans for context-sensitive wandering.
        - [ ] Unit test span computation logic.
        - [ ] Integration test dynamic span on GPU.
+       - [ ] Ensure span parameter persists across CPU and GPU paths.
 95. Introduce continual exploration strategies during long runs.
    - [ ] Research approaches for continual exploration strategies during long runs.
        - [ ] Explore exploration strategies resilient to stagnation.


### PR DESCRIPTION
## Summary
- detail persistent hidden state mapping steps for the PyTorch converter
- expand dynamic attention span plan in Neuronenblitz with granular sub-tasks
- track new converter and attention span work in the main TODO list

## Testing
- `pre-commit run --files TODO.md converttodo.md neuronenblitztodo.md`

------
https://chatgpt.com/codex/tasks/task_e_6894d47b6df083279ef0fa7d43df6605