### PR TITLE
Add dataset watcher diff and automatic model refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ shards training data:
 Neuronenblitz can also monitor datasets for changes. Enable
 ``neuronenblitz.auto_update`` in ``config.yaml`` and use ``DatasetWatcher`` to
 reset learning state whenever files within the dataset directory are modified.
+The watcher records individual file checksums and exposes
+``changed_files()``/``total_files()`` for inspection.  Combine it with
+``model_refresh.auto_refresh`` to automatically retrain or incrementally update
+a model when the dataset changes:
+
+```python
+from model_refresh import auto_refresh
+model, refreshed = auto_refresh(model, dataset, watcher)
+```
+
 When pipelines use parallel branches, the framework automatically assigns each
 branch a unique ``shard_index`` so dataset shards are distributed evenly across
 branches. This keeps parallel pipelines processing disjoint data without manual

--- a/TODO.md
+++ b/TODO.md
@@ -659,8 +659,8 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
             - [x] Document strategy comparison.
         - [x] Plan configuration flag enabling or disabling auto-updates.
     - [ ] Implement Update Neuronenblitz models automatically when datasets change with CPU/GPU support.
-        - [ ] Build dataset watcher to trigger updates.
-        - [ ] Invoke retrain or reload routine when changes are detected.
+        - [x] Build dataset watcher to trigger updates.
+        - [x] Invoke retrain or reload routine when changes are detected.
         - [ ] Confirm implementation works on both CPU and GPU.
     - [ ] Add tests validating Update Neuronenblitz models automatically when datasets change.
         - [ ] Simulate dataset modification and verify model refresh.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -203,6 +203,8 @@ from marble_neuronenblitz import Neuronenblitz
 watcher = DatasetWatcher("data/iris")
 nb = Neuronenblitz(core)
 nb.refresh_on_dataset_change(watcher)
