### PR TITLE
Add episodic memory gated attention

### DIFF
--- a/neuronenblitztodo.md
+++ b/neuronenblitztodo.md
@@ -36,12 +36,12 @@ This document lists 100 concrete ideas for enhancing the `Neuronenblitz` algorit
               - [x] Execute SAC-enhanced wanderer and gather same metrics.
               - [x] Analyze convergence speed differences.
 5. Add memory-gated attention to modulate path selection.
-   - [ ] Design gating mechanism using episodic memory cues.
-       - [ ] Specify features retrieved from episodic memory.
-       - [ ] Formulate gating equation blending memory and context.
-   - [ ] Inject gating weights into attention calculations.
-       - [ ] Modify attention module to accept gate values.
-       - [ ] Ensure gradients propagate through gating path.
+   - [x] Design gating mechanism using episodic memory cues.
+       - [x] Specify features retrieved from episodic memory (reward values).
+       - [x] Formulate gating equation blending memory and context via tanh-normalised reward.
+   - [x] Inject gating weights into attention calculations.
+       - [x] Modify attention module to accept gate values.
+       - [x] Ensure gradients propagate through gating path.
     - [x] Expose gate strength hyperparameter in config.
         - [x] Add `memory.gate_strength` to configs and docs.
         - [x] Provide reasonable default and tuning guidance.

--- a/tests/test_memory_gated_attention.py
+++ b/tests/test_memory_gated_attention.py
@@ -1,0 +1,26 @@
+import torch
+import pytest
+
+from attention_utils import GatingLayer
+from episodic_memory import EpisodicMemory
+
+devices = ["cpu"]
+if torch.cuda.is_available():
+    devices.append("cuda")
+
+
+@pytest.mark.parametrize("device", devices)
+def test_memory_gating_uses_reward(device: str) -> None:
+    memory = EpisodicMemory()
+    memory.add_episode({"task": "x"}, reward=2.0, outcome=None)
+    layer = GatingLayer(mode="memory").to(device)
+    gate = layer(
+        4,
+        device=torch.device(device),
+        memory=memory,
+        context={"task": "x"},
+    )
+    expected = torch.full(
+        (4,), torch.tanh(torch.tensor(2.0)), device=device, dtype=torch.float32
+    )
+    assert torch.allclose(gate, expected)


### PR DESCRIPTION
## Summary
- extend attention utilities with memory-based gating driven by episodic rewards
- allow ContextAwareAttention to supply episodic memory and context for gating
- document memory-gated attention progress and add coverage test

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_689896d1a6e88327b2453ba56844dd77