### PR TITLE
Add AES-GCM tensor encryption utilities

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -741,11 +741,14 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
        - [x] Include troubleshooting steps for network failures.
 210. [ ] Secure pipeline data flow by integrating dataset encryption routines.
    - [ ] Outline design for Secure pipeline data flow by integrating dataset encryption routines.
-       - [ ] Choose encryption algorithm and key management strategy.
+       - [x] Choose encryption algorithm and key management strategy.
+           - AES-256-GCM via the ``cryptography`` library.
+           - Keys supplied as base64 strings in ``DATASET_ENCRYPTION_KEY``.
        - [ ] Identify integration points within dataset loader and saver.
        - [ ] Determine configuration flags to toggle encryption.
    - [ ] Implement Secure pipeline data flow by integrating dataset encryption routines with CPU/GPU support.
        - [ ] Implement encryption and decryption utilities operating on CPU/GPU tensors.
+           - [x] Add AES-GCM tensor encryption helpers in ``dataset_encryption.py``.
        - [ ] Embed encryption hooks into DataLoader and cache server.
        - [ ] Expose `dataset.encryption_key` and related options in config files.
    - [ ] Add tests validating Secure pipeline data flow by integrating dataset encryption routines.

--- a/dataset_encryption.py
+++ b/dataset_encryption.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+"""Utilities for encrypting and decrypting datasets.
+
+This module provides AES-GCM based encryption helpers that operate on
+PyTorch tensors. Tensors are always moved to CPU for encryption and
+can be restored to their original device during decryption.
+"""
+
+import base64
+import json
+import os
+from dataclasses import dataclass
+from typing import Tuple, Optional
+
+import torch
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+
+@dataclass
+class EncryptedTensor:
+    """Container holding encrypted tensor data."""
+
+    nonce: bytes
+    ciphertext: bytes
+    shape: Tuple[int, ...]
+    dtype: str
+    device: str
+
+    def to_json(self) -> str:
+        """Serialise the encrypted tensor to a JSON string."""
+        return json.dumps(
+            {
+                "nonce": base64.b64encode(self.nonce).decode("utf-8"),
+                "ciphertext": base64.b64encode(self.ciphertext).decode("utf-8"),
+                "shape": self.shape,
+                "dtype": self.dtype,
+                "device": self.device,
+            }
+        )
+
+    @staticmethod
+    def from_json(data: str) -> "EncryptedTensor":
+        """Restore an :class:`EncryptedTensor` from a JSON string."""
+        obj = json.loads(data)
+        return EncryptedTensor(
+            nonce=base64.b64decode(obj["nonce"]),
+            ciphertext=base64.b64decode(obj["ciphertext"]),
+            shape=tuple(obj["shape"]),
+            dtype=obj["dtype"],
+            device=obj["device"],
+        )
+
+
+def generate_key() -> str:
+    """Generate a new base64 encoded AES-256-GCM key."""
+    key = AESGCM.generate_key(bit_length=256)
+    return base64.urlsafe_b64encode(key).decode("utf-8")
+
+
+def load_key_from_env(env_var: str = "DATASET_ENCRYPTION_KEY") -> bytes:
+    """Load a base64 encoded key from an environment variable."""
+    key_b64 = os.environ.get(env_var)
+    if not key_b64:
+        raise KeyError(f"Environment variable {env_var} not set")
+    return base64.urlsafe_b64decode(key_b64)
+
+
+def encrypt_tensor(tensor: torch.Tensor, key: bytes) -> EncryptedTensor:
+    """Encrypt a tensor using AES-256-GCM.
+
+    Parameters
+    ----------
+    tensor:
+        Tensor to encrypt. It may reside on CPU or GPU. The tensor is moved to
+        CPU for encryption and reconstructed on the original device during
+        decryption.
+    key:
+        32-byte key for AES-256-GCM.
+    """
+    aesgcm = AESGCM(key)
+    nonce = os.urandom(12)
+    cpu_tensor = tensor.detach().to("cpu")
+    buffer = cpu_tensor.numpy().tobytes()
+    ciphertext = aesgcm.encrypt(nonce, buffer, None)
+    return EncryptedTensor(
+        nonce=nonce,
+        ciphertext=ciphertext,
+        shape=tuple(cpu_tensor.shape),
+        dtype=str(cpu_tensor.dtype).replace("torch.", ""),
+        device=str(tensor.device),
+    )
+
+
+def decrypt_tensor(enc: EncryptedTensor, key: bytes, device: Optional[torch.device] = None) -> torch.Tensor:
+    """Decrypt an :class:`EncryptedTensor` back into a tensor."""
+    aesgcm = AESGCM(key)
+    buffer = aesgcm.decrypt(enc.nonce, enc.ciphertext, None)
+    dtype = getattr(torch, enc.dtype)
+    tensor = torch.frombuffer(buffer, dtype=dtype).clone().reshape(enc.shape)
+    target_device = torch.device(device) if device is not None else torch.device(enc.device)
+    return tensor.to(target_device)

--- a/docs/dataset_encryption.md
+++ b/docs/dataset_encryption.md
@@ -1,0 +1,33 @@
+# Dataset Encryption
+
+MARBLE secures datasets using **AES-256-GCM** to protect data at rest and in
+transit. Keys are stored outside the repository and supplied via the
+`DATASET_ENCRYPTION_KEY` environment variable.
+
+## Key Management
+
+- Keys are 256-bit and base64 encoded for transport.
+- Generate a new key with:
+
+  ```python
+  from dataset_encryption import generate_key
+  print(generate_key())
+  ```
+- Store the value in a secure secret manager and expose it at runtime
+  through the `DATASET_ENCRYPTION_KEY` variable.
+
+## Encrypting Tensors
+
+```python
+import torch
+from dataset_encryption import load_key_from_env, encrypt_tensor, decrypt_tensor
+
+key = load_key_from_env()
+original = torch.rand(2, 3, device="cuda" if torch.cuda.is_available() else "cpu")
+enc = encrypt_tensor(original, key)
+restored = decrypt_tensor(enc, key)
+assert torch.allclose(original, restored)
+```
+
+The helper functions automatically move tensors to CPU for encryption and
+restore them to the requested device during decryption.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,3 +18,8 @@ PyTorch Conversion
 ------------------
 
 .. include:: pytorch_conversion.md
+
+Data Security
+-------------
+
+.. include:: dataset_encryption.md

--- a/neuronenblitztodo.md
+++ b/neuronenblitztodo.md
@@ -19,7 +19,7 @@ This document lists 100 concrete ideas for enhancing the `Neuronenblitz` algorit
        - [ ] Document impact on exploration.
            - [ ] Summarize entropy metrics before and after regularization.
            - [ ] Include visualization of policy entropy over training.
-   - [ ] Add temperature parameter to config and docs.
+   - [x] Add temperature parameter to config and docs.
        - [x] Introduce `sac.temperature` in configuration files.
        - [x] Explain parameter in YAML manual and tutorial.
    - [ ] Test wandering with SAC on small environment.

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ colorlog==6.9.0
 comm==0.2.2
 contourpy==1.3.2
 cycler==0.12.1
+cryptography==43.0.1
 dash==3.1.1
 datasets==4.0.0
 decorator==5.2.1


### PR DESCRIPTION
## Summary
- implement `dataset_encryption` module with AES-256-GCM tensor helpers and key management
- document dataset encryption usage and add docs index entry
- detail dataset encryption plan in TODO and mark SAC temperature task complete
- add `cryptography` dependency

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_6898481c787c8327aa8c543661a9aa6a