### PR TITLE
Add dynamic attention span module to Neuronenblitz

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -206,6 +206,8 @@ Each entry is listed under its section heading.
 - exploration_bonus
 - synapse_potential_cap
 - attention_update_scale
+- attention_span_threshold
+- max_attention_span
 - plasticity_modulation
 - wander_depth_noise
 - reward_decay

--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -8,7 +8,7 @@ No failing tests.
 - tests/test_streamlit_progress.py::test_progress_desktop: IndexError: list index out of range
 - tests/test_streamlit_progress.py::test_progress_mobile: IndexError: list index out of range
 - tests/test_streamlit_all_buttons.py::test_click_all_buttons: IndexError: list index out of range
-- tests/test_streamlit_playground.py: multiple failures (TypeError: Brain.__init__() got an unexpected keyword argument 'dream_replay_buffer_size')
+- tests/test_streamlit_playground.py::test_initialize_marble: TypeError: Neuronenblitz.__init__() got an unexpected keyword argument 'auto_update' [resolved]
 - tests/test_streamlit_gui.py::test_pipeline_tab_add_and_run: IndexError: list index out of range
 - tests/test_streamlit_gui.py::test_pipeline_reorder_and_remove: IndexError: list index out of range
 - tests/test_hybrid_memory_kuzu.py::test_kuzu_memory_separate_from_topology: RuntimeError: Catalog exception: function DATETIME does not exist [resolved]

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -208,6 +208,18 @@ nb.refresh_on_dataset_change(watcher)
 This process runs entirely on CPU so the behaviour is identical on systems with
 or without GPUs.
 
+#### Adaptive attention span
+
+`Neuronenblitz` can trim low-salience portions of a path to focus computation.
+Control this behaviour via ``neuronenblitz.attention_span_threshold`` (fraction
+of cumulative attention to keep) and ``neuronenblitz.max_attention_span``
+(optional maximum number of elements). The span module operates on CUDA when
+available and otherwise falls back to CPU automatically:
+
+```python
+nb = Neuronenblitz(core, max_attention_span=5, attention_span_threshold=0.8)
+```
+
 Set ``dataloader.tokenizer_type: bert_wordpiece`` or ``tokenizer_json`` in
 ``config.yaml`` to use the same tokenizer when constructing ``MARBLE``. Each
 project example assumes a ``dataloader`` prepared this way and passes it to

--- a/config.yaml
+++ b/config.yaml
@@ -216,6 +216,8 @@ neuronenblitz:
   exploration_bonus: 0.0
   synapse_potential_cap: 100.0
   attention_update_scale: 1.0
+  attention_span_threshold: 0.9
+  max_attention_span: null
   plasticity_modulation: 1.0
   wander_depth_noise: 0.0
   reward_decay: 1.0

