### PR TITLE
Add Iris dataset download script

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,6 +27,9 @@ This document outlines upcoming milestones for future Marble releases.
   - [ ] Add automated tests covering each tab and widget.
 - Additional tutorials and educational projects
   - [ ] Curate real-world datasets with download scripts.
+    - [x] Add script to download the Iris dataset.
+    - [ ] Add script to download the CIFAR-10 dataset.
+    - [ ] Add script to download the IMDB sentiment dataset.
   - [ ] Write step-by-step guides with full code listings.
   - [ ] Provide expected results for CPU and GPU runs.
     - [x] Project 2 – Image Classification.

--- a/scripts/download_iris.py
+++ b/scripts/download_iris.py
@@ -1,0 +1,36 @@
+"""Download the Iris dataset and save as CSV.
+
+This script fetches the Iris dataset from OpenML using scikit-learn and
+stores it under the provided output path. The dataset is small and the
+operation is identical on CPU or GPU systems.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from sklearn.datasets import fetch_openml
+
+
+def download_iris(output: Path) -> None:
+    """Fetch the Iris dataset and write it to ``output`` as CSV."""
+    data = fetch_openml("iris", version=1, as_frame=True)
+    df = data.frame
+    output.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(output, index=False)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download the Iris dataset")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data/iris.csv"),
+        help="Destination file for the CSV output",
+    )
+    args = parser.parse_args()
+    download_iris(args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- break down roadmap tasks for dataset downloads and mark Iris script as completed
- add `download_iris.py` utility to fetch the Iris dataset as CSV

## Testing
- `python scripts/download_iris.py --output data/iris.csv` *(fails: Remote end closed connection without response)*

------
https://chatgpt.com/codex/tasks/task_e_68989a6706608327a701963ec6aad4e4