### PR TITLE
Add synthetic dataset helper and parity test

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1599,7 +1599,13 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
                 - [x] Integrate new tests into existing suites.
             - [ ] exampletrain.py
                 - [ ] Create lightweight mock Stable Diffusion pipeline for tests.
-                - [ ] Generate synthetic dataset to avoid large downloads.
+                    - [ ] Implement MockTokenizer returning fixed token IDs.
+                    - [ ] Implement MockTextEncoder producing deterministic embeddings.
+                    - [ ] Assemble MockStableDiffusionPipeline exposing tokenizer and text_encoder.
+                    - [ ] Ensure mock pipeline honours selected device (CPU/GPU).
+                - [x] Generate synthetic dataset to avoid large downloads.
+                    - [x] Provide deterministic data generator for CPU/GPU.
+                    - [x] Cover generator with parity test.
                 - [ ] Write CPU and GPU parity test using mocks.
                 - [ ] Integrate new tests into existing suites.
             - [x] neuronenblitz_kernel.py

--- a/exampletrain_utils.py
+++ b/exampletrain_utils.py
@@ -1,0 +1,63 @@
+"""Utility helpers for ``exampletrain`` tests.
+
+This module provides lightweight fixtures that allow the heavy
+``exampletrain.py`` script to be tested without downloading large
+datasets or initialising the full Stable Diffusion pipeline.  The
+utilities here are intentionally self‑contained and operate entirely on
+CPU or GPU depending on availability so that parity between devices can
+be verified easily.
+
+Currently the module exposes :func:`create_synthetic_dataset` which
+produces a deterministic sequence of input/target pairs.  Each value is
+generated using the supplied random seed so tests can rely on
+reproducible behaviour.  When a CUDA device is available the tensors are
+allocated on that device; otherwise they default to the CPU.  Callers
+can also explicitly select the device.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+import torch
+
+
+def create_synthetic_dataset(
+    num_samples: int = 10,
+    device: Optional[str] = None,
+    seed: int = 0,
+) -> List[Tuple[torch.Tensor, torch.Tensor]]:
+    """Generate a deterministic synthetic dataset.
+
+    Parameters
+    ----------
+    num_samples:
+        Number of ``(input, target)`` pairs to produce.
+    device:
+        The device on which tensors should be allocated.  If ``None`` the
+        function will automatically select ``"cuda"`` when available or
+        fallback to ``"cpu"`` otherwise.
+    seed:
+        Random seed controlling the generated values.
+
+    Returns
+    -------
+    list of tuple of ``torch.Tensor``
+        Each tuple contains an ``input`` tensor and a corresponding
+        ``target`` tensor.  The relationship ``target = 2 * input + 1`` is
+        intentionally simple yet non‑trivial, enabling tests to verify
+        training and inference logic without relying on external
+        resources.
+    """
+
+    actual_device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+    gen = torch.Generator(device=actual_device)
+    gen.manual_seed(seed)
+
+    inputs = torch.rand(num_samples, generator=gen, device=actual_device)
+    targets = 2 * inputs + 1
+
+    return list(zip(inputs, targets))
+
+
+__all__ = ["create_synthetic_dataset"]

--- a/tests/test_exampletrain_utils.py
+++ b/tests/test_exampletrain_utils.py
@@ -1,0 +1,22 @@
+import torch
+
+from exampletrain_utils import create_synthetic_dataset
+
+
+def test_synthetic_dataset_cpu_gpu_parity():
+    """Synthetic dataset should yield identical values on CPU and GPU."""
+
+    cpu_data = create_synthetic_dataset(num_samples=5, device="cpu", seed=123)
+
+    if torch.cuda.is_available():
+        gpu_data = create_synthetic_dataset(num_samples=5, device="cuda", seed=123)
+
+        for (cpu_in, cpu_out), (gpu_in, gpu_out) in zip(cpu_data, gpu_data):
+            assert torch.allclose(cpu_in, gpu_in.cpu())
+            assert torch.allclose(cpu_out, gpu_out.cpu())
+    else:
+        # When CUDA is unavailable ensure the CPU path still returns tensors.
+        assert len(cpu_data) == 5
+        first_in, first_out = cpu_data[0]
+        assert isinstance(first_in, torch.Tensor)
+        assert isinstance(first_out, torch.Tensor)


### PR DESCRIPTION
## Summary
- provide deterministic synthetic dataset generator for exampletrain tests
- add CPU/GPU parity test for synthetic dataset
- expand TODO with detailed subtasks for exampletrain fallback tests

## Testing
- `pre-commit run --files exampletrain_utils.py tests/test_exampletrain_utils.py TODO.md`

------
https://chatgpt.com/codex/tasks/task_e_68986672785c83279ab4d61de3961ab9