### PR TITLE
Track plasticity event history in Neuronenblitz

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -228,6 +228,8 @@ Each entry is listed under its section heading.
 - wander_cache_ttl
 - wander_anomaly_threshold
 - wander_history_size
+- plasticity_history_size: Number of recent structural plasticity events stored
+  in ``Neuronenblitz.plasticity_history`` for meta-learning analysis.
 - phase_rate
 - phase_adaptation_rate
 - synaptic_fatigue_enabled

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2075,6 +2075,11 @@ Run `python project23_omni.py` to test all paradigms together.
    see how each context feature influenced the chosen weights. The method
    returns the original context and weights along with gradient-based
    contributions for every learner.
+   To review how often structural changes occur, set
+   `neuronenblitz.plasticity_history_size` in `config.yaml`. Neuronenblitz
+   records up to this many recent plasticity events—including source and target
+   neurons, new neuron IDs and triggering synapse potentials—in
+   `nb.plasticity_history` for later analysis or meta-learning strategies.
 
 ## Project 24 – Continuous Weight Field Learning (Experimental)
 

--- a/config.yaml
+++ b/config.yaml
@@ -237,6 +237,7 @@ neuronenblitz:
   wander_cache_ttl: 300
   wander_anomaly_threshold: 3.0
   wander_history_size: 100
+  plasticity_history_size: 100
   phase_rate: 0.1
   phase_adaptation_rate: 0.05
   synaptic_fatigue_enabled: true

--- a/neuronenblitztodo.md
+++ b/neuronenblitztodo.md
@@ -50,9 +50,9 @@ This document lists 100 concrete ideas for enhancing the `Neuronenblitz` algorit
        - [ ] Report effects on path diversity and accuracy.
 6. Use episodic memory to bias wandering toward past successes. (Completed with episodic replay bias)
 7. Apply meta-learning to adjust plasticity thresholds dynamically.
-   - [ ] Record plasticity outcomes over recent steps.
-       - [ ] Log success metrics for each plasticity event.
-       - [ ] Maintain rolling history buffer.
+   - [x] Record plasticity outcomes over recent steps.
+       - [x] Log success metrics for each plasticity event.
+       - [x] Maintain rolling history buffer.
    - [ ] Train meta-learner to propose threshold updates.
        - [ ] Choose lightweight model for meta-learning.
        - [ ] Fit model on recorded outcomes to predict new thresholds.

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -673,6 +673,12 @@ neuronenblitz:
   wander_history_size: How many recent path lengths are kept to compute the
     running mean and standard deviation for anomaly detection. Larger values
     smooth out short-term fluctuations.
+  plasticity_history_size: Number of recent structural plasticity events
+    retained in ``Neuronenblitz.plasticity_history``. Each event captures the
+    source and target neurons, the newly created neuron, and the synapse
+    potential that triggered the change. Increasing this value provides more
+    context for meta-learning algorithms that adapt ``plasticity_threshold``
+    but consumes additional memory. Typical range is 50–500; default ``100``.
   phase_rate: Amount added to ``global_phase`` each time ``dynamic_wander``
     runs. Higher values make the oscillator advance more quickly, altering
     the cosine gating applied to every synapse.


### PR DESCRIPTION
## Summary
- add `plasticity_history_size` option for Neuronenblitz
- log structural plasticity events with timestamp and synapse potential
- document new configuration and update TODO

## Testing
- `pre-commit run --files marble_neuronenblitz/core.py config.yaml CONFIGURABLE_PARAMETERS.md yaml-manual.txt TUTORIAL.md neuronenblitztodo.md`

------
https://chatgpt.com/codex/tasks/task_e_689885bcbf188327b0f108de505bb818