### PR TITLE
docs: describe dataset encryption usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,36 @@ shards training data:
 - `num_shards` – total number of shards when splitting datasets across workers.
 - `shard_index` – the shard index handled by this process.
 - `offline` – disable remote downloads for fully local operation.
-- `encryption_key` – optional key used to encrypt on-disk dataset caches.
+### Enabling Dataset Encryption
+
+MARBLE secures cached datasets with **AES-256-GCM** so that only authorised
+processes can read them. Generate a 256‑bit key and expose it via the
+`DATASET_ENCRYPTION_KEY` environment variable:
+
+```python
+from dataset_encryption import generate_key
+print(generate_key())
+```
+
+Add the following to `config.yaml` to activate encryption:
+
+```yaml
+dataset:
+  encryption_enabled: true
+  encryption_key: ${DATASET_ENCRYPTION_KEY}
+```
+
+Any CLI entry point, such as `pipeline_cli.py` or `dataset_cache_server.py`,
+uses the key automatically when the environment variable is present. Example:
+
+```bash
+export DATASET_ENCRYPTION_KEY="<base64-key>"
+python pipeline_cli.py --config config.yaml pipeline.json
+```
+
+Rotate keys by generating a new value, re-encrypting cached datasets and
+restarting services with the updated `DATASET_ENCRYPTION_KEY`.
+
 Neuronenblitz can also monitor datasets for changes. Enable
 ``neuronenblitz.auto_update`` in ``config.yaml`` and use ``DatasetWatcher`` to
 reset learning state whenever files within the dataset directory are modified.

--- a/TODO.md
+++ b/TODO.md
@@ -759,9 +759,9 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
        - [ ] Benchmark performance overhead on CPU and GPU.
        - [ ] Confirm failures occur with incorrect or missing keys.
        - [x] Verify cache server decrypts encrypted files.
-   - [ ] Document Secure pipeline data flow by integrating dataset encryption routines in README and TUTORIAL.
-       - [ ] Document enabling encryption in config and CLI.
-       - [ ] Provide guidance for key management and rotation.
+   - [x] Document Secure pipeline data flow by integrating dataset encryption routines in README and TUTORIAL.
+       - [x] Document enabling encryption in config and CLI.
+       - [x] Provide guidance for key management and rotation.
 211. [x] Route memory allocations through the memory pool for every operation.
    - [x] Outline design for Route memory allocations through the memory pool for every operation.
        - Introduce an ``ArrayMemoryPool`` capable of preallocating tensor buffers

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -183,10 +183,35 @@ for row in StreamingCSVLoader("data.csv", tokenizer=tok):
     print(row["input_ids"], row["target"])
 ```
 
-If you set ``dataset.encryption_key`` in ``config.yaml`` the loader encrypts all
-objects before writing them to disk and automatically decrypts them when
-loading. Use the same key on every machine that processes the dataset to handle
-them correctly.
+### Encrypting dataset caches
+
+1. **Generate a key** and store it securely:
+
+   ```python
+   from dataset_encryption import generate_key
+   print(generate_key())
+   ```
+
+2. **Expose the key** via the ``DATASET_ENCRYPTION_KEY`` environment variable.
+
+3. **Enable encryption** in ``config.yaml``:
+
+   ```yaml
+   dataset:
+     encryption_enabled: true
+     encryption_key: ${DATASET_ENCRYPTION_KEY}
+   ```
+
+4. **Run your pipeline** with the variable set so cached files are encrypted at
+   rest and transparently decrypted when the same key is supplied:
+
+   ```bash
+   export DATASET_ENCRYPTION_KEY="<base64-key>"
+   python pipeline_cli.py --config config.yaml pipeline.json
+   ```
+
+Rotate keys by re-encrypting caches with a freshly generated value and updating
+the ``DATASET_ENCRYPTION_KEY`` on every machine that accesses the dataset.
 
 #### Automatically refresh models when datasets change
 


### PR DESCRIPTION
## Summary
- document how to enable AES-256-GCM dataset encryption via YAML and CLI environment variable
- explain key generation and rotation guidance in tutorial and README
- mark dataset encryption documentation tasks as complete in TODO list

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_6898543497388327bb441ad34673849d