### PR TITLE
feat: add async dispatcher for message bus

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -722,7 +722,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
              path payload structures for serialization.
    - [ ] Implement Connect with remote wanderers for asynchronous exploration phases with CPU/GPU support.
        - [ ] Build client and server components leveraging the MessageBus.
-       - [ ] Integrate asynchronous dispatcher to handle incoming updates.
+       - [x] Integrate asynchronous dispatcher to handle incoming updates.
        - [ ] Ensure device context (CPU/GPU) is transmitted with payloads.
        - [x] Provide ``SessionManager`` handling token renewal and cleanup.
    - [ ] Add tests validating Connect with remote wanderers for asynchronous exploration phases.

--- a/message_bus.py
+++ b/message_bus.py
@@ -3,12 +3,13 @@
 import time
 from dataclasses import dataclass
 from queue import Queue, Empty
-from threading import Lock
-from typing import Dict, List, Optional
+from threading import Event, Lock, Thread
+from typing import Callable, Dict, List, Optional
 
 import networkx as nx
 from event_bus import global_event_bus
 
+__all__ = ["Message", "MessageBus", "AsyncDispatcher"]
 
 @dataclass
 class Message:
@@ -116,4 +117,58 @@ class MessageBus:
             else:
                 g.add_edge(msg.sender, msg.recipient, weight=1)
         return g
+
+
+class AsyncDispatcher:
+    """Background thread dispatching incoming messages to a handler.
+
+    Parameters
+    ----------
+    bus:
+        The :class:`MessageBus` instance to listen on.
+    agent_id:
+        Identifier of the agent whose queue should be monitored.
+    handler:
+        Callback invoked with each :class:`Message` received.
+    poll_interval:
+        Time in seconds to wait when polling the queue before checking the
+        stop flag.
+    """
+
+    def __init__(
+        self,
+        bus: MessageBus,
+        agent_id: str,
+        handler: Callable[[Message], None],
+        *,
+        poll_interval: float = 0.1,
+    ) -> None:
+        self._bus = bus
+        self._agent_id = agent_id
+        self._handler = handler
+        self._poll_interval = poll_interval
+        self._stop = Event()
+        self._thread: Optional[Thread] = None
+
+    def start(self) -> None:
+        """Start dispatching messages in a background thread."""
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                msg = self._bus.receive(self._agent_id, timeout=self._poll_interval)
+            except Empty:
+                continue
+            self._handler(msg)
+
+    def stop(self) -> None:
+        """Stop the background dispatcher and wait for it to terminate."""
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join()
 

--- a/tests/test_async_dispatcher.py
+++ b/tests/test_async_dispatcher.py
@@ -1,0 +1,25 @@
+from threading import Event
+
+from message_bus import AsyncDispatcher, MessageBus
+
+
+def test_async_dispatcher_invokes_handler() -> None:
+    bus = MessageBus()
+    bus.register("sender")
+    bus.register("receiver")
+    ev = Event()
+    received = []
+
+    def handler(msg):
+        received.append(msg)
+        ev.set()
+
+    dispatcher = AsyncDispatcher(bus, "receiver", handler, poll_interval=0.01)
+    dispatcher.start()
+    bus.send("sender", "receiver", {"ping": 1})
+    assert ev.wait(1.0), "handler was not invoked"
+    dispatcher.stop()
+    assert len(received) == 1
+    assert received[0].content == {"ping": 1}
+    assert received[0].sender == "sender"
+    assert received[0].recipient == "receiver"


### PR DESCRIPTION
## Summary
- extend message bus with AsyncDispatcher to process incoming messages in a background thread
- add unit test for asynchronous dispatching behavior
- mark TODO task for async dispatcher as complete

## Testing
- `python -m py_compile message_bus.py tests/test_async_dispatcher.py`


------
https://chatgpt.com/codex/tasks/task_e_6897973dcbb08327ba60290a7ba3c153