### PR TITLE
Document sac temperature parameter

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -544,7 +544,10 @@ Each entry is listed under its section heading.
 - double_q
 
 ## sac
-- temperature
+- temperature: Entropy temperature coefficient for Soft Actor-Critic. Default
+  ``0.1``. See ``TUTORIAL.md`` section "Soft Actor-Critic Wandering" for a
+  worked example demonstrating how this parameter influences exploration on CPU
+  and GPU.
 
 ## contrastive_learning
 - enabled

--- a/TODO.md
+++ b/TODO.md
@@ -1535,6 +1535,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
             - [ ] Validate entries against current `config.yaml`.
             - [ ] Keep parameter list sorted alphabetically.
             - [ ] Reference related examples or tutorials.
+            - [x] Document `sac.temperature` with default value and tutorial link.
         - [ ] Extend `TUTORIAL.md` with projects for new features (e.g., self-distillation).
             - [ ] Create step-by-step project showcasing feature.
             - [ ] Link to dataset download and preparation code.


### PR DESCRIPTION
## Summary
- document `sac.temperature` configuration option with default value and tutorial reference
- track documentation progress for `sac.temperature` in TODO list

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68977e52ec348327b366e218de239822