+from model_refresh import auto_refresh
+auto_refresh(nb, dataset, watcher)
 ```
 
 This process runs entirely on CPU so the behaviour is identical on systems with

--- a/dataset_watcher.py
+++ b/dataset_watcher.py
@@ -1,43 +1,88 @@
 import hashlib
+import json
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Dict, Iterable
 
 
 class DatasetWatcher:
     """Monitor a dataset directory for file changes using checksums.
 
-    The watcher recursively hashes all files in ``path``. Whenever
-    :meth:`has_changed` is called the current checksum is compared to the
-    previously stored one. A new checksum is persisted to ``checksum_path``
-    if a change is detected. The implementation is CPU-only and works the
-    same regardless of GPU availability.
+    The watcher recursively hashes all files in ``path`` and persists a
+    mapping of relative file names to their SHA256 digests. Subsequent
+    calls to :meth:`has_changed` compare the current mapping to the
+    previously stored one and record which files have been added, removed
+    or modified. The implementation is entirely CPU based so the behaviour
+    is identical on systems with or without GPUs.
     """
 
     def __init__(self, path: str | os.PathLike[str], checksum_path: Optional[str | os.PathLike[str]] = None) -> None:
         self.path = Path(path)
         if checksum_path is None:
-            checksum_path = self.path / ".dataset_checksum"
+            checksum_path = self.path / ".dataset_state.json"
         self.checksum_path = Path(checksum_path)
         self.checksum_path.parent.mkdir(parents=True, exist_ok=True)
+        self._changed: list[str] | None = None
+        self._total_files: int | None = None
 
-    def _compute_checksum(self) -> str:
-        """Return SHA256 checksum of all files under ``path``."""
-        sha = hashlib.sha256()
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _compute_snapshot(self) -> Dict[str, str]:
+        """Return a mapping of ``relative_path -> sha256`` for all files."""
+        snapshot: Dict[str, str] = {}
         if not self.path.exists():
-            return sha.hexdigest()
+            return snapshot
         for file in sorted(p for p in self.path.rglob("*") if p.is_file()):
-            sha.update(str(file.relative_to(self.path)).encode())
+            sha = hashlib.sha256()
             with file.open("rb") as fh:
                 for chunk in iter(lambda: fh.read(65536), b""):
                     sha.update(chunk)
-        return sha.hexdigest()
+            snapshot[str(file.relative_to(self.path))] = sha.hexdigest()
+        return snapshot
 
+    def _read_snapshot(self) -> Dict[str, str]:
+        if not self.checksum_path.exists():
+            return {}
+        text = self.checksum_path.read_text().strip()
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            # Backwards compatibility with legacy single checksum files
+            return {"__legacy_checksum__": text}
+
+    def _write_snapshot(self, snap: Dict[str, str]) -> None:
+        self.checksum_path.write_text(json.dumps(snap, sort_keys=True))
+
+    def _diff(self, old: Dict[str, str], new: Dict[str, str]) -> Iterable[str]:
+        paths = set(old) | set(new)
+        for p in paths:
+            if old.get(p) != new.get(p):
+                yield p
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
     def has_changed(self) -> bool:
         """Return ``True`` if the dataset contents differ from the last run."""
-        current = self._compute_checksum()
-        previous = self.checksum_path.read_text().strip() if self.checksum_path.exists() else None
-        if current != previous:
-            self.checksum_path.write_text(current)
+        current = self._compute_snapshot()
+        previous = self._read_snapshot()
+        changed = list(self._diff(previous, current))
+        self._changed = changed
+        self._total_files = len(current)
+        if changed:
+            self._write_snapshot(current)
             return True
         return False
+
+    def changed_files(self) -> list[str]:
+        """Return list of files that changed since the previous snapshot."""
+        if self._changed is None:
+            self.has_changed()
+        return self._changed or []
+
+    def total_files(self) -> int:
+        """Return the total number of tracked files in the dataset."""
+        if self._total_files is None:
+            self.has_changed()
+        return self._total_files or 0

--- a/tests/test_dataset_watcher.py
+++ b/tests/test_dataset_watcher.py
@@ -1,0 +1,23 @@
+import os
+from dataset_watcher import DatasetWatcher
+
+
+def test_changed_files_detection(tmp_path):
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "a.txt").write_text("a")
+    watcher = DatasetWatcher(data)
+    assert watcher.has_changed()
+    assert set(watcher.changed_files()) == {"a.txt"}
+    assert watcher.total_files() == 1
+
+    # No changes
+    assert not watcher.has_changed()
+    assert watcher.changed_files() == []
+
+    # Modify existing and add new file
+    (data / "a.txt").write_text("b")
+    (data / "b.txt").write_text("c")
+    assert watcher.has_changed()
+    assert set(watcher.changed_files()) == {"a.txt", "b.txt"}
+    assert watcher.total_files() == 2

--- a/tests/test_model_auto_refresh.py
+++ b/tests/test_model_auto_refresh.py
@@ -1,0 +1,45 @@
+import torch
+
+import model_refresh
+from dataset_watcher import DatasetWatcher
+from model_refresh import auto_refresh
+
+
+def test_auto_refresh_strategy(monkeypatch, tmp_path):
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "a.txt").write_text("0")
+    watcher = DatasetWatcher(data)
+    watcher.has_changed()  # establish baseline snapshot
+
+    model = torch.nn.Linear(1, 1)
+    dataset = [(torch.tensor([0.0]), torch.tensor([0.0]))]
+
+    calls = []
+
+    def fake_full(m, d, **kw):
+        calls.append("full")
+        return m
+
+    def fake_inc(m, d, **kw):
+        calls.append("inc")
+        return m
+
+    monkeypatch.setattr(model_refresh, "full_retrain", fake_full)
+    monkeypatch.setattr(model_refresh, "incremental_update", fake_inc)
+
+    # Force full retrain
+    (data / "a.txt").write_text("1")
+    auto_refresh(model, dataset, watcher, strategy="full")
+    assert calls == ["full"]
+
+    # Force incremental update
+    (data / "a.txt").write_text("2")
+    auto_refresh(model, dataset, watcher, strategy="incremental")
+    assert calls == ["full", "inc"]
+
+    # Auto strategy triggers full retrain when ratio exceeds threshold
+    (data / "a.txt").write_text("3")
+    (data / "b.txt").write_text("1")
+    auto_refresh(model, dataset, watcher, strategy="auto", change_threshold=0.4)
+    assert calls[-1] == "full"


### PR DESCRIPTION
## Summary
- Extend `DatasetWatcher` to track per-file checksums, report changed files, and expose total file counts.
- Provide `auto_refresh` utility choosing between full retrain and incremental update when datasets change.
- Document dataset change monitoring and automatic refresh workflow in README and TUTORIAL.
- Add tests for dataset change detection and refresh strategy selection.

## Testing
- `python -m py_compile dataset_watcher.py model_refresh.py tests/test_dataset_watcher.py tests/test_model_auto_refresh.py`


------
https://chatgpt.com/codex/tasks/task_e_689649a8fa0883278f72fe3ab6128ca4