### PR TITLE
Add CPU-only test runner script

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1621,8 +1621,9 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
             - [x] Configure workflow to force CPU execution.
             - [x] Add job to the CI pipeline definition.
             - [ ] Verify sample run completes without CUDA.
-                - [ ] Run the CI job without CUDA and ensure all tests pass.
-                - [ ] Record results in cpu_fallback_report.md.
+                - [x] Implement standalone script `scripts/run_cpu_fallback_tests.py` to run each test with CUDA disabled.
+                - [ ] Execute the script locally and ensure all tests pass.
+                - [ ] Record results in `cpu_fallback_report.md`.
         - [x] Summarize fallback strategy in developer docs.
             - [x] Draft section describing fallback approach.
             - [x] Enumerate modules with verified fallbacks.

--- a/cpu_fallback_report.md
+++ b/cpu_fallback_report.md
@@ -1,3 +1,7 @@
 # Modules lacking CPU fallback tests
 
 Currently all modules have CPU fallback tests in place. No outstanding modules require additional coverage.
+
+## CPU-only test execution
+
+The repository now includes `scripts/run_cpu_fallback_tests.py`, which runs each test module with `CUDA_VISIBLE_DEVICES` cleared so that execution occurs strictly on the CPU.  After running this script, append a summary of the results below to track ongoing verification runs.

--- a/scripts/run_cpu_fallback_tests.py
+++ b/scripts/run_cpu_fallback_tests.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def discover_test_files(root: Path) -> list[Path]:
+    """Collect all pytest files under the tests directory."""
+    tests_dir = root / "tests"
+    return sorted(p for p in tests_dir.rglob("test_*.py"))
+
+
+def run_tests_cpu_only(test_files: list[Path]) -> int:
+    """Run each test file with CUDA disabled. Returns number of failures."""
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = ""
+    failures: list[str] = []
+    for test in test_files:
+        print(f"Running {test} with CUDA disabled", flush=True)
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", str(test)], env=env
+        )
+        if result.returncode != 0:
+            failures.append(str(test))
+    if failures:
+        print("Failed tests:")
+        for f in failures:
+            print(f" - {f}")
+    else:
+        print("All tests passed without CUDA.")
+    return len(failures)
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    tests = discover_test_files(repo_root)
+    failures = run_tests_cpu_only(tests)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `run_cpu_fallback_tests.py` to execute each test file with CUDA disabled
- document the new runner in `cpu_fallback_report.md`
- refine TODO steps for CPU fallback verification

## Testing
- `python -m py_compile scripts/run_cpu_fallback_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68987f631ee48327a0dfac1251e8761a