### PR TITLE
feat: expand wanderer session management

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -707,7 +707,10 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
            - Use the existing `MessageBus` as transport with a dedicated topic per wanderer.
            - Clients establish a WebSocket connection and register using a unique `wanderer_id`.
            - Heartbeat pings keep sessions alive and allow the coordinator to detect disconnects.
-       - [ ] Specify authentication and session management.
+       - [x] Specify authentication and session management.
+           - [x] Use HMAC-signed tokens carrying wanderer_id and timestamp.
+           - [x] Track sessions with expiration metadata via `SessionManager`.
+           - [x] Expose APIs to list active sessions and revoke tokens.
        - [x] Define token format and generation algorithm.
        - [x] Implement token verification routine.
        - [x] Outline session timeout and renewal strategy.

--- a/tests/test_wanderer_auth.py
+++ b/tests/test_wanderer_auth.py
@@ -36,3 +36,13 @@ def test_session_lifecycle():
     # Expire the session
     time.sleep(0.2)
     assert not mgr.verify(new_token)
+
+
+def test_active_and_revoke_session():
+    mgr = SessionManager("abc", session_timeout=1.0)
+    token = mgr.start("w1")
+    assert "w1" in mgr.active_sessions()
+    assert mgr.revoke(token)
+    assert "w1" not in mgr.active_sessions()
+    # Revoking again should fail
+    assert not mgr.revoke(token)


### PR DESCRIPTION
## Summary
- add listing and revocation APIs to SessionManager
- test token lifecycle, active session tracking, and revocation
- document authentication and session management design steps

## Testing
- `pre-commit run --files wanderer_auth.py tests/test_wanderer_auth.py TODO.md`
- `pre-commit run --files tests/test_wanderer_auth.py`

------
https://chatgpt.com/codex/tasks/task_e_68972ea1f88c83279477366364148579