### PR TITLE
Raise error on corrupted RNN hidden state metadata

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1612,7 +1612,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
             - [x] Implement save logic in converter output.
             - [ ] Integrate load routine in runtime initialization.
             - [ ] Ensure operations work on CPU and GPU.
-            - [ ] Add error handling for corrupted or mismatched state files.
+            - [x] Add error handling for corrupted or mismatched state files.
         - [ ] Write unit and integration tests for state persistence.
             - [ ] Test single-layer and multi-layer RNNs.
             - [ ] Validate persistence across CPU/GPU transfers.

--- a/converttodo.md
+++ b/converttodo.md
@@ -85,7 +85,7 @@
         - [x] Map serialized states to runtime modules.
         - [x] Load serialized states into runtime structures.
         - [x] Verify shapes match original expectations.
-        - [x] Warn when states are missing or mismatched.
+        - [x] Raise error when states are missing or mismatched.
         - [x] Document runtime loading process.
         - [x] Add CLI flag to enable or disable hidden state restoration.
             - [x] Update converter CLI to accept `--restore-hidden`.

--- a/docs/hidden_state_serialization.md
+++ b/docs/hidden_state_serialization.md
@@ -8,9 +8,10 @@ remains portable across CPU and GPU environments.
 When a model is loaded via `core_from_json`, these serialized values are
 automatically mapped back to their corresponding RNN neurons.  The helper
 `restore_hidden_states` assigns each value to the neuron matching the recorded
-layer index and direction, emitting a warning if the stored tensor length does
-not match the expected hidden size.  Device information ensures that restored
-states live on the correct CPU or CUDA backend, preserving training context.
+layer index and direction and raises a `ValueError` if the stored tensor length
+does not match the expected hidden size or if the tensor payload is corrupted.
+Device information ensures that restored states live on the correct CPU or CUDA
+backend, preserving training context.
 
 ## Format Versioning
 


### PR DESCRIPTION
## Summary
- raise `ValueError` when hidden state metadata is missing or mismatched
- document stricter hidden state restoration behavior
- update RNN hidden state serialization tests

## Testing
- `pre-commit run --files TODO.md converttodo.md docs/hidden_state_serialization.md marble_utils.py tests/test_rnn_hidden_state_serialization.py`

------
https://chatgpt.com/codex/tasks/task_e_689731b988a88327856afdec6031c1df