### PR TITLE
Add soft actor critic CPU/GPU parity tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1588,9 +1588,9 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
             - [x] run_profiler.py
                 - [x] Write parity tests verifying CPU and GPU execution.
                 - [x] Integrate new tests into existing suites.
-            - [ ] soft_actor_critic.py
-                - [ ] Write parity tests verifying CPU and GPU execution.
-                - [ ] Integrate new tests into existing suites.
+            - [x] soft_actor_critic.py
+                - [x] Write parity tests verifying CPU and GPU execution.
+                - [x] Integrate new tests into existing suites.
         - [ ] Create CI job that runs full suite with CUDA disabled.
             - [ ] Configure workflow to force CPU execution.
             - [ ] Add job to the CI pipeline definition.

--- a/cpu_fallback_report.md
+++ b/cpu_fallback_report.md
@@ -4,4 +4,3 @@
 - `exampletrain.py`
 - `neuronenblitz_kernel.py`
 - `run_profiler.py`
-- `soft_actor_critic.py`

--- a/docs/cpu_fallback_catalog.md
+++ b/docs/cpu_fallback_catalog.md
@@ -38,7 +38,6 @@ Generated list of modules referencing CUDA-specific code paths.
 - reinforcement_learning.py
 - run_profiler.py
 - scripts/optimize.py
-- soft_actor_critic.py
 - streaming_dataset_step.py
 - streamlit_playground.py
 - system_metrics.py

--- a/tests/test_soft_actor_critic.py
+++ b/tests/test_soft_actor_critic.py
@@ -1,0 +1,44 @@
+import pytest
+import torch
+
+from soft_actor_critic import create_sac_networks
+
+
+def _generate_sample(state_dim: int, batch: int = 3):
+    """Generate a random state tensor for tests."""
+    return torch.randn(batch, state_dim)
+
+
+def test_create_sac_networks_cpu():
+    """Actor and critic should operate on CPU without CUDA."""
+    torch.manual_seed(0)
+    actor, critic = create_sac_networks(4, 2, device="cpu")
+    state = _generate_sample(4)
+    action, log_prob = actor(state)
+    q1, q2 = critic(state, action)
+    assert action.shape == (3, 2)
+    assert log_prob.shape == (3, 1)
+    assert q1.shape == (3, 1)
+    assert q2.shape == (3, 1)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_create_sac_networks_cpu_gpu_parity():
+    """CPU and GPU networks with same seed produce identical outputs."""
+    torch.manual_seed(0)
+    actor_cpu, critic_cpu = create_sac_networks(4, 2, device="cpu")
+    torch.manual_seed(0)
+    actor_gpu, critic_gpu = create_sac_networks(4, 2, device="cuda")
+
+    state = _generate_sample(4)
+    action_cpu, log_prob_cpu = actor_cpu(state)
+    q1_cpu, q2_cpu = critic_cpu(state, action_cpu)
+
+    state_gpu = state.to("cuda")
+    action_gpu, log_prob_gpu = actor_gpu(state_gpu)
+    q1_gpu, q2_gpu = critic_gpu(state_gpu, action_gpu)
+
+    assert torch.allclose(action_cpu, action_gpu.cpu(), atol=1e-6)
+    assert torch.allclose(log_prob_cpu, log_prob_gpu.cpu(), atol=1e-6)
+    assert torch.allclose(q1_cpu, q1_gpu.cpu(), atol=1e-6)
+    assert torch.allclose(q2_cpu, q2_gpu.cpu(), atol=1e-6)


### PR DESCRIPTION
## Summary
- add dedicated CPU/GPU parity tests for the soft actor critic networks
- mark soft actor critic fallback tasks complete and update reports
- prune soft_actor_critic from CPU fallback catalog

## Testing
- `pre-commit run --files tests/test_soft_actor_critic.py TODO.md cpu_fallback_report.md`
- `pre-commit run --files docs/cpu_fallback_catalog.md`


------
https://chatgpt.com/codex/tasks/task_e_68978dbf76988327a8aed98b9c229faf