### PR TITLE
Implement configurable clustering interval

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -3963,3 +3963,32 @@ This project demonstrates how a teacher network can guide a smaller student, all
    ```
 
 This project illustrates how span parameters influence the amount of history considered during Neuronenblitz updates. Experiment with different values to balance speed and accuracy.
+
+## Project: Control clustering frequency
+
+This short project demonstrates how the ``brain.auto_cluster_interval`` setting controls how often MARBLE reorganises neurons into clusters.
+
+1. **Download a dataset** – use Fashion-MNIST for a quick test.
+
+   ```python
+   from torchvision.datasets import FashionMNIST
+   train = FashionMNIST(root="data", download=True, train=True)
+   pairs = [(img.flatten().float(), img.flatten().float()) for img, _ in train[:100]]
+   ```
+
+2. **Configure the clustering interval** – set ``auto_cluster_interval`` to ``3`` in a YAML file so clustering happens every three epochs.
+
+   ```yaml
+   brain:
+     auto_cluster_interval: 3
+   ```
+
+3. **Train and observe** – create a MARBLE instance with this configuration and train for a few epochs. Clustering will run twice during five epochs.
+
+   ```python
+   from config_loader import create_marble_from_config
+   m = create_marble_from_config("config.yaml")
+   m.get_brain().train(pairs, epochs=5)
+   ```
+
+This experiment highlights how reducing clustering frequency can speed up training while still periodically reorganising neuron topology.

--- a/marble_brain.py
+++ b/marble_brain.py
@@ -595,12 +595,13 @@ class Brain:
                     target_tier=new_tier,
                 )
                 self.perform_neurogenesis(use_combined_attention=True)
-            min_k = int(self.core.params.get("min_cluster_k", 1))
-            self.core.cluster_neurons(k=max(self.cluster_k, min_k))
-            self.core.relocate_clusters(
-                high=self.cluster_high_threshold,
-                medium=self.cluster_medium_threshold,
-            )
+            if self.auto_cluster_interval > 0 and (epoch + 1) % self.auto_cluster_interval == 0:
+                min_k = int(self.core.params.get("min_cluster_k", 1))
+                self.core.cluster_neurons(k=max(self.cluster_k, min_k))
+                self.core.relocate_clusters(
+                    high=self.cluster_high_threshold,
+                    medium=self.cluster_medium_threshold,
+                )
             self.lobe_manager.organize()
             self.lobe_manager.self_attention(val_loss)
             if self.offload_enabled:

--- a/streamlit_playground.py
+++ b/streamlit_playground.py
@@ -1631,7 +1631,8 @@ def run_playground() -> None:
             unsafe_allow_html=True,
         )
     st.title("MARBLE Playground")
-
+    import marble_interface as _mi
+    _mi.new_marble_system = new_marble_system
     if st.button("About"):
         if hasattr(st, "dialog"):
             with st.dialog("About MARBLE"):
@@ -1658,7 +1659,7 @@ def run_playground() -> None:
     )
     cfg_text = st.sidebar.text_area("Or paste YAML", key="cfg_text")
     inst_name = st.sidebar.text_input("Instance Name", value=registry.active or "main")
-    if st.sidebar.button("Create Instance"):
+    if st.sidebar.button("Create Instance", key="create_instance"):
         yaml_data = None
         if cfg_upload is not None:
             yaml_data = cfg_upload.getvalue().decode("utf-8")
@@ -1667,12 +1668,15 @@ def run_playground() -> None:
         else:
             with open(cfg_path, "r", encoding="utf-8") as f:
                 yaml_data = f.read()
-        marble = registry.create(
-            inst_name, cfg_path if not yaml_data else None, yaml_text=yaml_data
-        )
-        st.session_state["marble"] = marble
-        st.session_state["config_yaml"] = yaml_data
-        st.sidebar.success(f"Instance '{inst_name}' created")
+        try:
+            marble = registry.create(
+                inst_name, cfg_path if not yaml_data else None, yaml_text=yaml_data
+            )
+            st.session_state["marble"] = marble
+            st.session_state["config_yaml"] = yaml_data
+            st.sidebar.success(f"Instance '{inst_name}' created")
+        except Exception as exc:  # pragma: no cover - runtime safety
+            st.sidebar.error(f"Instance creation failed: {exc}")
 
     if registry.list():
         active = st.sidebar.selectbox(

--- a/tests/test_pretraining_and_clustering.py
+++ b/tests/test_pretraining_and_clustering.py
@@ -19,12 +19,14 @@ class DummyCore:
         self.params = {"pretraining_epochs": pre_epochs, "min_cluster_k": min_k}
         self.neurons = []
         self.synapses = []
+        self.cluster_calls = 0
 
     def get_usage_by_tier(self, tier):
         return 0.0
 
     def cluster_neurons(self, k):
         self.cluster_called_with = k
+        self.cluster_calls += 1
 
     def relocate_clusters(self, high, medium):
         pass
@@ -58,6 +60,29 @@ def test_pretraining_epochs_runs_once():
 def test_min_cluster_k_enforced():
     core = DummyCore(min_k=3)
     nb = DummyNB()
-    brain = Brain(core, nb, None, metrics_visualizer=None, dream_enabled=False, cluster_k=2)
+    brain = Brain(
+        core,
+        nb,
+        None,
+        metrics_visualizer=None,
+        dream_enabled=False,
+        cluster_k=2,
+        auto_cluster_interval=1,
+    )
     brain.train([(0.1, 0.2)], epochs=1)
     assert core.cluster_called_with == 3
+
+
+def test_auto_cluster_interval_respected():
+    core = DummyCore()
+    nb = DummyNB()
+    brain = Brain(
+        core,
+        nb,
+        None,
+        metrics_visualizer=None,
+        dream_enabled=False,
+        auto_cluster_interval=2,
+    )
+    brain.train([(0.1, 0.2)], epochs=5)
+    assert core.cluster_calls == 2

--- a/unused_config_keys.txt
+++ b/unused_config_keys.txt
@@ -12,7 +12,6 @@ autoencoder_learning.noise_std
 autograd.enabled
 autograd.gradient_accumulation_steps
 autograd.learning_rate
-brain.auto_cluster_interval
 brain.auto_firing_enabled
 brain.auto_neurogenesis_prob
 brain.auto_offload
@@ -212,6 +211,7 @@ dataloader.tokenizer_type
 dataloader.tokenizer_vocab_size
 dataloader.track_metadata
 dataset.cache_url
+dataset.encryption_enabled
 dataset.encryption_key
 dataset.kuzu_graph
 dataset.kuzu_graph.db_path
@@ -300,10 +300,13 @@ mcp_server.port
 memory_system.consolidation_interval
 memory_system.long_term_path
 memory_system.threshold
+meta.rate
+meta.window
 meta_controller.adjustment
 meta_controller.history_length
 meta_controller.max_threshold
 meta_controller.min_threshold
+meta_learning
 meta_learning.distill_alpha
 meta_learning.enabled
 meta_learning.epochs
@@ -369,6 +372,8 @@ neuromodulatory_system.initial.reward
 neuromodulatory_system.initial.stress
 neuronenblitz.activity_gate_exponent
 neuronenblitz.alternative_connection_prob
+neuronenblitz.attention
+neuronenblitz.attention.dynamic_span
 neuronenblitz.attention_decay
 neuronenblitz.attention_span_threshold
 neuronenblitz.attention_update_scale
@@ -421,6 +426,7 @@ neuronenblitz.max_attention_span
 neuronenblitz.max_learning_rate
 neuronenblitz.max_wander_depth
 neuronenblitz.memory_gate_decay
+neuronenblitz.memory_gate_strength
 neuronenblitz.merge_tolerance
 neuronenblitz.min_learning_rate
 neuronenblitz.momentum_coefficient
@@ -431,6 +437,7 @@ neuronenblitz.parallel_update_strategy
 neuronenblitz.parallel_wanderers
 neuronenblitz.phase_adaptation_rate
 neuronenblitz.phase_rate
+neuronenblitz.plasticity_history_size
 neuronenblitz.plasticity_modulation
 neuronenblitz.plasticity_threshold
 neuronenblitz.reinforcement_learning_enabled
@@ -508,11 +515,14 @@ remote_hardware.grpc.address
 remote_hardware.grpc.backoff_factor
 remote_hardware.grpc.max_retries
 remote_hardware.tier_plugin
+sac.temperature
 scheduler.plugin
 semi_supervised_learning.batch_size
 semi_supervised_learning.enabled
 semi_supervised_learning.epochs
 semi_supervised_learning.unlabeled_weight
+serve_model.host
+serve_model.port
 synaptic_echo_learning.echo_influence
 synaptic_echo_learning.enabled
 synaptic_echo_learning.epochs

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -908,7 +908,12 @@ brain:
   early_stopping_delta: Minimum drop in validation loss required to reset the
     patience counter. This prevents noise in the validation metric from
     triggering false improvements. Typical ranges are ``1e-4`` to ``1e-3``.
-  auto_cluster_interval: Epoch interval between automatic clustering of neurons.
+  auto_cluster_interval: Number of training epochs between automatic neuron
+    clustering passes. Clustering groups neurons with similar activity and
+    relocates them to specialized lobes. Set to ``1`` to cluster after every
+    epoch for rapid topology adaptation or increase to reduce overhead. Values
+    between ``1`` and ``10`` are typical; ``0`` disables automatic clustering
+    entirely.
   cluster_method: Algorithm used for clustering; ``"kmeans"`` is provided but
     others may be added in future.
   auto_save_enabled: Enables periodic saves controlled by ``auto_save_interval``.


### PR DESCRIPTION
## Summary
- Respect `brain.auto_cluster_interval` during training to control how often neurons are re-clustered
- Document clustering interval configuration and add a tutorial project demonstrating its use
- Allow Streamlit playground to swap in a patched `new_marble_system` and gracefully handle instance creation errors

## Testing
- `pytest tests/test_pretraining_and_clustering.py::test_pretraining_epochs_runs_once -q`
- `pytest tests/test_pretraining_and_clustering.py::test_min_cluster_k_enforced -q`
- `pytest tests/test_pretraining_and_clustering.py::test_auto_cluster_interval_respected -q`
- `pytest tests/test_config.py::test_load_config_defaults -q`
- `pytest tests/test_streamlit_progress.py::test_progress_desktop -vv` *(fails: IndexError: list index out of range)*

------
https://chatgpt.com/codex/tasks/task_e_6898db1be3288327924dd4a73e1c40d1