### PR TITLE
Add CPU/GPU parity tests for precompile benchmark and run profiler

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1576,18 +1576,18 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
             - [ ] attention_utils.py
                 - [x] Write parity tests verifying CPU and GPU execution.
                 - [x] Integrate new tests into existing suites.
-            - [ ] benchmark_graph_precompile.py
-                - [ ] Write parity tests verifying CPU and GPU execution.
-                - [ ] Integrate new tests into existing suites.
+            - [x] benchmark_graph_precompile.py
+                - [x] Write parity tests verifying CPU and GPU execution.
+                - [x] Integrate new tests into existing suites.
             - [ ] exampletrain.py
                 - [ ] Write parity tests verifying CPU and GPU execution.
                 - [ ] Integrate new tests into existing suites.
             - [ ] neuronenblitz_kernel.py
                 - [ ] Write parity tests verifying CPU and GPU execution.
                 - [ ] Integrate new tests into existing suites.
-            - [ ] run_profiler.py
-                - [ ] Write parity tests verifying CPU and GPU execution.
-                - [ ] Integrate new tests into existing suites.
+            - [x] run_profiler.py
+                - [x] Write parity tests verifying CPU and GPU execution.
+                - [x] Integrate new tests into existing suites.
             - [ ] soft_actor_critic.py
                 - [ ] Write parity tests verifying CPU and GPU execution.
                 - [ ] Integrate new tests into existing suites.

--- a/tests/test_benchmark_graph_precompile_cpu_gpu.py
+++ b/tests/test_benchmark_graph_precompile_cpu_gpu.py
@@ -1,0 +1,20 @@
+import pytest
+import torch
+
+from benchmark_graph_precompile import benchmark_precompile
+
+
+devices = ["cpu"]
+if torch.cuda.is_available():
+    devices.append("cuda")
+
+
+@pytest.mark.parametrize("device", devices)
+def test_benchmark_precompile_device_parity(device: str, monkeypatch) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: device == "cuda")
+    result = benchmark_precompile(repeats=5)
+    assert set(result) == {"no_precompile", "precompiled", "speedup"}
+    assert result["no_precompile"] > 0
+    assert result["precompiled"] > 0
+    assert result["speedup"] >= 0
+

--- a/tests/test_run_profiler_cpu_gpu.py
+++ b/tests/test_run_profiler_cpu_gpu.py
@@ -1,0 +1,20 @@
+import time
+import pytest
+import torch
+
+from run_profiler import RunProfiler
+
+
+devices = ["cpu"]
+if torch.cuda.is_available():
+    devices.append("cuda")
+
+
+@pytest.mark.parametrize("device", devices)
+def test_run_profiler_records_device(device: str, tmp_path) -> None:
+    profiler = RunProfiler(tmp_path / "profile.json")
+    dev = torch.device(device)
+    profiler.start("step", dev)
+    time.sleep(0.001)
+    profiler.end()
+    assert profiler.records[0].device == device


### PR DESCRIPTION
## Summary
- add CPU/GPU parity test for benchmark_graph_precompile
- add CPU/GPU parity test for run_profiler
- mark related TODO items as completed

## Testing
- no tests run (QUICKMODE)

------
https://chatgpt.com/codex/tasks/task_e_6897890a8d7c83279ed2d094a2b38978