### PR TITLE
Add CPU-only CI job and update roadmap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,26 @@ jobs:
           git diff --exit-code unused_config_keys.txt
       - name: Run tests
         run: pytest -n auto
+
+  test-no-cuda:
+    runs-on: ubuntu-latest
+    env:
+      CUDA_VISIBLE_DEVICES: ""
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run pre-commit
+        run: pre-commit run --files $(git diff --name-only HEAD)
+      - name: Check unused config keys
+        run: |
+          python scripts/list_config_keys.py config.yaml --unused --report unused_config_keys.txt
+          git diff --exit-code unused_config_keys.txt
+      - name: Run tests without CUDA
+        run: pytest -n auto

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,17 +22,17 @@ This document outlines upcoming milestones for future Marble releases.
 
 ## v0.2.0 – Planned
 - Streamlined GUI integration across all features
-  - Audit existing GUI components and identify duplication.
-  - Ensure every feature toggles correctly on CPU and GPU.
-  - Add automated tests covering each tab and widget.
+  - [ ] Audit existing GUI components and identify duplication.
+  - [ ] Ensure every feature toggles correctly on CPU and GPU.
+  - [ ] Add automated tests covering each tab and widget.
 - Additional tutorials and educational projects
-  - Curate real-world datasets with download scripts.
-  - Write step-by-step guides with full code listings.
-  - Provide expected results for CPU and GPU runs.
+  - [ ] Curate real-world datasets with download scripts.
+  - [ ] Write step-by-step guides with full code listings.
+  - [ ] Provide expected results for CPU and GPU runs.
 - Extended hardware plugin catalog
-  - Research upcoming accelerators (e.g., TPU, custom ASICs).
-  - Prototype plugin interface for each device with CPU fallback.
-  - Document installation and testing procedures.
+  - [ ] Research upcoming accelerators (e.g., TPU, custom ASICs).
+  - [ ] Prototype plugin interface for each device with CPU fallback.
+  - [ ] Document installation and testing procedures.
 
 Further versions will refine the API and add more tutorials based on
 community feedback.

--- a/TODO.md
+++ b/TODO.md
@@ -1618,8 +1618,8 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
                 - [x] Write parity tests verifying CPU and GPU execution.
                 - [x] Integrate new tests into existing suites.
         - [ ] Create CI job that runs full suite with CUDA disabled.
-            - [ ] Configure workflow to force CPU execution.
-            - [ ] Add job to the CI pipeline definition.
+            - [x] Configure workflow to force CPU execution.
+            - [x] Add job to the CI pipeline definition.
             - [ ] Verify sample run completes without CUDA.
         - [x] Summarize fallback strategy in developer docs.
             - [x] Draft section describing fallback approach.


### PR DESCRIPTION
## Summary
- add CI job running tests with CUDA disabled
- track CPU-only CI progress in TODO
- convert roadmap items into actionable checkboxes

## Testing
- `pre-commit run --files .github/workflows/ci.yml TODO.md ROADMAP.md`

------
https://chatgpt.com/codex/tasks/task_e_68986d1439208327bfece3db9a574ada