### PR TITLE
Add configurable meta-learning defaults

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -374,6 +374,10 @@ Each entry is listed under its section heading.
 - min_threshold
 - max_threshold
 
+## meta
+- rate
+- window
+
 ## neuromodulatory_system.initial
 - arousal
 - stress

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -2620,7 +2620,10 @@ re-executes from that point, preserving the previous computation.
 28. **Tweak adaptive controllers** on the *Adaptive Control* tab. Inspect the
     meta-controller's loss history and adjust its parameters, review super
     evolution metrics and apply dimensional search or n-dimensional topology
-    evaluations with a single click.
+    evaluations with a single click. Global defaults for the controller live in
+    the ``meta`` section of ``config.yaml`` where ``rate`` controls how strongly
+    thresholds are adjusted and ``window`` defines how many recent losses are
+    considered.
 29. **Manage hybrid memory** on the *Hybrid Memory* tab. Initialize the vector
     and symbolic stores, add new key/value pairs, query for similar entries and
     prune older items without leaving the UI.

--- a/config.yaml
+++ b/config.yaml
@@ -391,6 +391,9 @@ lobe_manager:
   attention_decrease_factor: 0.95
 formula: "log(1+T)/log(1+I)"
 formula_num_neurons: 100
+meta:
+  rate: 0.5            # Step size for meta-learning adjustments
+  window: 5            # Number of recent outcomes considered by the meta-learner
 meta_controller:
   history_length: 5
   adjustment: 0.5

--- a/config_loader.py
+++ b/config_loader.py
@@ -41,6 +41,9 @@ def load_config(path: str | None = None) -> dict:
     validate_config_schema(data)
     nb = data.setdefault("neuronenblitz", {})
     nb.setdefault("attention", {}).setdefault("dynamic_span", False)
+    meta = data.setdefault("meta", {})
+    meta.setdefault("rate", 0.5)
+    meta.setdefault("window", 5)
     return data
 
 
@@ -122,10 +125,11 @@ def create_marble_from_config(
     formula_num_neurons = cfg.get("formula_num_neurons", 100)
 
     # Meta-parameter controller
+    meta_defaults = cfg.get("meta", {})
     mc_cfg = cfg.get("meta_controller", {})
     meta_controller = MetaParameterController(
-        history_length=mc_cfg.get("history_length", 5),
-        adjustment=mc_cfg.get("adjustment", 0.5),
+        history_length=mc_cfg.get("history_length", meta_defaults.get("window", 5)),
+        adjustment=mc_cfg.get("adjustment", meta_defaults.get("rate", 0.5)),
         min_threshold=mc_cfg.get("min_threshold", 1.0),
         max_threshold=mc_cfg.get("max_threshold", 20.0),
     )

--- a/neuronenblitztodo.md
+++ b/neuronenblitztodo.md
@@ -56,9 +56,9 @@ This document lists 100 concrete ideas for enhancing the `Neuronenblitz` algorit
    - [ ] Train meta-learner to propose threshold updates.
        - [ ] Choose lightweight model for meta-learning.
        - [ ] Fit model on recorded outcomes to predict new thresholds.
-   - [ ] Add config options for meta-learning rate and window size.
-       - [ ] Introduce parameters `meta.rate` and `meta.window`.
-       - [ ] Document recommended ranges and defaults.
+   - [x] Add config options for meta-learning rate and window size.
+       - [x] Introduce parameters `meta.rate` and `meta.window`.
+       - [x] Document recommended ranges and defaults.
    - [ ] Add tests verifying threshold adapts.
        - [ ] Simulate scenarios where thresholds should change.
        - [ ] Assert meta-learner adjusts values accordingly.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,6 +40,8 @@ def test_load_config_defaults():
     assert cfg["core"]["interconnection_prob"] == 0.05
     assert cfg["brain"]["save_threshold"] == 0.05
     assert cfg["meta_controller"]["history_length"] == 5
+    assert cfg["meta"]["rate"] == 0.5
+    assert cfg["meta"]["window"] == 5
     assert cfg["neuromodulatory_system"]["initial"]["emotion"] == "neutral"
     assert cfg["network"]["remote_client"]["url"] == "http://localhost:8001"
     assert cfg["network"]["remote_client"]["timeout"] == 5.0
@@ -120,6 +122,7 @@ def test_create_marble_from_config():
     marble = create_marble_from_config()
     assert isinstance(marble, MARBLE)
     assert marble.brain.meta_controller.history_length == 5
+    assert marble.brain.meta_controller.adjustment == 0.5
     assert isinstance(marble.brain.remote_client, RemoteBrainClient)
     assert isinstance(marble.brain.torrent_client, BrainTorrentClient)
     assert marble.brain.neurogenesis_factor == 1.0
@@ -220,6 +223,18 @@ def test_new_nb_parameters_configurable(tmp_path):
     assert marble.neuronenblitz._cache_max_size == 7
     assert marble.neuronenblitz._rmsprop_beta == 0.8
     assert marble.neuronenblitz._grad_epsilon == 1e-6
+
+
+def test_meta_section_overrides_meta_controller(tmp_path):
+    cfg = load_config()
+    cfg.setdefault("meta", {})["rate"] = 0.2
+    cfg["meta"]["window"] = 7
+    cfg_path = tmp_path / "meta.yaml"
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(cfg, f)
+    marble = create_marble_from_config(str(cfg_path))
+    assert marble.brain.meta_controller.adjustment == 0.2
+    assert marble.brain.meta_controller.history_length == 7
 
 
 def test_global_workspace_config(tmp_path):

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -1052,6 +1052,17 @@ formula: Mathematical expression used to compute initial neuron values instead
   of the Mandelbrot seed. If omitted the Mandelbrot algorithm is used.
 formula_num_neurons: Number of neurons created when ``formula`` is provided.
 
+meta:
+  # Global meta-learning settings influencing how the meta-learner adapts
+  # plasticity thresholds. These serve as defaults for ``meta_controller``
+  # unless that section overrides them.
+  rate: Step size applied whenever the meta-learner adjusts the threshold.
+    Higher values react quickly but may cause oscillations. Typical range
+    is ``0.1``–``1.0``.
+  window: Number of recent loss values considered when computing
+    adjustments. Larger windows smooth out noise but slow adaptation.
+    Values between ``3`` and ``20`` are common.
+
 meta_controller:
   # The meta-controller monitors validation losses and adjusts
   # ``neuronenblitz.plasticity_threshold`` accordingly. If losses rise the


### PR DESCRIPTION
## Summary
- Introduce global `meta.rate` and `meta.window` settings to tune meta-learning behaviour
- Use new `meta` defaults when instantiating the MetaParameterController
- Document meta-learning parameters across manual, tutorial, and config lists
- Expand configuration tests covering new meta settings

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68988f36bd388327b2bdd10269bedae5