### PR TITLE
Add snapshot flag to converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1297,6 +1297,21 @@ extension:
 python convert_model.py --pytorch my_model.pt --output marble_model.marble
 ```
 
+Alternatively, you can pass ``--snapshot`` to save a snapshot automatically.
+If ``--output`` is omitted the file is written next to the PyTorch checkpoint
+with a `.marble` extension:
+
+```bash
+python convert_model.py --pytorch my_model.pt --snapshot
+```
+
+Providing ``--output`` alongside ``--snapshot`` lets you choose the destination
+path (the `.marble` suffix is appended automatically):
+
+```bash
+python convert_model.py --pytorch my_model.pt --snapshot --output ./out/model
+```
+
 Specify ``--dry-run`` to see the resulting graph statistics without writing a
 file. You can also call ``convert_model`` directly:
 

--- a/convert_model.py
+++ b/convert_model.py
@@ -22,6 +22,12 @@ def main() -> None:
         help="Output path (.json or .marble)",
     )
     parser.add_argument(
+        "--snapshot",
+        action="store_true",
+        help="Save converted model as a .marble snapshot. If --output is omitted,"
+        " writes alongside the PyTorch file with a .marble extension",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Run conversion without saving JSON",
@@ -74,7 +80,7 @@ def main() -> None:
     if not args.pytorch:
         parser.error("--pytorch is required (either via CLI or config file)")
 
-    if not args.output and not (
+    if not (args.output or args.snapshot) and not (
         args.dry_run
         or args.summary
         or args.summary_output
@@ -84,7 +90,15 @@ def main() -> None:
         or args.summary_graph
         or args.show_graph
     ):
-        parser.error("--output is required unless running in dry-run or summary mode")
+        parser.error(
+            "--output is required unless running in dry-run or summary mode or --snapshot"
+        )
+
+    if args.snapshot:
+        if args.output:
+            args.output = str(Path(args.output).with_suffix(".marble"))
+        else:
+            args.output = str(Path(args.pytorch).with_suffix(".marble"))
 
     from torch_model_io import load_model_auto
 

--- a/converttodo.md
+++ b/converttodo.md
@@ -333,9 +333,9 @@
       - [x] Validate bias application through unit tests.
   - [ ] Conversion CLI and API enhancements
    - [ ] Option to produce .marble snapshot directly
-       - [ ] Add CLI flag enabling snapshot output.
-           - [ ] Update argparse to include `--snapshot` option.
-           - [ ] Document flag usage in converter README.
+       - [x] Add CLI flag enabling snapshot output.
+           - [x] Update argparse to include `--snapshot` option.
+           - [x] Document flag usage in converter README.
        - [ ] Serialise converted graph into `.marble` format.
            - [ ] Implement serializer for graph object to `.marble`.
            - [ ] Validate snapshot loads correctly in MARBLE runtime.


### PR DESCRIPTION
## Summary
- allow `convert_model.py` to save `.marble` snapshots via new `--snapshot` flag with automatic output path handling
- document snapshot flag usage
- track completion of snapshot flag task in converter TODO

## Testing
- `python convert_model.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68973667bf648327a10ffd785329deb2