--- a/config_loader.py
+++ b/config_loader.py
@@ -112,6 +112,10 @@ def create_marble_from_config(
     neuro_base_synapses = brain_params.pop("neurogenesis_base_synapses", 10)
     super_evolution_mode = brain_params.pop("super_evolution_mode", False)
 
+    dataset_path = cfg.get("dataset", {}).get("source")
+    if nb_params.get("auto_update") and dataset_path:
+        nb_params.setdefault("dataset_path", dataset_path)
+
     formula = cfg.get("formula")
     formula_num_neurons = cfg.get("formula_num_neurons", 100)
 

--- a/marble_neuronenblitz/__init__.py
+++ b/marble_neuronenblitz/__init__.py
@@ -8,6 +8,7 @@ from .core import (
 )
 from .learning import disable_rl, enable_rl, rl_select_action, rl_update
 from .memory import decay_memory_gates
+from .attention_span import DynamicSpanModule
 
 __all__ = [
     "Neuronenblitz",
@@ -21,5 +22,6 @@ __all__ = [
     "rl_update",
     "decay_memory_gates",
     "ContextAwareAttention",
+    "DynamicSpanModule",
 ]
 

--- a/marble_neuronenblitz/attention_span.py
+++ b/marble_neuronenblitz/attention_span.py
@@ -1,0 +1,49 @@
+import torch
+
+class DynamicSpanModule:
+    """Adaptive attention span selection for Neuronenblitz.
+
+    The module scores attention weights and selects a variable span per batch
+    based on a cumulative probability threshold. It supports batched inputs and
+    automatically utilises CUDA when available, falling back to CPU otherwise.
+    """
+
+    def __init__(self, max_span: int | None = None, threshold: float = 0.9, device: torch.device | None = None) -> None:
+        self.max_span = max_span
+        self.threshold = threshold
+        self.device = device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    def score_spans(self, scores: torch.Tensor) -> torch.Tensor:
+        """Return cumulative attention distribution for ``scores``.
+
+        Parameters
+        ----------
+        scores:
+            Tensor of shape ``(batch, seq_len)`` containing raw attention
+            scores. Higher values denote greater importance.
+        """
+
+        norm = torch.softmax(scores, dim=-1)
+        return torch.cumsum(norm, dim=-1)
+
+    def select_spans(self, scores: torch.Tensor) -> torch.Tensor:
+        """Compute a boolean mask selecting the adaptive span.
+
+        The mask has the same shape as ``scores`` and marks elements that lie
+        within the dynamic span for each batch item.
+        """
+
+        cum_scores = self.score_spans(scores)
+        mask = cum_scores <= self.threshold
+        mask[..., 0] = True  # always keep at least one element
+        if self.max_span is not None:
+            idx = torch.arange(scores.size(-1), device=scores.device)
+            mask = mask & (idx < self.max_span)
+        return mask
+
+    def __call__(self, scores: torch.Tensor) -> torch.Tensor:
+        """Return selection mask for ``scores`` on the configured device."""
+
+        scores = scores.to(self.device)
+        mask = self.select_spans(scores)
+        return mask.detach().cpu()

--- a/tests/test_attention_span_module.py
+++ b/tests/test_attention_span_module.py
@@ -1,0 +1,44 @@
+import torch
+from marble_core import Core, Neuron
+from marble_neuronenblitz import Neuronenblitz, DynamicSpanModule
+from tests.test_core_functions import minimal_params
+
+
+def test_span_module_selects_threshold():
+    module = DynamicSpanModule(max_span=3, threshold=0.6)
+    scores = torch.tensor([[0.1, 0.2, 0.3, 0.4]])
+    mask = module(scores)
+    assert mask.shape == scores.shape
+    # cumulative softmax results keep first three elements under 0.6
+    assert mask[0, 0] and mask[0, 1]
+    assert not mask[0, -1]
+
+
+def test_span_module_device_fallback():
+    module = DynamicSpanModule()
+    if torch.cuda.is_available():
+        assert module.device.type == "cuda"
+    else:
+        assert module.device.type == "cpu"
+
+
+def test_neuronenblitz_applies_span():
+    params = minimal_params()
+    core = Core(params)
+    core.neurons = [Neuron(i, value=0.0) for i in range(3)]
+    core.add_synapse(0, 1, weight=1.0)
+    core.add_synapse(1, 2, weight=1.0)
+    nb = Neuronenblitz(
+        core,
+        max_attention_span=2,
+        attention_span_threshold=0.8,
+        split_probability=0.0,
+        alternative_connection_prob=0.0,
+        backtrack_probability=0.0,
+        backtrack_enabled=False,
+    )
+    core.neurons[0].attention_score = 1.0
+    core.neurons[1].attention_score = 0.5
+    core.neurons[2].attention_score = 0.1
+    _, path = nb.dynamic_wander(0.5)
+    assert len(path) <= 2

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -571,6 +571,14 @@ neuronenblitz:
     :meth:`Neuronenblitz.reset_learning_state` whenever files are modified.
     Set to ``false`` to disable this behaviour. The watcher performs all work
     on the CPU so it behaves identically on GPU and CPU environments.
+  attention_span_threshold: Cumulative attention mass (0.0–1.0) determining
+    how many high-scoring elements are kept when trimming a path. Lower values
+    yield shorter spans while ``1.0`` retains all elements. Span computation is
+    fully vectorised, supports batched inputs and automatically falls back to
+    CPU when CUDA is unavailable.
+  max_attention_span: Optional hard limit on the number of elements retained
+    after applying ``attention_span_threshold``. ``null`` disables the cap.
+    Use this to bound memory usage for very long sequences.
   remote_fallback: When true, neurons attempting remote execution fall back to
     local processing if the remote call fails.
   noise_injection_std: Standard deviation of Gaussian noise injected into neuron


### PR DESCRIPTION
## Summary
- implement `DynamicSpanModule` with adaptive span selection and CPU/GPU fallback
- integrate dynamic attention span and dataset auto-update into Neuronenblitz
- document new `attention_span_threshold` and `max_attention_span` parameters
- add thorough tests for span module and fix failing streamlit playground test

## Testing
- `pytest tests/test_attention_span_module.py -q`
- `pytest tests/test_streamlit_playground.py::test_initialize_marble -q`


------
https://chatgpt.com/codex/tasks/task_e_6895b39e39048327b363750d7daac202