### PR TITLE
feat: add AES dataset encryption hooks

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -744,12 +744,15 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
        - [x] Choose encryption algorithm and key management strategy.
            - AES-256-GCM via the ``cryptography`` library.
            - Keys supplied as base64 strings in ``DATASET_ENCRYPTION_KEY``.
-       - [ ] Identify integration points within dataset loader and saver.
+       - [x] Identify integration points within dataset loader.
+       - [x] Identify integration points within dataset saver.
        - [x] Determine configuration flags to toggle encryption.
     - [ ] Implement Secure pipeline data flow by integrating dataset encryption routines with CPU/GPU support.
        - [ ] Implement encryption and decryption utilities operating on CPU/GPU tensors.
            - [x] Add AES-GCM tensor encryption helpers in ``dataset_encryption.py``.
-       - [ ] Embed encryption hooks into DataLoader and cache server.
+       - [x] Embed encryption hooks into DataLoader.
+       - [x] Embed encryption hooks into dataset saver.
+       - [ ] Embed encryption hooks into dataset cache server.
        - [x] Expose `dataset.encryption_key` and related options in config files.
    - [ ] Add tests validating Secure pipeline data flow by integrating dataset encryption routines.
        - [ ] Encrypt and decrypt sample datasets verifying integrity.

--- a/docs/dataset_encryption.md
+++ b/docs/dataset_encryption.md
@@ -31,3 +31,23 @@ assert torch.allclose(original, restored)
 
 The helper functions automatically move tensors to CPU for encryption and
 restore them to the requested device during decryption.
+
+## Encrypting Cached Files
+
+Dataset utilities such as :mod:`dataset_loader` can encrypt files on disk
+using the same AES-256-GCM scheme. Pass the base64-encoded key to
+``prefetch_dataset``, ``load_dataset`` or ``export_dataset`` and the resulting
+bytes will be written as encrypted blobs::
+
+```python
+from dataset_encryption import load_key_from_env
+from dataset_loader import prefetch_dataset, wait_for_prefetch, export_dataset
+
+key = load_key_from_env()
+prefetch_dataset("https://example.com/data.csv", encryption_key=key)
+wait_for_prefetch()  # cached file is now encrypted at rest
+export_dataset([(1,2)], "data.csv", encryption_key=key)
+```
+
+Files are transparently decrypted when loading the dataset as long as the same
+key is supplied.


### PR DESCRIPTION
## Summary
- add AES-GCM byte encryption utilities
- secure dataset caching and exporting with optional encryption keys
- document dataset encryption workflow

## Testing
- `python -m py_compile dataset_encryption.py`
- `python -m py_compile dataset_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_68984c3246f88327895463d5d07165d6