### PR TITLE
Add attention utils parity tests and SAC enable helper

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1573,7 +1573,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
                 - [x] Scan repository for modules using CUDA-specific code paths.
                 - [x] Cross-reference existing tests for CPU coverage.
                 - [x] Produce markdown report listing modules lacking CPU fallback tests.
-            - [ ] attention_utils.py
+            - [x] attention_utils.py
                 - [x] Write parity tests verifying CPU and GPU execution.
                 - [x] Integrate new tests into existing suites.
             - [x] benchmark_graph_precompile.py

--- a/marble_neuronenblitz/__init__.py
+++ b/marble_neuronenblitz/__init__.py
@@ -6,7 +6,7 @@ from .core import (
     default_q_encoding,
     default_weight_update_fn,
 )
-from .learning import disable_rl, enable_rl, rl_select_action, rl_update
+from .learning import disable_rl, enable_rl, enable_sac, rl_select_action, rl_update
 from .memory import decay_memory_gates
 from .attention_span import DynamicSpanModule
 
@@ -17,6 +17,7 @@ __all__ = [
     "default_weight_update_fn",
     "default_q_encoding",
     "enable_rl",
+    "enable_sac",
     "disable_rl",
     "rl_select_action",
     "rl_update",

--- a/marble_neuronenblitz/learning.py
+++ b/marble_neuronenblitz/learning.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from .core import Neuronenblitz
 
 import numpy as np
+from soft_actor_critic import create_sac_networks
 
 
 def enable_rl(nb: "Neuronenblitz") -> None:
@@ -23,6 +24,21 @@ def enable_rl(nb: "Neuronenblitz") -> None:
 def disable_rl(nb: "Neuronenblitz") -> None:
     """Disable built-in reinforcement learning."""
     nb.rl_enabled = False
+
+
+def enable_sac(
+    nb: "Neuronenblitz",
+    state_dim: int,
+    action_dim: int,
+    *,
+    device: str | None = None,
+) -> None:
+    """Attach Soft Actor-Critic networks to ``nb`` on the requested device."""
+
+    actor, critic = create_sac_networks(state_dim, action_dim, device=device)
+    nb.sac_actor = actor
+    nb.sac_critic = critic
+    nb.sac_device = actor.device
 
 
 def rl_select_action(

--- a/neuronenblitztodo.md
+++ b/neuronenblitztodo.md
@@ -9,6 +9,9 @@ This document lists 100 concrete ideas for enhancing the `Neuronenblitz` algorit
    - [ ] Implement actor and critic networks within wander policy.
        - [x] Define neural architectures for actor and critic.
        - [ ] Integrate networks with wander policy update loop.
+           - [x] Instantiate actor and critic within Neuronenblitz via `enable_sac`.
+           - [ ] Sample actions from actor during dynamic_wander.
+           - [ ] Evaluate critic for state-action pairs and update networks.
        - [ ] Validate forward and backward passes on toy data.
    - [ ] Integrate entropy regularization into loss.
        - [ ] Add entropy term to objective function.

--- a/tests/test_attention_utils_cpu_fallback.py
+++ b/tests/test_attention_utils_cpu_fallback.py
@@ -1,7 +1,13 @@
 import pytest
 import torch
 
-from attention_utils import GatingLayer, generate_causal_mask
+from attention_utils import (
+    GatingLayer,
+    benchmark_mask_overhead,
+    gate_figure,
+    generate_causal_mask,
+    mask_figure,
+)
 
 devices = ["cpu"]
 if torch.cuda.is_available():
@@ -24,3 +30,29 @@ def test_gating_layer_parity(device: str, mode: str) -> None:
     assert gate.device.type == device
     cpu_gate = GatingLayer(mode=mode)(6)
     assert torch.allclose(gate.cpu(), cpu_gate, atol=1e-6)
+
+
+@pytest.mark.parametrize("device", devices)
+def test_benchmark_mask_overhead_runs(device: str) -> None:
+    """Ensure benchmark executes on both CPU and GPU and returns non-negative time."""
+    t = benchmark_mask_overhead(4, device=device, repeats=2)
+    assert isinstance(t, float)
+    assert t >= 0.0
+
+
+@pytest.mark.parametrize("device", devices)
+def test_mask_figure_accepts_tensor(device: str) -> None:
+    """mask_figure should handle tensors from different devices."""
+    mask = generate_causal_mask(3, device=torch.device(device))
+    fig = mask_figure(mask)
+    assert fig.data[0].z.shape == (3, 3)
+
+
+@pytest.mark.parametrize("mode", ["sine", "chaos"])
+@pytest.mark.parametrize("device", devices)
+def test_gate_figure_accepts_tensor(device: str, mode: str) -> None:
+    """gate_figure should render gating values regardless of device."""
+    layer = GatingLayer(mode=mode).to(device)
+    gate = layer(5, device=torch.device(device))
+    fig = gate_figure(gate)
+    assert len(fig.data[0].y) == 5

--- a/tests/test_enable_sac.py
+++ b/tests/test_enable_sac.py
@@ -1,0 +1,26 @@
+import pytest
+import torch
+
+from marble_core import Core
+from marble_neuronenblitz import Neuronenblitz
+from marble_neuronenblitz.learning import enable_sac
+
+
+devices = ["cpu"]
+if torch.cuda.is_available():
+    devices.append("cuda")
+
+
+@pytest.mark.parametrize("device", devices)
+def test_enable_sac_instantiates_networks(device: str) -> None:
+    core = Core({"width": 1, "height": 1})
+    nb = Neuronenblitz(core)
+    enable_sac(nb, state_dim=3, action_dim=2, device=device)
+    assert nb.sac_actor.device.type == device
+    state = torch.randn(1, 3, device=nb.sac_actor.device)
+    action, log_prob = nb.sac_actor(state)
+    q1, q2 = nb.sac_critic(state, action)
+    assert action.shape == (1, 2)
+    assert log_prob.shape == (1, 1)
+    assert q1.shape == (1, 1)
+    assert q2.shape == (1, 1)


### PR DESCRIPTION
## Summary
- expand attention utility tests to cover benchmarking and figure generation with CPU/GPU parity
- add `enable_sac` helper to attach Soft Actor-Critic networks to Neuronenblitz and export it
- document progress in TODO files and add tests for SAC network instantiation

## Testing
- no tests run (QUICKMODE)


------
https://chatgpt.com/codex/tasks/task_e_689792c5e34083278d0fd7f39cd62951