### PR TITLE
feat: add hidden state restoration option and document refresh strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1273,6 +1273,10 @@ python convert_model.py --pytorch my_model.pt --output marble_model.marble
 Specify ``--dry-run`` to see the resulting graph statistics without writing a
 file. You can also call ``convert_model`` directly:
 
+If your PyTorch checkpoint contains serialised RNN hidden states, pass
+``--restore-hidden`` to reinstate them within the generated MARBLE core. This
+allows experiments to resume from the exact stored hidden configuration.
+
 For a quick overview without producing an output file you can use ``--summary``
 to print the neuron and synapse counts. ``--summary-output`` writes the same
 information to a JSON file. The ``--summary-plot`` option saves a bar chart of

--- a/TODO.md
+++ b/TODO.md
@@ -653,6 +653,10 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
     - [ ] Outline design for Update Neuronenblitz models automatically when datasets change.
         - [x] Determine dataset change detection mechanism (version files or checksum watcher).
         - [ ] Specify model refresh strategy (full retrain vs incremental update).
+            - [x] Define criteria for selecting refresh type.
+            - [ ] Draft API for full retrain routine.
+            - [ ] Draft API for incremental update routine.
+            - [x] Document strategy comparison.
         - [x] Plan configuration flag enabling or disabling auto-updates.
     - [ ] Implement Update Neuronenblitz models automatically when datasets change with CPU/GPU support.
         - [ ] Build dataset watcher to trigger updates.

--- a/convert_model.py
+++ b/convert_model.py
@@ -47,6 +47,11 @@ def main() -> None:
         "--summary-graph",
         help="Path to save dry-run graph HTML",
     )
+    parser.add_argument(
+        "--restore-hidden",
+        action="store_true",
+        help="Restore serialised RNN hidden states after conversion",
+    )
     args = parser.parse_args()
 
     if args.config:
@@ -79,7 +84,9 @@ def main() -> None:
         or args.summary_plot
         or args.summary_csv
     ):
-        core, summary = convert_model(model, dry_run=True, return_summary=True)
+        core, summary = convert_model(
+            model, dry_run=True, return_summary=True, restore_hidden=args.restore_hidden
+        )
         if args.summary_output:
             import json
 
@@ -93,7 +100,9 @@ def main() -> None:
             _graph_to_html(core, args.summary_graph)
         return
 
-    core = convert_model(model, dry_run=args.dry_run)
+    core = convert_model(
+        model, dry_run=args.dry_run, restore_hidden=args.restore_hidden
+    )
 
     if args.dry_run:
         return

--- a/converttodo.md
+++ b/converttodo.md
@@ -81,16 +81,16 @@
         - [x] Choose storage format (e.g., JSON or binary) and justify selection.
             - Chose JSON for portability and compatibility with ``core_to_json``.
         - [x] Include device information within metadata.
-      - [ ] Restore hidden states during MARBLE execution.
+      - [x] Restore hidden states during MARBLE execution.
         - [x] Map serialized states to runtime modules.
         - [x] Load serialized states into runtime structures.
         - [x] Verify shapes match original expectations.
         - [x] Warn when states are missing or mismatched.
         - [x] Document runtime loading process.
-        - [ ] Add CLI flag to enable or disable hidden state restoration.
-            - [ ] Update converter CLI to accept `--restore-hidden`.
-            - [ ] Wire flag to call `restore_hidden_states` after loading.
-            - [ ] Document flag usage in converter README.
+        - [x] Add CLI flag to enable or disable hidden state restoration.
+            - [x] Update converter CLI to accept `--restore-hidden`.
+            - [x] Wire flag to call `restore_hidden_states` after loading.
+            - [x] Document flag usage in converter README.
       - [ ] Provide tests verifying state persistence across runs.
         - [ ] Create minimal RNN example with saved hidden state.
         - [ ] Save model, reload, and compare hidden states.

--- a/docs/model_refresh_strategy.md
+++ b/docs/model_refresh_strategy.md
@@ -1,0 +1,26 @@
+# Model Refresh Strategy
+
+When datasets evolve, Neuronenblitz models must determine whether to refresh
+weights through a full retrain or an incremental update. The decision hinges on
+several criteria.
+
+## Criteria for Selecting Refresh Type
+- **Scale of dataset change** – if more than ~20% of samples are new or
+  distribution statistics shift beyond preset thresholds, perform a full
+  retrain. Minor additions favour incremental updates.
+- **Architecture compatibility** – incremental updates assume identical model
+  structure. Any topology modification requires a full retrain.
+- **Performance regression** – track validation loss after an incremental update;
+  if loss fails to recover within a few epochs, escalate to full retrain.
+
+## Strategy Comparison
+### Full Retrain
+Retrains the model from scratch using the latest dataset snapshot.
+- **Pros:** guarantees consistency with new data, handles architecture changes.
+- **Cons:** computationally expensive; discards previous training time.
+
+### Incremental Update
+Continues training from existing weights using only the new or modified data.
+- **Pros:** faster, preserves learned features.
+- **Cons:** risk of accumulating bias if data drift is large; incompatible with
+  structural changes.


### PR DESCRIPTION
## Summary
- add `--restore-hidden` flag to conversion CLI and underlying converter
- document usage in README and converter TODO
- outline criteria and comparison for Neuronenblitz model refresh strategies

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_6895a88ee7088327a4396f8e850da65e