### PR TITLE
Implement remote wanderer client/server messaging components

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -721,11 +721,12 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
              in ``wanderer_messages.py`` with explicit device metadata and
              path payload structures for serialization.
    - [ ] Implement Connect with remote wanderers for asynchronous exploration phases with CPU/GPU support.
-       - [ ] Build client and server components leveraging the MessageBus.
+       - [x] Build client and server components leveraging the MessageBus.
        - [x] Integrate asynchronous dispatcher to handle incoming updates.
        - [x] Ensure device context (CPU/GPU) is transmitted with payloads.
        - [x] Provide ``SessionManager`` handling token renewal and cleanup.
    - [ ] Add tests validating Connect with remote wanderers for asynchronous exploration phases.
+       - [x] Basic client-server round-trip.
        - [ ] Simulate multiple remote wanderers exchanging updates.
        - [ ] Verify synchronization under intermittent connectivity.
        - [ ] Measure latency impact on exploration performance.

--- a/remote_wanderer.py
+++ b/remote_wanderer.py
@@ -7,11 +7,11 @@ heterogeneous environments.
 """
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Callable, Iterable
 
 import torch
 
-from message_bus import MessageBus, Message
+from message_bus import MessageBus, Message, AsyncDispatcher
 from wanderer_messages import ExplorationRequest, ExplorationResult, PathUpdate
 
 __all__ = [
@@ -20,6 +20,8 @@ __all__ = [
     "receive_exploration_request",
     "send_exploration_result",
     "receive_exploration_result",
+    "RemoteWandererClient",
+    "RemoteWandererServer",
 ]
 
 
@@ -113,3 +115,99 @@ def receive_exploration_result(msg: Message) -> ExplorationResult:
     """Decode an :class:`ExplorationResult` from ``msg``."""
 
     return ExplorationResult.from_payload(msg.content)
+
+
+class RemoteWandererClient:
+    """Client handling exploration requests for a remote wanderer.
+
+    The client listens on its dedicated :class:`MessageBus` queue and reacts to
+    incoming :class:`ExplorationRequest` messages.  For each request the provided
+    ``explore`` callback is invoked to perform the actual wandering logic.  The
+    resulting paths are returned to the coordinator via
+    :class:`ExplorationResult` messages.  Device information is transmitted with
+    every payload so coordinators can route tensors correctly on CPU or GPU.
+    """
+
+    def __init__(
+        self,
+        bus: MessageBus,
+        wanderer_id: str,
+        explore: Callable[[int, int], Iterable[PathUpdate]],
+        *,
+        device: str | None = None,
+        poll_interval: float = 0.1,
+    ) -> None:
+        self._bus = bus
+        self._wanderer_id = wanderer_id
+        self._explore = explore
+        self._device = device
+        self._dispatcher = AsyncDispatcher(
+            bus, wanderer_id, self._handle_request, poll_interval=poll_interval
+        )
+
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        """Register with the bus and begin processing requests."""
+
+        self._bus.register(self._wanderer_id)
+        self._dispatcher.start()
+
+    # ------------------------------------------------------------------
+    def stop(self) -> None:
+        """Stop processing requests."""
+
+        self._dispatcher.stop()
+
+    # ------------------------------------------------------------------
+    def _handle_request(self, msg: Message) -> None:
+        req = receive_exploration_request(msg)
+        torch.manual_seed(req.seed)
+        try:
+            paths = list(self._explore(req.seed, req.max_steps, req.device))
+        except TypeError:
+            paths = list(self._explore(req.seed, req.max_steps))
+        recipient = msg.sender or ""
+        send_exploration_result(
+            self._bus,
+            self._wanderer_id,
+            recipient,
+            paths,
+            device=self._device or current_device(),
+        )
+
+
+class RemoteWandererServer:
+    """Coordinator dispatching exploration requests to remote wanderers."""
+
+    def __init__(
+        self, bus: MessageBus, coordinator_id: str, *, timeout: float = 5.0
+    ) -> None:
+        self._bus = bus
+        self._coordinator_id = coordinator_id
+        self._timeout = timeout
+        self._bus.register(coordinator_id)
+
+    # ------------------------------------------------------------------
+    def request_exploration(
+        self,
+        wanderer_id: str,
+        *,
+        seed: int,
+        max_steps: int,
+        device: str | None = None,
+        timeout: float | None = None,
+    ) -> ExplorationResult:
+        """Send an exploration request and wait for the result."""
+
+        send_exploration_request(
+            self._bus,
+            self._coordinator_id,
+            wanderer_id,
+            seed=seed,
+            max_steps=max_steps,
+            device=device,
+        )
+        msg = self._bus.receive(
+            self._coordinator_id, timeout=timeout or self._timeout
+        )
+        return receive_exploration_result(msg)

--- a/tests/test_remote_wanderer_integration.py
+++ b/tests/test_remote_wanderer_integration.py
@@ -1,0 +1,26 @@
+from message_bus import MessageBus
+from wanderer_messages import PathUpdate
+from remote_wanderer import RemoteWandererClient, RemoteWandererServer
+
+
+import torch
+
+
+def dummy_explore(seed: int, max_steps: int, device: str | None = None):
+    torch.manual_seed(seed)
+    nodes = list(range(max_steps))
+    score = float(torch.rand(1, device=device if device and torch.cuda.is_available() else None).cpu().item())
+    yield PathUpdate(nodes=nodes, score=score)
+
+
+def test_remote_wanderer_round_trip():
+    bus = MessageBus()
+    server = RemoteWandererServer(bus, "coord")
+    client = RemoteWandererClient(bus, "w1", dummy_explore)
+    client.start()
+    result = server.request_exploration("w1", seed=42, max_steps=3)
+    assert result.wanderer_id == "w1"
+    assert len(result.paths) == 1
+    assert result.paths[0].nodes == [0, 1, 2]
+    assert result.device in {"cpu", "cuda:0"}
+    client.stop()


### PR DESCRIPTION
## Summary
- add `RemoteWandererClient` and `RemoteWandererServer` using `MessageBus` with device-aware messaging
- include integration test for a basic client-server round trip
- update TODO to reflect completed client/server work and to break down test subtasks

## Testing
- `python -m py_compile remote_wanderer.py tests/test_remote_wanderer_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_6897a4a6b644832785631ac1793d978d