### PR TITLE
feat: add summary table to converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1308,8 +1308,9 @@ For a quick overview without producing an output file you can use ``--summary``
 to print the neuron and synapse counts. ``--summary-output`` writes the same
 information to a JSON file. The ``--summary-plot`` option saves a bar chart of
 neuron and synapse counts per layer, and ``--summary-csv`` exports the counts
-to a CSV file for further analysis. ``--summary-graph`` exports an interactive
-HTML visualisation of the converted graph using Plotly.
+to a CSV file for further analysis. ``--summary-table`` prints the counts in a
+formatted table along with the active CPU or GPU device. ``--summary-graph``
+exports an interactive HTML visualisation of the converted graph using Plotly.
 
 Neurons created via the converter or the low-level graph builder now expose an
 ``activation_flag`` in their ``params`` dictionary. Runtime evaluators can set

--- a/converttodo.md
+++ b/converttodo.md
@@ -342,16 +342,16 @@
        - [ ] Ensure snapshot includes required metadata.
            - [ ] Embed version and converter information.
            - [ ] Add integrity checksum to snapshot.
-   - [ ] Auto-inference mode printing neuron/synapse counts
-       - [ ] Implement flag triggering automatic inference.
-           - [ ] Add CLI option and parse value.
-           - [ ] Provide help text explaining behaviour.
-       - [ ] Compute neuron and synapse counts after conversion.
-           - [ ] Traverse graph nodes to tally counts.
-           - [ ] Output counts to logger or stdout.
-       - [ ] Display counts in CLI output.
-           - [ ] Format table for counts.
-           - [ ] Include CPU/GPU differentiation if available.
+   - [x] Auto-inference mode printing neuron/synapse counts
+       - [x] Implement flag triggering automatic inference.
+           - [x] Add CLI option and parse value.
+           - [x] Provide help text explaining behaviour.
+       - [x] Compute neuron and synapse counts after conversion.
+           - [x] Traverse graph nodes to tally counts.
+           - [x] Output counts to logger or stdout.
+       - [x] Display counts in CLI output.
+           - [x] Format table for counts.
+           - [x] Include CPU/GPU differentiation if available.
    - [ ] Validation mode comparing outputs with PyTorch
        - [ ] Run forward pass on original PyTorch model.
            - [ ] Load sample inputs for evaluation.


### PR DESCRIPTION
## Summary
- add `--summary-table` flag to `convert_model.py` to display neuron and synapse counts
- document summary table usage in README
- mark auto-inference summary task complete in `converttodo.md`

## Testing
- `python -m py_compile convert_model.py`
- `python convert_model.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68966ef8b19083278b484897eeaa116f