### PR TITLE
test: add intermittent connectivity check for remote wanderers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -728,8 +728,11 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
    - [ ] Add tests validating Connect with remote wanderers for asynchronous exploration phases.
        - [x] Basic client-server round-trip.
        - [x] Simulate multiple remote wanderers exchanging updates.
-       - [ ] Verify synchronization under intermittent connectivity.
+       - [x] Verify synchronization under intermittent connectivity.
        - [ ] Measure latency impact on exploration performance.
+           - [ ] Introduce artificial message delays.
+           - [ ] Record exploration completion times under varying latencies.
+           - [ ] Analyze performance degradation and report findings.
    - [ ] Document Connect with remote wanderers for asynchronous exploration phases in README and TUTORIAL.
        - [ ] Provide configuration examples for enabling remote wanderers.
        - [ ] Include troubleshooting steps for network failures.

--- a/tests/test_remote_wanderer_connectivity.py
+++ b/tests/test_remote_wanderer_connectivity.py
@@ -1,0 +1,50 @@
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import torch
+
+from message_bus import MessageBus
+from remote_wanderer import RemoteWandererClient, RemoteWandererServer
+from wanderer_messages import PathUpdate
+
+
+def dummy_explore(seed: int, max_steps: int, device: str | None = None):
+    """Deterministic exploration yielding a single path.
+
+    Uses the provided seed to generate a reproducible score. The device
+    argument is optional to maintain backward compatibility with exploration
+    callbacks lacking device awareness.
+    """
+    torch.manual_seed(seed)
+    rand_kwargs = {"device": device} if device and torch.cuda.is_available() else {}
+    score = float(torch.rand(1, **rand_kwargs).cpu().item())
+    nodes = list(range(max_steps))
+    yield PathUpdate(nodes=nodes, score=score)
+
+
+def test_remote_wanderer_recovers_after_disconnect():
+    """Ensure coordination succeeds if the wanderer reconnects later.
+
+    The coordinator sends a request while the wanderer client is offline. Once
+    the client starts and processes the pending request the result must still
+    be delivered correctly.
+    """
+    bus = MessageBus()
+    server = RemoteWandererServer(bus, "coord", timeout=10.0)
+    bus.register("w1")  # allow queuing messages while client is offline
+    client = RemoteWandererClient(bus, "w1", dummy_explore)
+
+    def request_result():
+        return server.request_exploration("w1", seed=123, max_steps=4, timeout=10.0)
+
+    with ThreadPoolExecutor(max_workers=1) as ex:
+        future = ex.submit(request_result)
+        # give the server time to queue the request while client is offline
+        time.sleep(0.2)
+        client.start()  # simulate the wanderer reconnecting
+        result = future.result(timeout=10.0)
+
+    assert result.wanderer_id == "w1"
+    assert result.paths[0].nodes == [0, 1, 2, 3]
+    assert result.device in {"cpu", "cuda:0"}
+    client.stop()


### PR DESCRIPTION
## Summary
- test recovery when remote wanderer reconnects after a delay
- track progress for remote wanderer test coverage in TODO

## Testing
- `pre-commit run --files TODO.md tests/test_remote_wanderer_connectivity.py`


------
https://chatgpt.com/codex/tasks/task_e_6897a80604488327852f5e6a709883e2