### PR TITLE
docs: dynamic span tutorial and todo updates

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1647,6 +1647,8 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
             - [x] Integrate script into CI pipeline.
         - [ ] Implement missing parameters or prune outdated ones.
             - [ ] For each unused parameter, decide to implement or remove.
+                - [ ] neuronenblitz.attention_span_threshold
+                - [ ] neuronenblitz.max_attention_span
             - [ ] Add tests verifying newly implemented parameters on CPU and GPU.
             - [ ] Remove deprecated parameters and update defaults.
             - [ ] Update documentation in `CONFIGURABLE_PARAMETERS.md` and `yaml-manual.txt`.
@@ -1683,6 +1685,6 @@ This TODO list outlines 100 enhancements spanning the Marble framework, the unde
         - [ ] Benchmark and test span behavior on CPU and GPU.
             - [x] Create unit tests for varying span lengths.
             - [ ] Measure performance impact on both devices.
-            - [ ] Add tutorial section demonstrating span tuning.
+            - [x] Add tutorial section demonstrating span tuning.
             - [ ] Profile memory usage across span settings.
             - [x] Add regression test ensuring default span matches static mode.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -3913,3 +3913,53 @@ This project demonstrates how domain-specific validation logic can directly infl
    - CUDA out of memory: switch to the CPU command or reduce the training epochs.
 
 This project demonstrates how a teacher network can guide a smaller student, allowing compact models to inherit behaviour from more capable ones.
+
+## Project 102 – Dynamic Attention Span Tuning
+
+**Goal:** Explore how varying `max_attention_span` and `attention_span_threshold` alters Neuronenblitz's focus during training on a real dataset.
+
+1. **Download the dataset** – the Pima Indians Diabetes dataset contains medical measurements and is suitable for quick experiments:
+
+   ```bash
+   wget https://raw.githubusercontent.com/jbrownlee/Datasets/master/pima-indians-diabetes.data.csv -O diabetes.csv
+   ```
+
+2. **Prepare the training pairs** – use two of the numeric fields as inputs:
+
+   ```python
+   import pandas as pd
+   from marble_core import Core
+   from marble_neuronenblitz import Neuronenblitz
+   from tests.test_core_functions import minimal_params
+
+   df = pd.read_csv("diabetes.csv", header=None)
+   # Use glucose concentration (column 1) and age (column 7)
+   pairs = list(zip(df[1].tolist(), df[7].tolist()))
+   core = Core(minimal_params())
+   ```
+
+3. **Train with dynamic attention span** – start with a moderate threshold:
+
+   ```python
+   nb = Neuronenblitz(core, max_attention_span=5, attention_span_threshold=0.7)
+   nb.train(pairs, epochs=3)
+   ```
+
+4. **Tune the span** – lower the threshold to keep more context and observe any accuracy change:
+
+   ```python
+   nb = Neuronenblitz(core, max_attention_span=5, attention_span_threshold=0.4)
+   nb.train(pairs, epochs=3)
+   ```
+
+5. **Run on CPU or GPU** – the example automatically chooses the available device:
+
+   ```bash
+   # CPU execution
+   CUDA_VISIBLE_DEVICES="" python your_script.py
+
+   # GPU execution
+   python your_script.py
+   ```
+
+This project illustrates how span parameters influence the amount of history considered during Neuronenblitz updates. Experiment with different values to balance speed and accuracy.


### PR DESCRIPTION
## Summary
- add Project 102 demonstrating dynamic attention span tuning with Pima Indians dataset
- split config audit task into parameter-specific subtasks and mark span tutorial complete

## Testing
- no tests run (QUICKMODE)

------
https://chatgpt.com/codex/tasks/task_e_6898d2d8a2608327b1f66fcd279cc864