### PR TITLE
Add session manager for wanderer auth with renewal support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -710,12 +710,15 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
        - [ ] Specify authentication and session management.
            - [x] Define token format and generation algorithm.
            - [x] Implement token verification routine.
-           - [ ] Outline session timeout and renewal strategy.
+           - [x] Outline session timeout and renewal strategy.
+               - Sessions expire after ``session_timeout`` seconds of inactivity.
+               - A ``SessionManager`` issues refreshed tokens and purges idle entries.
        - [ ] Draft message formats for exchanging exploration results.
    - [ ] Implement Connect with remote wanderers for asynchronous exploration phases with CPU/GPU support.
        - [ ] Build client and server components leveraging the MessageBus.
        - [ ] Integrate asynchronous dispatcher to handle incoming updates.
        - [ ] Ensure device context (CPU/GPU) is transmitted with payloads.
+       - [x] Provide ``SessionManager`` handling token renewal and cleanup.
    - [ ] Add tests validating Connect with remote wanderers for asynchronous exploration phases.
        - [ ] Simulate multiple remote wanderers exchanging updates.
        - [ ] Verify synchronization under intermittent connectivity.

--- a/tests/test_wanderer_auth.py
+++ b/tests/test_wanderer_auth.py
@@ -1,6 +1,6 @@
 import time
 
-from wanderer_auth import generate_token, verify_token
+from wanderer_auth import SessionManager, generate_token, verify_token
 
 
 def test_generate_and_verify_token():
@@ -23,3 +23,16 @@ def test_token_tamper_detection():
     parts[2] = "deadbeef"
     bad_token = ":".join(parts)
     assert not verify_token(secret, bad_token)
+
+
+def test_session_lifecycle():
+    mgr = SessionManager("abc", session_timeout=0.1)
+    token = mgr.start("w1")
+    assert mgr.verify(token)
+    # Renewal should extend the session and return a new token
+    new_token = mgr.renew(token)
+    assert new_token is not None
+    assert mgr.verify(new_token)
+    # Expire the session
+    time.sleep(0.2)
+    assert not mgr.verify(new_token)


### PR DESCRIPTION
## Summary
- implement `SessionManager` to track wanderer sessions, renew tokens, and purge expired ones
- cover session lifecycle with new unit test
- document session timeout strategy in TODO roadmap

## Testing
- `python -m py_compile wanderer_auth.py tests/test_wanderer_auth.py`


------
https://chatgpt.com/codex/tasks/task_e_68972a4505e8832785084367f5f93842