### PR TITLE
Add config key check to CI and attention utils CPU fallback test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,9 @@ jobs:
           pip install -r requirements.txt
       - name: Run pre-commit
         run: pre-commit run --files $(git diff --name-only HEAD)
+      - name: Check unused config keys
+        run: |
+          python scripts/list_config_keys.py config.yaml --unused --report unused_config_keys.txt
+          git diff --exit-code unused_config_keys.txt
       - name: Run tests
         run: pytest -n auto

--- a/TODO.md
+++ b/TODO.md
@@ -1573,8 +1573,24 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
                 - [x] Scan repository for modules using CUDA-specific code paths.
                 - [x] Cross-reference existing tests for CPU coverage.
                 - [x] Produce markdown report listing modules lacking CPU fallback tests.
-            - [ ] Write parity tests verifying CPU and GPU execution.
-            - [ ] Integrate new tests into existing suites.
+            - [ ] attention_utils.py
+                - [x] Write parity tests verifying CPU and GPU execution.
+                - [x] Integrate new tests into existing suites.
+            - [ ] benchmark_graph_precompile.py
+                - [ ] Write parity tests verifying CPU and GPU execution.
+                - [ ] Integrate new tests into existing suites.
+            - [ ] exampletrain.py
+                - [ ] Write parity tests verifying CPU and GPU execution.
+                - [ ] Integrate new tests into existing suites.
+            - [ ] neuronenblitz_kernel.py
+                - [ ] Write parity tests verifying CPU and GPU execution.
+                - [ ] Integrate new tests into existing suites.
+            - [ ] run_profiler.py
+                - [ ] Write parity tests verifying CPU and GPU execution.
+                - [ ] Integrate new tests into existing suites.
+            - [ ] soft_actor_critic.py
+                - [ ] Write parity tests verifying CPU and GPU execution.
+                - [ ] Integrate new tests into existing suites.
         - [ ] Create CI job that runs full suite with CUDA disabled.
             - [ ] Configure workflow to force CPU execution.
             - [ ] Add job to the CI pipeline definition.
@@ -1600,7 +1616,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
             - [x] Scan codebase with ripgrep to detect usages.
             - [x] Compile report of unused parameters.
              - [x] Add unit test ensuring the script flags future unused parameters.
-            - [ ] Integrate script into CI pipeline.
+            - [x] Integrate script into CI pipeline.
         - [ ] Implement missing parameters or prune outdated ones.
             - [ ] For each unused parameter, decide to implement or remove.
             - [ ] Add tests verifying newly implemented parameters on CPU and GPU.

--- a/cpu_fallback_report.md
+++ b/cpu_fallback_report.md
@@ -1,6 +1,5 @@
 # Modules lacking CPU fallback tests
 
-- `attention_utils.py`
 - `benchmark_graph_precompile.py`
 - `exampletrain.py`
 - `neuronenblitz_kernel.py`

--- a/tests/test_attention_utils_cpu_fallback.py
+++ b/tests/test_attention_utils_cpu_fallback.py
@@ -1,0 +1,26 @@
+import pytest
+import torch
+
+from attention_utils import GatingLayer, generate_causal_mask
+
+devices = ["cpu"]
+if torch.cuda.is_available():
+    devices.append("cuda")
+
+
+@pytest.mark.parametrize("device", devices)
+def test_generate_causal_mask_parity(device: str) -> None:
+    mask = generate_causal_mask(4, device=torch.device(device))
+    assert mask.device.type == device
+    cpu_mask = generate_causal_mask(4)
+    assert torch.equal(mask.cpu(), cpu_mask)
+
+
+@pytest.mark.parametrize("mode", ["sine", "chaos"])
+@pytest.mark.parametrize("device", devices)
+def test_gating_layer_parity(device: str, mode: str) -> None:
+    layer = GatingLayer(mode=mode).to(device)
+    gate = layer(6, device=torch.device(device))
+    assert gate.device.type == device
+    cpu_gate = GatingLayer(mode=mode)(6)
+    assert torch.allclose(gate.cpu(), cpu_gate, atol=1e-6)

--- a/unused_config_keys.txt
+++ b/unused_config_keys.txt
@@ -370,7 +370,9 @@ neuromodulatory_system.initial.stress
 neuronenblitz.activity_gate_exponent
 neuronenblitz.alternative_connection_prob
 neuronenblitz.attention_decay
+neuronenblitz.attention_span_threshold
 neuronenblitz.attention_update_scale
+neuronenblitz.auto_update
 neuronenblitz.backtrack_depth_limit
 neuronenblitz.backtrack_enabled
 neuronenblitz.backtrack_probability
@@ -415,6 +417,7 @@ neuronenblitz.loss_module
 neuronenblitz.loss_scale
 neuronenblitz.lr_adjustment_factor
 neuronenblitz.lr_scheduler
+neuronenblitz.max_attention_span
 neuronenblitz.max_learning_rate
 neuronenblitz.max_wander_depth
 neuronenblitz.memory_gate_decay
@@ -506,6 +509,7 @@ remote_hardware.grpc.address
 remote_hardware.grpc.backoff_factor
 remote_hardware.grpc.max_retries
 remote_hardware.tier_plugin
+sac.temperature
 scheduler.plugin
 semi_supervised_learning.batch_size
 semi_supervised_learning.enabled


### PR DESCRIPTION
## Summary
- check for unused configuration keys during CI
- add CPU/GPU parity tests for attention utilities
- refresh CPU fallback report and unused config key list

## Testing
- `pre-commit run --files .github/workflows/ci.yml TODO.md cpu_fallback_report.md tests/test_attention_utils_cpu_fallback.py`

------
https://chatgpt.com/codex/tasks/task_e_6897869ce2f0832795ed87cb50599e83