### PR TITLE
Ensure remote wanderer messages carry device context

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -723,7 +723,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [ ] Implement Connect with remote wanderers for asynchronous exploration phases with CPU/GPU support.
        - [ ] Build client and server components leveraging the MessageBus.
        - [x] Integrate asynchronous dispatcher to handle incoming updates.
-       - [ ] Ensure device context (CPU/GPU) is transmitted with payloads.
+       - [x] Ensure device context (CPU/GPU) is transmitted with payloads.
        - [x] Provide ``SessionManager`` handling token renewal and cleanup.
    - [ ] Add tests validating Connect with remote wanderers for asynchronous exploration phases.
        - [ ] Simulate multiple remote wanderers exchanging updates.

--- a/remote_wanderer.py
+++ b/remote_wanderer.py
@@ -1,0 +1,115 @@
+"""Utilities for exchanging exploration messages with device metadata.
+
+These helpers wrap :class:`MessageBus` to ensure that every payload
+includes the sender's execution device (CPU or GPU).  This allows
+coordinator and wanderers to route tensors appropriately when working in
+heterogeneous environments.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+import torch
+
+from message_bus import MessageBus, Message
+from wanderer_messages import ExplorationRequest, ExplorationResult, PathUpdate
+
+__all__ = [
+    "current_device",
+    "send_exploration_request",
+    "receive_exploration_request",
+    "send_exploration_result",
+    "receive_exploration_result",
+]
+
+
+def current_device() -> str:
+    """Return the current execution device.
+
+    Detects GPU availability and returns a device string that can be used in
+    payloads.  The string uses the standard ``cuda:0`` format for GPUs.
+    """
+
+    return "cuda:0" if torch.cuda.is_available() else "cpu"
+
+
+def send_exploration_request(
+    bus: MessageBus,
+    sender: str,
+    recipient: str,
+    *,
+    seed: int,
+    max_steps: int,
+    device: str | None = None,
+) -> None:
+    """Send an :class:`ExplorationRequest` to ``recipient``.
+
+    Parameters
+    ----------
+    bus:
+        Message bus instance used for transmission.
+    sender:
+        Identifier of the sending agent (usually the coordinator).
+    recipient:
+        Identifier of the remote wanderer.
+    seed:
+        Random seed controlling exploration behaviour.
+    max_steps:
+        Maximum number of steps the wanderer may take.
+    device:
+        Optional device string.  If ``None`` the current device is detected
+        automatically.
+    """
+
+    if device is None:
+        device = current_device()
+    request = ExplorationRequest(
+        wanderer_id=recipient,
+        seed=seed,
+        max_steps=max_steps,
+        device=device,
+    )
+    bus.send(sender, recipient, request.to_payload())
+
+
+def receive_exploration_request(msg: Message) -> ExplorationRequest:
+    """Decode an :class:`ExplorationRequest` from ``msg``."""
+
+    return ExplorationRequest.from_payload(msg.content)
+
+
+def send_exploration_result(
+    bus: MessageBus,
+    sender: str,
+    recipient: str,
+    paths: Iterable[PathUpdate],
+    *,
+    device: str | None = None,
+) -> None:
+    """Send an :class:`ExplorationResult` to ``recipient``.
+
+    Parameters
+    ----------
+    bus:
+        Message bus instance used for transmission.
+    sender:
+        Identifier of the wanderer sending the results.
+    recipient:
+        Identifier of the coordinator receiving the results.
+    paths:
+        Iterable of :class:`PathUpdate` objects describing discovered paths.
+    device:
+        Optional execution device of the wanderer.  Detected automatically when
+        omitted.
+    """
+
+    if device is None:
+        device = current_device()
+    result = ExplorationResult(wanderer_id=sender, paths=list(paths), device=device)
+    bus.send(sender, recipient, result.to_payload())
+
+
+def receive_exploration_result(msg: Message) -> ExplorationResult:
+    """Decode an :class:`ExplorationResult` from ``msg``."""
+
+    return ExplorationResult.from_payload(msg.content)

--- a/tests/test_remote_wanderer_messages.py
+++ b/tests/test_remote_wanderer_messages.py
@@ -1,0 +1,42 @@
+"""Tests for remote wanderer message helpers."""
+import torch
+
+from message_bus import MessageBus
+from wanderer_messages import PathUpdate
+from remote_wanderer import (
+    current_device,
+    send_exploration_request,
+    receive_exploration_request,
+    send_exploration_result,
+    receive_exploration_result,
+)
+
+
+def test_request_device_transmission():
+    bus = MessageBus()
+    bus.register("coordinator")
+    bus.register("wanderer")
+
+    send_exploration_request(
+        bus,
+        "coordinator",
+        "wanderer",
+        seed=42,
+        max_steps=5,
+    )
+    msg = bus.receive("wanderer")
+    req = receive_exploration_request(msg)
+    assert req.device == current_device()
+
+
+def test_result_device_transmission():
+    bus = MessageBus()
+    bus.register("coordinator")
+    bus.register("wanderer")
+
+    paths = [PathUpdate(nodes=[1, 2], score=0.5)]
+    send_exploration_result(bus, "wanderer", "coordinator", paths)
+    msg = bus.receive("coordinator")
+    res = receive_exploration_result(msg)
+    assert res.device == current_device()
+    assert len(res.paths) == 1 and res.paths[0].nodes == [1, 2]


### PR DESCRIPTION
## Summary
- Add remote_wanderer helper functions to send and receive exploration messages with device metadata
- Test device field propagation through MessageBus helpers
- Mark TODO item for device context transmission as complete

## Testing
- `python -m py_compile remote_wanderer.py tests/test_remote_wanderer_messages.py`


------
https://chatgpt.com/codex/tasks/task_e_6897a2ecaf30832792a6df809a55257c