### PR TITLE
Define remote wanderer message schemas

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -708,12 +708,15 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
            - Clients establish a WebSocket connection and register using a unique `wanderer_id`.
            - Heartbeat pings keep sessions alive and allow the coordinator to detect disconnects.
        - [ ] Specify authentication and session management.
-           - [x] Define token format and generation algorithm.
-           - [x] Implement token verification routine.
-           - [x] Outline session timeout and renewal strategy.
-               - Sessions expire after ``session_timeout`` seconds of inactivity.
-               - A ``SessionManager`` issues refreshed tokens and purges idle entries.
-       - [ ] Draft message formats for exchanging exploration results.
+       - [x] Define token format and generation algorithm.
+       - [x] Implement token verification routine.
+       - [x] Outline session timeout and renewal strategy.
+           - Sessions expire after ``session_timeout`` seconds of inactivity.
+           - A ``SessionManager`` issues refreshed tokens and purges idle entries.
+       - [x] Draft message formats for exchanging exploration results.
+           - Introduced dataclasses ``ExplorationRequest`` and ``ExplorationResult``
+             in ``wanderer_messages.py`` with explicit device metadata and
+             path payload structures for serialization.
    - [ ] Implement Connect with remote wanderers for asynchronous exploration phases with CPU/GPU support.
        - [ ] Build client and server components leveraging the MessageBus.
        - [ ] Integrate asynchronous dispatcher to handle incoming updates.

--- a/tests/test_wanderer_messages.py
+++ b/tests/test_wanderer_messages.py
@@ -1,0 +1,17 @@
+"""Tests for wanderer message serialisation."""
+from wanderer_messages import ExplorationRequest, ExplorationResult, PathUpdate
+
+
+def test_request_round_trip() -> None:
+    req = ExplorationRequest(wanderer_id="w1", seed=123, max_steps=10, device="cuda:0", timestamp=1.0)
+    payload = req.to_payload()
+    restored = ExplorationRequest.from_payload(payload)
+    assert restored == req
+
+
+def test_result_round_trip() -> None:
+    paths = [PathUpdate(nodes=[1, 2, 3], score=0.5), PathUpdate(nodes=[4, 5], score=1.2)]
+    res = ExplorationResult(wanderer_id="w2", paths=paths, device="cpu", timestamp=2.0)
+    payload = res.to_payload()
+    restored = ExplorationResult.from_payload(payload)
+    assert restored == res

--- a/wanderer_messages.py
+++ b/wanderer_messages.py
@@ -1,0 +1,130 @@
+"""Message schemas for remote wanderer coordination.
+
+Provides dataclasses that can be serialized to dictionaries for
+transmission over the :class:`MessageBus`. These messages carry
+exploration commands and results between the coordinator and remote
+wanderers. All messages include the execution ``device`` so that
+receivers can route tensors to CPU or GPU appropriately.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+import time
+
+
+@dataclass
+class ExplorationRequest:
+    """Command issued by the coordinator to start exploration.
+
+    Attributes
+    ----------
+    wanderer_id:
+        Identifier of the remote wanderer that should execute the request.
+    seed:
+        Random seed to ensure deterministic behaviour across devices.
+    max_steps:
+        Maximum number of steps the wanderer may take.
+    device:
+        Execution device, e.g. ``"cpu"`` or ``"cuda:0"``.
+    timestamp:
+        Time the request was created (``time.time()``).
+    """
+
+    wanderer_id: str
+    seed: int
+    max_steps: int
+    device: str
+    timestamp: float = time.time()
+
+    def to_payload(self) -> Dict[str, Any]:
+        """Return a serialisable dictionary representing the request."""
+        return {
+            "wanderer_id": self.wanderer_id,
+            "seed": self.seed,
+            "max_steps": self.max_steps,
+            "device": self.device,
+            "timestamp": self.timestamp,
+        }
+
+    @classmethod
+    def from_payload(cls, payload: Dict[str, Any]) -> "ExplorationRequest":
+        """Create an instance from a payload dictionary."""
+        return cls(
+            wanderer_id=str(payload["wanderer_id"]),
+            seed=int(payload["seed"]),
+            max_steps=int(payload["max_steps"]),
+            device=str(payload.get("device", "cpu")),
+            timestamp=float(payload.get("timestamp", time.time())),
+        )
+
+
+@dataclass
+class PathUpdate:
+    """Single exploration path discovered by a wanderer.
+
+    Attributes
+    ----------
+    nodes:
+        Sequence of visited node identifiers.
+    score:
+        Numeric score associated with the path.
+    """
+
+    nodes: List[int]
+    score: float
+
+    def to_payload(self) -> Dict[str, Any]:
+        return {"nodes": self.nodes, "score": self.score}
+
+    @classmethod
+    def from_payload(cls, payload: Dict[str, Any]) -> "PathUpdate":
+        return cls(nodes=list(payload["nodes"]), score=float(payload["score"]))
+
+
+@dataclass
+class ExplorationResult:
+    """Result message sent from a wanderer to the coordinator.
+
+    Attributes
+    ----------
+    wanderer_id:
+        Identifier of the sending wanderer.
+    paths:
+        List of :class:`PathUpdate` instances representing exploration
+        results.
+    device:
+        Execution device used by the wanderer.
+    timestamp:
+        Time the result was created (``time.time()``).
+    """
+
+    wanderer_id: str
+    paths: List[PathUpdate]
+    device: str
+    timestamp: float = time.time()
+
+    def to_payload(self) -> Dict[str, Any]:
+        """Return a serialisable dictionary representing the result."""
+        return {
+            "wanderer_id": self.wanderer_id,
+            "paths": [p.to_payload() for p in self.paths],
+            "device": self.device,
+            "timestamp": self.timestamp,
+        }
+
+    @classmethod
+    def from_payload(cls, payload: Dict[str, Any]) -> "ExplorationResult":
+        return cls(
+            wanderer_id=str(payload["wanderer_id"]),
+            paths=[PathUpdate.from_payload(p) for p in payload.get("paths", [])],
+            device=str(payload.get("device", "cpu")),
+            timestamp=float(payload.get("timestamp", time.time())),
+        )
+
+
+__all__ = [
+    "ExplorationRequest",
+    "ExplorationResult",
+    "PathUpdate",
+]


### PR DESCRIPTION
## Summary
- add `ExplorationRequest`, `PathUpdate`, and `ExplorationResult` dataclasses describing remote wanderer message payloads including explicit device info
- document remote wanderer message formats in TODO.md and add round-trip tests

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68972c2e6a80832790843d5a535c606c