### PR TITLE
Add config key listing utility

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1573,7 +1573,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
 - [x] Benchmark learning performance with and without dream consolidation.
 334. [ ] Audit config.yaml for unused parameters and implement missing ones.
         - [ ] Identify parameters defined in config.yaml but not referenced in code.
-            - [ ] Write utility script to list all configuration keys.
+            - [x] Write utility script to list all configuration keys.
             - [ ] Scan codebase with ripgrep to detect usages.
             - [ ] Compile report of unused parameters.
             - [ ] Add unit test ensuring the script flags future unused parameters.

--- a/scripts/list_config_keys.py
+++ b/scripts/list_config_keys.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import argparse
+import pathlib
+from typing import Any, List
+
+import yaml
+
+
+def _collect_keys(obj: Any, prefix: str = "") -> List[str]:
+    keys: List[str] = []
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            path = f"{prefix}{k}" if not prefix else f"{prefix}.{k}"
+            keys.append(path)
+            keys.extend(_collect_keys(v, path))
+    return keys
+
+
+def list_config_keys(cfg_path: str | pathlib.Path) -> List[str]:
+    """Return dot-separated keys defined in the YAML configuration."""
+    with open(cfg_path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return sorted(_collect_keys(data))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="List configuration keys")
+    parser.add_argument(
+        "config", nargs="?", default="config.yaml", help="Path to YAML config"
+    )
+    args = parser.parse_args()
+    for key in list_config_keys(args.config):
+        print(key)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_list_config_keys.py
+++ b/tests/test_list_config_keys.py
@@ -1,0 +1,8 @@
+from scripts.list_config_keys import list_config_keys
+
+
+def test_list_config_keys_contains_known_parameters():
+    keys = list_config_keys("config.yaml")
+    assert "dataset.source" in keys
+    assert "core.backend" in keys
+    assert "dream_reinforcement_learning.dream_cycle_duration" in keys


### PR DESCRIPTION
## Summary
- add script to enumerate YAML configuration keys
- mark TODO item for config key listing as completed
- test listing for known parameters

## Testing
- `pytest tests/test_list_config_keys.py -q`
- `pre-commit run --files TODO.md scripts/list_config_keys.py tests/test_list_config_keys.py`


------
https://chatgpt.com/codex/tasks/task_e_689580aea4f88327a34745f3f91b7122