### PR TITLE
Use serve_model defaults from configuration

### DIFF
--- a/pipeline_plugins.py
+++ b/pipeline_plugins.py
@@ -189,7 +189,7 @@ class ServeModelPlugin(PipelinePlugin):
         from config_loader import load_config
 
         cfg = load_config()
-        defaults = cfg.get("mcp_server", {})
+        defaults = cfg.get("serve_model", {})
         host = host if host is not None else defaults.get("host", "localhost")
         port = port if port is not None else defaults.get("port", 5080)
         super().__init__(host=host, port=port)

--- a/unused_config_keys.txt
+++ b/unused_config_keys.txt
@@ -513,8 +513,6 @@ semi_supervised_learning.batch_size
 semi_supervised_learning.enabled
 semi_supervised_learning.epochs
 semi_supervised_learning.unlabeled_weight
-serve_model.host
-serve_model.port
 synaptic_echo_learning.echo_influence
 synaptic_echo_learning.enabled
 synaptic_echo_learning.epochs


### PR DESCRIPTION
## Summary
- Make `ServeModelPlugin` read default host and port from the `serve_model` section of the configuration
- Remove `serve_model.host` and `serve_model.port` from the list of unused configuration keys

## Testing
- `pytest tests/test_serve_model_plugin.py`
- `pytest tests/test_mcp_serve_model_plugin.py`


------
https://chatgpt.com/codex/tasks/task_e_6898d8abab008327902c634b4040be01