### PR TITLE
Add SAC gradient parity test and Neuronenblitz kernel CPU/GPU parity

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1587,11 +1587,13 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
                 - [x] Write parity tests verifying CPU and GPU execution.
                 - [x] Integrate new tests into existing suites.
             - [ ] exampletrain.py
-                - [ ] Write parity tests verifying CPU and GPU execution.
+                - [ ] Create lightweight mock Stable Diffusion pipeline for tests.
+                - [ ] Generate synthetic dataset to avoid large downloads.
+                - [ ] Write CPU and GPU parity test using mocks.
                 - [ ] Integrate new tests into existing suites.
-            - [ ] neuronenblitz_kernel.py
-                - [ ] Write parity tests verifying CPU and GPU execution.
-                - [ ] Integrate new tests into existing suites.
+            - [x] neuronenblitz_kernel.py
+                - [x] Write parity tests verifying CPU and GPU execution.
+                - [x] Integrate new tests into existing suites.
             - [x] run_profiler.py
                 - [x] Write parity tests verifying CPU and GPU execution.
                 - [x] Integrate new tests into existing suites.

--- a/neuronenblitztodo.md
+++ b/neuronenblitztodo.md
@@ -12,7 +12,7 @@ This document lists 100 concrete ideas for enhancing the `Neuronenblitz` algorit
            - [x] Instantiate actor and critic within Neuronenblitz via `enable_sac`.
            - [x] Sample actions from actor during dynamic_wander.
            - [x] Evaluate critic for state-action pairs and update networks.
-       - [ ] Validate forward and backward passes on toy data.
+       - [x] Validate forward and backward passes on toy data.
    - [ ] Integrate entropy regularization into loss.
        - [ ] Add entropy term to objective function.
        - [ ] Tune regularization weight for stability.

