### PR TITLE
chore: update CPU fallback report

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1586,7 +1586,7 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
         - [x] Document any GPU-only limitations.
             - [x] Record modules lacking CPU implementation.
             - [x] Update README with limitation notes.
-        - [ ] Add fallback tests for newly introduced modules.
+        - [x] Add fallback tests for newly introduced modules.
             - [x] Catalog modules lacking CPU fallback tests.
                 - [x] Scan repository for modules using CUDA-specific code paths.
                 - [x] Cross-reference existing tests for CPU coverage.
@@ -1621,6 +1621,8 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
             - [x] Configure workflow to force CPU execution.
             - [x] Add job to the CI pipeline definition.
             - [ ] Verify sample run completes without CUDA.
+                - [ ] Run the CI job without CUDA and ensure all tests pass.
+                - [ ] Record results in cpu_fallback_report.md.
         - [x] Summarize fallback strategy in developer docs.
             - [x] Draft section describing fallback approach.
             - [x] Enumerate modules with verified fallbacks.

--- a/cpu_fallback_report.md
+++ b/cpu_fallback_report.md
@@ -1,5 +1,3 @@
 # Modules lacking CPU fallback tests
 
-- `benchmark_graph_precompile.py`
-- `neuronenblitz_kernel.py`
-- `run_profiler.py`
+Currently all modules have CPU fallback tests in place. No outstanding modules require additional coverage.


### PR DESCRIPTION
## Summary
- mark fallback test coverage for new modules complete
- note pending CI verification subtasks and update CPU fallback report

## Testing
- `pre-commit run --files cpu_fallback_report.md TODO.md`


------
https://chatgpt.com/codex/tasks/task_e_68987a6884f48327b58d0bdaf278d9bc