### PR TITLE
Add custom converter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1453,6 +1453,9 @@ def convert_my_layer(layer, core, inputs):
 Any occurrence of `MyCustomLayer` in the PyTorch model will be converted using
 the provided function.
 
+For a full working script showcasing a custom converter on CPU or GPU, see
+`examples/custom_converter_example.py`.
+
 ## Workflow Templates
 
 Starter pipelines for common workflows can be generated with

--- a/converttodo.md
+++ b/converttodo.md
@@ -314,14 +314,14 @@
       - [x] Document usage for runtime evaluators.
       - [x] Add tests verifying flag presence.
 - [ ] torch.fx integration for arbitrary models
-  - [ ] Trace custom layers and call registered converters
-      - [ ] Extend tracing logic to capture user-defined layers.
-      - [ ] Look up converters via registry and invoke them.
-      - [ ] Raise descriptive errors when converters are missing.
-  - [ ] Allow decorators to register new converters
-      - [ ] Design decorator API for converter registration.
-      - [ ] Register decorated functions at import time.
-      - [ ] Provide examples demonstrating decorator usage.
+  - [x] Trace custom layers and call registered converters
+      - [x] Extend tracing logic to capture user-defined layers.
+      - [x] Look up converters via registry and invoke them.
+      - [x] Raise descriptive errors when converters are missing.
+  - [x] Allow decorators to register new converters
+      - [x] Design decorator API for converter registration.
+      - [x] Register decorated functions at import time.
+      - [x] Provide examples demonstrating decorator usage.
 - [ ] Weight and bias extraction helpers
   - [x] Handle GPU tensors transparently
       - [x] Detect tensor device during extraction.

--- a/docs/pytorch_conversion.md
+++ b/docs/pytorch_conversion.md
@@ -29,6 +29,13 @@ from pytorch_to_marble import unsupported_layer
 unsupported_layer(torch.nn.MaxPool3d)
 ```
 
+A complete working example demonstrating how to register and use a custom
+converter can be found in
+``examples/custom_converter_example.py``.  The script defines a
+``DoubleLinear`` module, registers a converter with
+``@register_converter`` and converts the model on CPU or GPU depending on
+availability.
+
 When ``convert_model`` encounters ``MaxPool3d`` it will now immediately raise a
 clear error indicating the layer is not supported. This makes gaps in converter
 coverage visible while providing guidance for future contributors.

--- a/examples/custom_converter_example.py
+++ b/examples/custom_converter_example.py
@@ -1,0 +1,55 @@
+import os
+import sys
+
+import torch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from pytorch_to_marble import convert_model, register_converter, LAYER_CONVERTERS
+
+
+class DoubleLinear(torch.nn.Module):
+    """Linear layer followed by a fixed scaling factor of 2."""
+
+    def __init__(self, in_features: int, out_features: int) -> None:
+        super().__init__()
+        self.fc = torch.nn.Linear(in_features, out_features)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - example script
+        return self.fc(x) * 2.0
+
+
+@register_converter(DoubleLinear)
+def convert_double_linear(layer: DoubleLinear, core, inputs):
+    """Convert :class:`DoubleLinear` into MARBLE neurons."""
+    out_ids = LAYER_CONVERTERS[torch.nn.Linear](layer.fc, core, inputs)
+    for nid in out_ids:
+        for syn in core.neurons[nid].synapses:
+            syn.weight *= 2.0
+    return out_ids
+
+
+class WrapperModel(torch.nn.Module):
+    """Model that uses the custom :class:`DoubleLinear` layer."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.double_layer = DoubleLinear(4, 3)
+        self.input_size = 4
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - example script
+        return self.double_layer(x)
+
+
+def main() -> None:  # pragma: no cover - example script
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = WrapperModel().to(device)
+    sample = torch.randn(1, 4, device=device)
+    traced_out = model(sample)
+    core = convert_model(model)
+    print("PyTorch output:", traced_out.cpu().tolist())
+    print("Converted neurons:", len(core.neurons))
+    print("Converted synapses:", len(core.synapses))
+
+
+if __name__ == "__main__":  # pragma: no cover - example script
+    main()


### PR DESCRIPTION
## Summary
- add `examples/custom_converter_example.py` demonstrating a registered converter
- document custom converter example in README and docs
- mark related tasks complete in `converttodo.md`

## Testing
- `python examples/custom_converter_example.py`

------
https://chatgpt.com/codex/tasks/task_e_68989fae5ba8832787cfceed787b25ad