### PR TITLE
Add test for unused config key detection

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1576,7 +1576,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
             - [x] Write utility script to list all configuration keys.
             - [x] Scan codebase with ripgrep to detect usages.
             - [x] Compile report of unused parameters.
-            - [ ] Add unit test ensuring the script flags future unused parameters.
+             - [x] Add unit test ensuring the script flags future unused parameters.
             - [ ] Integrate script into CI pipeline.
         - [ ] Implement missing parameters or prune outdated ones.
             - [ ] For each unused parameter, decide to implement or remove.

--- a/tests/test_list_config_keys.py
+++ b/tests/test_list_config_keys.py
@@ -1,4 +1,6 @@
-from scripts.list_config_keys import list_config_keys
+from scripts.list_config_keys import find_unused_keys, list_config_keys
+
+import yaml
 
 
 def test_list_config_keys_contains_known_parameters():
@@ -6,3 +8,18 @@ def test_list_config_keys_contains_known_parameters():
     assert "dataset.source" in keys
     assert "core.backend" in keys
     assert "dream_reinforcement_learning.dream_cycle_duration" in keys
+
+
+def test_find_unused_keys_detects_unreferenced_parameters(tmp_path):
+    """Ensure configuration keys absent from code are flagged as unused."""
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(yaml.safe_dump({"alpha": 1, "beta": 2}), encoding="utf-8")
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "example.py").write_text("value = config['alpha']\n", encoding="utf-8")
+
+    unused = find_unused_keys(cfg, root=src)
+    assert "beta" in unused
+    assert "alpha" not in unused


### PR DESCRIPTION
## Summary
- add regression test ensuring `find_unused_keys` flags unreferenced configuration entries
- update TODO to mark unit test for unused parameter detection as complete

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68959da364088327adeb7fee2558f467