### PR TITLE
docs: document CPU fallback strategy

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1595,10 +1595,10 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
             - [ ] Configure workflow to force CPU execution.
             - [ ] Add job to the CI pipeline definition.
             - [ ] Verify sample run completes without CUDA.
-        - [ ] Summarize fallback strategy in developer docs.
-            - [ ] Draft section describing fallback approach.
-            - [ ] Enumerate modules with verified fallbacks.
-            - [ ] Link to new tests and CI job for reference.
+        - [x] Summarize fallback strategy in developer docs.
+            - [x] Draft section describing fallback approach.
+            - [x] Enumerate modules with verified fallbacks.
+            - [x] Link to new tests and CI job for reference.
 
 ### Dream Replay Enhancements
 

--- a/docs/cpu_fallback_catalog.md
+++ b/docs/cpu_fallback_catalog.md
@@ -1,5 +1,23 @@
-# Modules requiring CPU fallback tests
+# CPU Fallback Strategy and Catalog
 
+## Fallback strategy
+Marble provides GPU acceleration when available but every module must
+offer an equivalent CPU execution path. Each component guards CUDA
+usage with `torch.cuda.is_available()` and routes tensors accordingly
+so behaviour remains consistent regardless of device. Parity tests
+assert that CPU and GPU paths produce matching results, and the CI
+workflow `.github/workflows/ci.yml` runs on CPU-only runners to detect
+regressions in fallback logic.
+
+## Verified CPU/GPU parity
+The following modules currently have explicit tests confirming parity
+between devices:
+- `attention_utils.py` – see `tests/test_attention_utils_cpu_fallback.py`,
+- `benchmark_graph_precompile.py` – see `tests/test_benchmark_graph_precompile_cpu_gpu.py`,
+- `run_profiler.py` – see `tests/test_run_profiler_cpu_gpu.py`,
+- `soft_actor_critic.py` – see `tests/test_soft_actor_critic.py`.
+
+## Modules requiring CPU fallback tests
 Generated list of modules referencing CUDA-specific code paths.
 
 - adversarial_dataset.py


### PR DESCRIPTION
## Summary
- detail fallback approach for CPU paths and list modules with verified parity
- mark corresponding developer-doc TODO item as complete

## Testing
- `pre-commit run --files docs/cpu_fallback_catalog.md TODO.md`


------
https://chatgpt.com/codex/tasks/task_e_689798ff600883279804aa46df5e6565