--- a/tests/test_neuronenblitz_kernel_parity.py
+++ b/tests/test_neuronenblitz_kernel_parity.py
@@ -1,0 +1,127 @@
+import math
+import pytest
+import torch
+
+from neuronenblitz_kernel import apply_weight_updates
+
+
+def _apply_weight_updates_cpu(
+    source: torch.Tensor,
+    weights: torch.Tensor,
+    potentials: torch.Tensor,
+    momentum: torch.Tensor,
+    grad_sq: torch.Tensor,
+    prev_grad: torch.Tensor,
+    eligibility: torch.Tensor,
+    mem_gate: torch.Tensor,
+    error: float,
+    learning_rate: float,
+    momentum_coeff: float,
+    rms_beta: float,
+    grad_epsilon: float,
+    cap: float,
+    weight_limit: float,
+    gradient_score_scale: float,
+    synapse_potential_cap: float,
+    path_len: int,
+):
+    """Reference implementation of the CUDA kernel in pure PyTorch."""
+    dtype = weights.dtype
+    src = source.float()
+    w = weights.float().clone()
+    pot = potentials.float().clone()
+    mom = momentum.float().clone()
+    gs = grad_sq.float().clone()
+    pg = prev_grad.float().clone()
+    elig = eligibility.float()
+    mem = mem_gate.float()
+    delta = (error * src) / float(path_len + 1)
+    flip_mask = pg * delta < 0.0
+    delta = torch.where(flip_mask, delta * 0.5, delta)
+    pg = delta.clone()
+    delta = delta * elig
+    v = rms_beta * gs + (1.0 - rms_beta) * (delta * delta)
+    gs = v
+    scaled_delta = delta / torch.sqrt(v + grad_epsilon)
+    m = momentum_coeff * mom + scaled_delta
+    mom = m
+    update = learning_rate * (momentum_coeff * m + scaled_delta)
+    update = torch.clamp(update, -cap, cap)
+    w = torch.clamp(w + update, -weight_limit, weight_limit)
+    pot = torch.minimum(
+        pot + torch.abs(scaled_delta) * gradient_score_scale,
+        torch.tensor(synapse_potential_cap, dtype=pot.dtype),
+    )
+    mem_factor = 1.0 + mem
+    scores = torch.abs(torch.tensor(error, dtype=pot.dtype)) * torch.abs(w) / float(path_len)
+    scores = scores * mem_factor
+    return (
+        w.to(dtype),
+        pot.to(dtype),
+        mom.to(dtype),
+        gs.to(dtype),
+        pg.to(dtype),
+        scores.to(dtype),
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+def test_apply_weight_updates_cpu_gpu_parity(dtype):
+    torch.manual_seed(0)
+    size = 64
+    device = "cuda"
+    kwargs = dict(device=device, dtype=dtype)
+    source = torch.randn(size, **kwargs)
+    weights = torch.randn(size, **kwargs)
+    potentials = torch.zeros(size, **kwargs)
+    momentum = torch.zeros(size, **kwargs)
+    grad_sq = torch.ones(size, **kwargs)
+    prev_grad = torch.zeros(size, **kwargs)
+    eligibility = torch.ones(size, **kwargs)
+    mem_gate = torch.zeros(size, **kwargs)
+    params = dict(
+        error=0.1,
+        learning_rate=0.01,
+        momentum_coeff=0.9,
+        rms_beta=0.99,
+        grad_epsilon=1e-8,
+        cap=0.1,
+        weight_limit=1.0,
+        gradient_score_scale=0.5,
+        synapse_potential_cap=10.0,
+        path_len=10,
+    )
+
+    w_cpu, pot_cpu, mom_cpu, gs_cpu, pg_cpu, sc_cpu = _apply_weight_updates_cpu(
+        source.cpu(),
+        weights.cpu(),
+        potentials.cpu(),
+        momentum.cpu(),
+        grad_sq.cpu(),
+        prev_grad.cpu(),
+        eligibility.cpu(),
+        mem_gate.cpu(),
+        **params,
+    )
+
+    w_gpu, pot_gpu, mom_gpu, gs_gpu, pg_gpu, sc_gpu = apply_weight_updates(
+        source,
+        weights.clone(),
+        potentials.clone(),
+        momentum.clone(),
+        grad_sq.clone(),
+        prev_grad.clone(),
+        eligibility,
+        mem_gate,
+        **params,
+    )
+
+    atol = 1e-3 if dtype == torch.float16 else 1e-6
+    assert torch.allclose(w_cpu, w_gpu.cpu(), atol=atol)
+    assert torch.allclose(pot_cpu, pot_gpu.cpu(), atol=atol)
+    assert torch.allclose(mom_cpu, mom_gpu.cpu(), atol=atol)
+    assert torch.allclose(gs_cpu, gs_gpu.cpu(), atol=atol)
+    assert torch.allclose(pg_cpu, pg_gpu.cpu(), atol=atol)
+    assert torch.allclose(sc_cpu, sc_gpu.cpu(), atol=atol)
+

--- a/tests/test_soft_actor_critic.py
+++ b/tests/test_soft_actor_critic.py
@@ -10,21 +10,25 @@ def _generate_sample(state_dim: int, batch: int = 3):
 
 
 def test_create_sac_networks_cpu():
-    """Actor and critic should operate on CPU without CUDA."""
+    """Actor and critic should operate on CPU and support backpropagation."""
     torch.manual_seed(0)
     actor, critic = create_sac_networks(4, 2, device="cpu")
     state = _generate_sample(4)
     action, log_prob = actor(state)
     q1, q2 = critic(state, action)
+    loss = (q1 + q2 + log_prob).mean()
+    loss.backward()
     assert action.shape == (3, 2)
     assert log_prob.shape == (3, 1)
     assert q1.shape == (3, 1)
     assert q2.shape == (3, 1)
+    for p in list(actor.parameters()) + list(critic.parameters()):
+        assert p.grad is not None
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_create_sac_networks_cpu_gpu_parity():
-    """CPU and GPU networks with same seed produce identical outputs."""
+    """CPU and GPU networks with same seed produce identical outputs and gradients."""
     torch.manual_seed(0)
     actor_cpu, critic_cpu = create_sac_networks(4, 2, device="cpu")
     torch.manual_seed(0)
@@ -33,12 +37,20 @@ def test_create_sac_networks_cpu_gpu_parity():
     state = _generate_sample(4)
     action_cpu, log_prob_cpu = actor_cpu(state)
     q1_cpu, q2_cpu = critic_cpu(state, action_cpu)
+    loss_cpu = (q1_cpu + q2_cpu + log_prob_cpu).mean()
+    loss_cpu.backward()
 
     state_gpu = state.to("cuda")
     action_gpu, log_prob_gpu = actor_gpu(state_gpu)
     q1_gpu, q2_gpu = critic_gpu(state_gpu, action_gpu)
+    loss_gpu = (q1_gpu + q2_gpu + log_prob_gpu).mean()
+    loss_gpu.backward()
 
     assert torch.allclose(action_cpu, action_gpu.cpu(), atol=1e-6)
     assert torch.allclose(log_prob_cpu, log_prob_gpu.cpu(), atol=1e-6)
     assert torch.allclose(q1_cpu, q1_gpu.cpu(), atol=1e-6)
     assert torch.allclose(q2_cpu, q2_gpu.cpu(), atol=1e-6)
+    for p_cpu, p_gpu in zip(actor_cpu.parameters(), actor_gpu.parameters()):
+        assert torch.allclose(p_cpu.grad, p_gpu.grad.cpu(), atol=1e-6)
+    for p_cpu, p_gpu in zip(critic_cpu.parameters(), critic_gpu.parameters()):
+        assert torch.allclose(p_cpu.grad, p_gpu.grad.cpu(), atol=1e-6)


### PR DESCRIPTION
## Summary
- ensure SAC actor/critic backpropagates correctly on CPU and GPU
- add parity test for neuronenblitz CUDA kernel against CPU reference implementation
- split exampletrain parity task into actionable subtasks and mark kernel parity complete

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_6897b20fb160832786221525c451da90