### PR TITLE
Add SAC toy environment and tests

### DIFF
--- a/examples/sac_toy_env.py
+++ b/examples/sac_toy_env.py
@@ -1,0 +1,57 @@
+import torch
+
+class SACGridEnv:
+    """Simple 1D grid environment for SAC evaluation.
+
+    The agent starts at position 0 in a linear grid and aims to reach
+    ``grid_size - 1``. Actions ``0`` and ``1`` move left and right
+    respectively. Each step incurs a small negative reward while reaching
+    the goal yields ``+1``. The environment operates on both CPU and GPU
+    depending on the provided device.
+    """
+
+    def __init__(self, grid_size: int = 5, max_steps: int = 20, device: torch.device | None = None) -> None:
+        self.grid_size = grid_size
+        self.max_steps = max_steps
+        self.device = device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.state: torch.Tensor | None = None
+        self.steps = 0
+
+    def reset(self) -> torch.Tensor:
+        """Reset environment to the starting state."""
+        self.state = torch.tensor(0, device=self.device, dtype=torch.int64)
+        self.steps = 0
+        return self._get_observation()
+
+    def _get_observation(self) -> torch.Tensor:
+        obs = torch.zeros(self.grid_size, device=self.device, dtype=torch.float32)
+        obs[int(self.state.item())] = 1.0
+        return obs
+
+    def step(self, action: torch.Tensor | int):
+        """Apply ``action`` and return ``(obs, reward, done, info)``.
+
+        Parameters
+        ----------
+        action: torch.Tensor | int
+            ``0`` moves left, ``1`` moves right. Values outside this range
+            leave the state unchanged.
+        """
+        if isinstance(action, torch.Tensor):
+            action = int(action.item())
+        if action == 1:
+            self.state = torch.clamp(self.state + 1, 0, self.grid_size - 1)
+        elif action == 0:
+            self.state = torch.clamp(self.state - 1, 0, self.grid_size - 1)
+        self.steps += 1
+        done = bool(self.state.item() == self.grid_size - 1 or self.steps >= self.max_steps)
+        reward_value = 1.0 if self.state.item() == self.grid_size - 1 else -0.1
+        reward = torch.tensor(reward_value, device=self.device, dtype=torch.float32)
+        return self._get_observation(), reward, done, {}
+
+    def to(self, device: torch.device) -> "SACGridEnv":
+        """Move environment state to ``device``."""
+        self.device = device
+        if self.state is not None:
+            self.state = self.state.to(device)
+        return self

--- a/neuronenblitztodo.md
+++ b/neuronenblitztodo.md
@@ -27,14 +27,14 @@ This document lists 100 concrete ideas for enhancing the `Neuronenblitz` algorit
        - [x] Introduce `sac.temperature` in configuration files.
        - [x] Explain parameter in YAML manual and tutorial.
    - [ ] Test wandering with SAC on small environment.
-       - [ ] Build minimal environment for SAC evaluation.
-           - [ ] Define state and action spaces for toy environment.
-           - [ ] Implement reward function and termination criteria.
-           - [ ] Write reset and step methods with unit tests.
-       - [ ] Compare performance against baseline wanderer.
-           - [ ] Run baseline wanderer on environment and record metrics.
-           - [ ] Execute SAC-enhanced wanderer and gather same metrics.
-           - [ ] Analyze convergence speed differences.
+      - [x] Build minimal environment for SAC evaluation.
+          - [x] Define state and action spaces for toy environment.
+          - [x] Implement reward function and termination criteria.
+          - [x] Write reset and step methods with unit tests.
+          - [ ] Compare performance against baseline wanderer.
+              - [ ] Run baseline wanderer on environment and record metrics.
+              - [ ] Execute SAC-enhanced wanderer and gather same metrics.
+              - [ ] Analyze convergence speed differences.
 5. Add memory-gated attention to modulate path selection.
    - [ ] Design gating mechanism using episodic memory cues.
        - [ ] Specify features retrieved from episodic memory.

--- a/tests/test_sac_toy_env.py
+++ b/tests/test_sac_toy_env.py
@@ -1,0 +1,27 @@
+import torch
+import pytest
+from examples.sac_toy_env import SACGridEnv
+
+
+def test_sac_grid_env_cpu():
+    env = SACGridEnv(grid_size=3, max_steps=5, device=torch.device("cpu"))
+    state = env.reset()
+    assert state.device.type == "cpu"
+    assert state.sum().item() == 1.0
+    state, reward, done, _ = env.step(torch.tensor(1))
+    assert not done
+    assert reward.item() == pytest.approx(-0.1)
+    state, reward, done, _ = env.step(torch.tensor(1))
+    assert done
+    assert reward.item() == pytest.approx(1.0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_sac_grid_env_gpu():
+    device = torch.device("cuda")
+    env = SACGridEnv(grid_size=3, max_steps=5, device=device)
+    state = env.reset()
+    assert state.device.type == "cuda"
+    state, reward, done, _ = env.step(torch.tensor(1, device=device))
+    assert state.device.type == "cuda"
+    assert reward.device.type == "cuda"


### PR DESCRIPTION
## Summary
- add `SACGridEnv` toy environment supporting CPU/GPU for SAC evaluation
- introduce tests for `SACGridEnv` covering CPU and CUDA paths
- mark SAC environment tasks as complete in neuronenblitz TODO

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_689864ec31f8832784a70f5a8b2266b3