### PR TITLE
Implement hidden state restoration for converted RNNs

### DIFF
--- a/converttodo.md
+++ b/converttodo.md
@@ -82,12 +82,15 @@
             - Chose JSON for portability and compatibility with ``core_to_json``.
         - [x] Include device information within metadata.
       - [ ] Restore hidden states during MARBLE execution.
-        - [ ] Map serialized states to runtime modules.
-        - [ ] Load serialized states into runtime structures.
-        - [ ] Verify shapes match original expectations.
-        - [ ] Warn when states are missing or mismatched.
-        - [ ] Document runtime loading process.
+        - [x] Map serialized states to runtime modules.
+        - [x] Load serialized states into runtime structures.
+        - [x] Verify shapes match original expectations.
+        - [x] Warn when states are missing or mismatched.
+        - [x] Document runtime loading process.
         - [ ] Add CLI flag to enable or disable hidden state restoration.
+            - [ ] Update converter CLI to accept `--restore-hidden`.
+            - [ ] Wire flag to call `restore_hidden_states` after loading.
+            - [ ] Document flag usage in converter README.
       - [ ] Provide tests verifying state persistence across runs.
         - [ ] Create minimal RNN example with saved hidden state.
         - [ ] Save model, reload, and compare hidden states.

--- a/docs/hidden_state_serialization.md
+++ b/docs/hidden_state_serialization.md
@@ -4,3 +4,10 @@ The RNN converter now stores initial hidden states alongside layer metadata.
 Each entry records the layer index, direction, tensor values, shape, dtype,
 and device. The information is serialised as JSON through `core_to_json` so it
 remains portable across CPU and GPU environments.
+
+When a model is loaded via `core_from_json`, these serialized values are
+automatically mapped back to their corresponding RNN neurons.  The helper
+`restore_hidden_states` assigns each value to the neuron matching the recorded
+layer index and direction, emitting a warning if the stored tensor length does
+not match the expected hidden size.  Device information ensures that restored
+states live on the correct CPU or CUDA backend, preserving training context.

--- a/pytorch_to_marble.py
+++ b/pytorch_to_marble.py
@@ -18,7 +18,7 @@ from torch.nn.modules.pooling import (
 
 from marble_core import Core, Neuron, Synapse
 from marble_graph_builder import add_fully_connected_layer as gb_add_fc
-from marble_utils import core_to_json
+from marble_utils import core_to_json, restore_hidden_states
 
 logger = logging.getLogger(__name__)
 
@@ -850,6 +850,7 @@ def convert_model(
     }
     if dry_run or return_summary:
         _print_dry_run_summary(core, node_outputs, layer_synapses)
+    restore_hidden_states(core)
     if return_summary:
         return core, summary
     return core


### PR DESCRIPTION
## Summary
- serialize and restore RNN hidden states in core JSON
- map stored hidden state tensors back onto neurons with device-aware loading
- document hidden state loading and update converter TODO items

## Testing
- `python -m py_compile marble_utils.py pytorch_to_marble.py`


------
https://chatgpt.com/codex/tasks/task_e_6895a1a45984832794920421bdd55f7d