### PR TITLE
Add CPU fallback test cataloging script and report

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1569,10 +1569,10 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
             - [x] Record modules lacking CPU implementation.
             - [x] Update README with limitation notes.
         - [ ] Add fallback tests for newly introduced modules.
-            - [ ] Catalog modules lacking CPU fallback tests.
+            - [x] Catalog modules lacking CPU fallback tests.
                 - [x] Scan repository for modules using CUDA-specific code paths.
-                - [ ] Cross-reference existing tests for CPU coverage.
-                - [ ] Produce markdown report listing modules lacking CPU fallback tests.
+                - [x] Cross-reference existing tests for CPU coverage.
+                - [x] Produce markdown report listing modules lacking CPU fallback tests.
             - [ ] Write parity tests verifying CPU and GPU execution.
             - [ ] Integrate new tests into existing suites.
         - [ ] Create CI job that runs full suite with CUDA disabled.

--- a/cpu_fallback_report.md
+++ b/cpu_fallback_report.md
@@ -1,0 +1,8 @@
+# Modules lacking CPU fallback tests
+
+- `attention_utils.py`
+- `benchmark_graph_precompile.py`
+- `exampletrain.py`
+- `neuronenblitz_kernel.py`
+- `run_profiler.py`
+- `soft_actor_critic.py`

--- a/scripts/catalog_cpu_fallback_tests.py
+++ b/scripts/catalog_cpu_fallback_tests.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import subprocess
+from scan_cuda_modules import scan_repo
+
+
+def find_modules_missing_cpu_tests(repo_root: Path):
+    cuda_modules = [m for m in scan_repo(repo_root) if not m.startswith("tests/")]
+    tests_dir = repo_root / "tests"
+    missing = []
+    for module in cuda_modules:
+        mod_stem = Path(module).stem
+        # search tests directory for module name
+        result = subprocess.run(
+            ["rg", mod_stem, str(tests_dir)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            missing.append(module)
+    return missing
+
+
+def generate_report(repo_root: Path, missing):
+    report_path = repo_root / "cpu_fallback_report.md"
+    lines = ["# Modules lacking CPU fallback tests", ""]
+    if missing:
+        for m in missing:
+            lines.append(f"- `{m}`")
+    else:
+        lines.append("All modules with CUDA usage have associated tests.")
+    report_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return report_path
+
+
+if __name__ == "__main__":
+    root = Path(__file__).resolve().parents[1]
+    missing = find_modules_missing_cpu_tests(root)
+    report = generate_report(root, missing)
+    for m in missing:
+        print(m)
+    print(f"Report written to {report}")


### PR DESCRIPTION
## Summary
- implement `catalog_cpu_fallback_tests.py` to scan CUDA modules and check for matching tests
- generate `cpu_fallback_report.md` listing modules lacking CPU fallback tests
- mark TODO entry for cataloging missing CPU fallback tests as complete

## Testing
- `python scripts/catalog_cpu_fallback_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_689783438878832781dcc17f1130e9d0