### PR TITLE
feat: decrypt cached datasets on server

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -752,12 +752,13 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
            - [x] Add AES-GCM tensor encryption helpers in ``dataset_encryption.py``.
        - [x] Embed encryption hooks into DataLoader.
        - [x] Embed encryption hooks into dataset saver.
-       - [ ] Embed encryption hooks into dataset cache server.
+       - [x] Embed encryption hooks into dataset cache server.
        - [x] Expose `dataset.encryption_key` and related options in config files.
    - [ ] Add tests validating Secure pipeline data flow by integrating dataset encryption routines.
        - [ ] Encrypt and decrypt sample datasets verifying integrity.
        - [ ] Benchmark performance overhead on CPU and GPU.
        - [ ] Confirm failures occur with incorrect or missing keys.
+       - [x] Verify cache server decrypts encrypted files.
    - [ ] Document Secure pipeline data flow by integrating dataset encryption routines in README and TUTORIAL.
        - [ ] Document enabling encryption in config and CLI.
        - [ ] Provide guidance for key management and rotation.

--- a/docs/dataset_encryption.md
+++ b/docs/dataset_encryption.md
@@ -51,3 +51,22 @@ export_dataset([(1,2)], "data.csv", encryption_key=key)
 
 Files are transparently decrypted when loading the dataset as long as the same
 key is supplied.
+
+## Serving Encrypted Datasets
+
+The :class:`DatasetCacheServer` decrypts AES-256-GCM protected files on the fly
+so that clients without direct access to the key can still download plaintext
+datasets. Provide the key explicitly or via the ``DATASET_ENCRYPTION_KEY``
+environment variable when instantiating the server:
+
+```python
+from dataset_cache_server import DatasetCacheServer
+from dataset_encryption import load_key_from_env
+
+key = load_key_from_env()
+server = DatasetCacheServer(encryption_key=key)
+server.start()
+```
+
+Any cached file beginning with ``b"ENC"`` is decrypted before being returned to
+the client. Unencrypted files are served unchanged.

--- a/tests/test_dataset_cache_server.py
+++ b/tests/test_dataset_cache_server.py
@@ -1,0 +1,31 @@
+import socket
+import time
+
+import requests
+
+from dataset_cache_server import DatasetCacheServer
+from dataset_encryption import encrypt_bytes
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def test_dataset_cache_server_decrypts(tmp_path):
+    key = "secret"
+    data = b"hello"
+    enc = b"ENC" + encrypt_bytes(data, key)
+    cache_dir = tmp_path
+    path = cache_dir / "test.bin"
+    path.write_bytes(enc)
+
+    port = _find_free_port()
+    server = DatasetCacheServer(cache_dir=str(cache_dir), encryption_key=key)
+    server.start(port=port)
+    # Give the server a moment to start
+    time.sleep(0.1)
+    resp = requests.get(f"http://127.0.0.1:{port}/test.bin")
+    assert resp.content == data
+    server.stop()


### PR DESCRIPTION
## Summary
- add optional AES-256-GCM decryption to `DatasetCacheServer`
- document serving of encrypted datasets
- test cache server decryption and update TODO

## Testing
- `pre-commit run --files dataset_cache_server.py docs/dataset_encryption.md TODO.md`
- `pre-commit run --files tests/test_dataset_cache_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68984e0532ec832786607c38c002aa54