### PR TITLE
Add dataset auto-refresh test and wanderer auth tokens

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -662,8 +662,8 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
         - [x] Build dataset watcher to trigger updates.
         - [x] Invoke retrain or reload routine when changes are detected.
         - [x] Confirm implementation works on both CPU and GPU.
-    - [ ] Add tests validating Update Neuronenblitz models automatically when datasets change.
-        - [ ] Simulate dataset modification and verify model refresh.
+    - [x] Add tests validating Update Neuronenblitz models automatically when datasets change.
+        - [x] Simulate dataset modification and verify model refresh.
         - [x] Ensure stable runs when dataset remains unchanged.
     - [x] Document Update Neuronenblitz models automatically when datasets change in README and TUTORIAL.
         - [x] Explain auto-update workflow and configuration options.
@@ -708,6 +708,9 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
            - Clients establish a WebSocket connection and register using a unique `wanderer_id`.
            - Heartbeat pings keep sessions alive and allow the coordinator to detect disconnects.
        - [ ] Specify authentication and session management.
+           - [x] Define token format and generation algorithm.
+           - [x] Implement token verification routine.
+           - [ ] Outline session timeout and renewal strategy.
        - [ ] Draft message formats for exchanging exploration results.
    - [ ] Implement Connect with remote wanderers for asynchronous exploration phases with CPU/GPU support.
        - [ ] Build client and server components leveraging the MessageBus.

--- a/tests/test_neuronenblitz_auto_update.py
+++ b/tests/test_neuronenblitz_auto_update.py
@@ -1,0 +1,38 @@
+import pytest
+import torch
+
+from dataset_watcher import DatasetWatcher
+from marble_core import Core
+from marble_neuronenblitz.core import Neuronenblitz
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_neuronenblitz_refresh_on_dataset_change(tmp_path, device):
+    """Neuronenblitz resets when the watched dataset changes."""
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "a.txt").write_text("0")
+    watcher = DatasetWatcher(data)
+    watcher.has_changed()  # establish baseline snapshot
+
+    core = Core(params={"width": 1, "height": 1})
+    nb = Neuronenblitz(core, auto_update=True, dataset_path=str(data))
+
+    reset_calls = {"count": 0}
+
+    def fake_reset() -> None:
+        reset_calls["count"] += 1
+
+    nb.reset_learning_state = fake_reset
+
+    # No change yet
+    assert nb.refresh_on_dataset_change(watcher) is False
+    assert reset_calls["count"] == 0
+
+    # Modify dataset and expect refresh
+    (data / "a.txt").write_text("1")
+    assert nb.refresh_on_dataset_change(watcher) is True
+    assert reset_calls["count"] == 1

--- a/tests/test_wanderer_auth.py
+++ b/tests/test_wanderer_auth.py
@@ -1,0 +1,25 @@
+import time
+
+from wanderer_auth import generate_token, verify_token
+
+
+def test_generate_and_verify_token():
+    secret = "abc"
+    token = generate_token(secret, "w1", timestamp=0)
+    assert verify_token(secret, token, max_age=10)
+
+
+def test_token_expiry():
+    secret = "abc"
+    token = generate_token(secret, "w1", timestamp=time.time() - 100)
+    assert verify_token(secret, token, max_age=200)
+    assert not verify_token(secret, token, max_age=50)
+
+
+def test_token_tamper_detection():
+    secret = "abc"
+    token = generate_token(secret, "w1", timestamp=0)
+    parts = token.split(":")
+    parts[2] = "deadbeef"
+    bad_token = ":".join(parts)
+    assert not verify_token(secret, bad_token)

--- a/wanderer_auth.py
+++ b/wanderer_auth.py
@@ -1,0 +1,49 @@
+"""Authentication helpers for remote wanderers.
+
+Provides minimal HMAC-based token generation and verification that
+is independent of CPU/GPU availability.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+
+
+def generate_token(
+    secret: str, wanderer_id: str, timestamp: float | None = None
+) -> str:
+    """Return ``token`` authorising ``wanderer_id``.
+
+    Parameters
+    ----------
+    secret:
+        Shared secret used for HMAC signing.
+    wanderer_id:
+        Identifier of the remote wanderer.
+    timestamp:
+        Optional POSIX timestamp.  Defaults to ``time.time()``.
+    """
+
+    if timestamp is None:
+        timestamp = time.time()
+    payload = f"{wanderer_id}:{int(timestamp)}".encode()
+    signature = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    return f"{int(timestamp)}:{wanderer_id}:{signature}"
+
+
+def verify_token(secret: str, token: str, max_age: float = 300.0) -> bool:
+    """Validate ``token`` and enforce ``max_age`` seconds lifetime."""
+
+    try:
+        ts_str, wanderer_id, signature = token.split(":", 2)
+        timestamp = int(ts_str)
+    except ValueError:
+        return False
+    expected = hmac.new(
+        secret.encode(), f"{wanderer_id}:{timestamp}".encode(), hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(expected, signature):
+        return False
+    return (time.time() - timestamp) <= max_age


### PR DESCRIPTION
## Summary
- test Neuronenblitz resets when dataset files change
- add HMAC-based token generation and verification for wanderer authentication
- document and plan authentication subtasks in TODO

## Testing
- `pre-commit run --files TODO.md wanderer_auth.py tests/test_neuronenblitz_auto_update.py tests/test_wanderer_auth.py`

------
https://chatgpt.com/codex/tasks/task_e_6897250d3d408327bed5d7e054fafab8