### PR TITLE
Enable UnifiedLearner via config and CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -51,6 +51,20 @@ def main() -> None:
         help="Milliseconds between cross-device tensor synchronizations (100-10000 recommended)",
     )
     parser.add_argument(
+        "--unified-learning",
+        action="store_true",
+        help="Enable UnifiedLearner meta-controller",
+    )
+    parser.add_argument(
+        "--unified-learning-gating-hidden",
+        type=int,
+        help="Hidden units for UnifiedLearner gating network",
+    )
+    parser.add_argument(
+        "--unified-learning-log-path",
+        help="Path to UnifiedLearner decision log",
+    )
+    parser.add_argument(
         "--pipeline",
         help="Path to a pipeline JSON file to execute after initialization",
     )
@@ -127,6 +141,7 @@ def main() -> None:
         "neuronenblitz": {},
         "brain": {},
         "sync": {},
+        "unified_learning": {},
         "network": {"remote_client": {}},
         "core": {},
         "cross_validation": {},
@@ -151,6 +166,12 @@ def main() -> None:
         overrides["brain"]["early_stopping_patience"] = args.early_stopping_patience
     if args.early_stopping_delta is not None:
         overrides["brain"]["early_stopping_delta"] = args.early_stopping_delta
+    if args.unified_learning:
+        overrides["unified_learning"]["enabled"] = True
+    if args.unified_learning_gating_hidden is not None:
+        overrides["unified_learning"]["gating_hidden"] = args.unified_learning_gating_hidden
+    if args.unified_learning_log_path is not None:
+        overrides["unified_learning"]["log_path"] = args.unified_learning_log_path
     if args.remote_retries is not None:
         overrides["network"]["remote_client"]["max_retries"] = args.remote_retries
     if args.remote_backoff is not None:

--- a/config_loader.py
+++ b/config_loader.py
@@ -177,6 +177,7 @@ def create_marble_from_config(
     autograd_params = cfg.get("autograd", {})
     gw_cfg = cfg.get("global_workspace", {})
     ac_cfg = cfg.get("attention_codelets", {})
+    ul_cfg = cfg.get("unified_learning", {})
     pytorch_challenge_params = cfg.get("pytorch_challenge", {})
     gpt_cfg = cfg.get("gpt", {})
 
@@ -314,6 +315,18 @@ def create_marble_from_config(
 
         marble.tensor_sync_service = TensorSyncService(
             interval_ms=int(sync_cfg.get("interval_ms", 1000))
+        )
+    if ul_cfg.get("enabled"):
+        from unified_learning import UnifiedLearner
+
+        learners = ul_cfg.get("learners", {})
+        marble.unified_learner = UnifiedLearner(
+            marble.core,
+            marble.neuronenblitz if hasattr(marble, "neuronenblitz") else marble,
+            learners,
+            gating_hidden=ul_cfg.get("gating_hidden", 8),
+            log_path=ul_cfg.get("log_path"),
+            plugin_dirs=ul_cfg.get("plugin_dirs"),
         )
     if gw_cfg.get("enabled", False):
         from global_workspace import activate as activate_global_workspace

--- a/tests/test_unified_learning_config.py
+++ b/tests/test_unified_learning_config.py
@@ -1,0 +1,28 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from config_loader import create_marble_from_config
+from learning_plugins import LearningModule, register_learning_module
+
+
+class DummyLearner(LearningModule):
+    def train_step(self, *args, device, marble=None):  # pragma: no cover - simple stub
+        return 0.0
+
+
+def test_unified_learning_from_config(tmp_path):
+    register_learning_module("dummy", DummyLearner)
+    log_file = tmp_path / "ul.jsonl"
+    overrides = {
+        "unified_learning": {
+            "enabled": True,
+            "gating_hidden": 5,
+            "log_path": str(log_file),
+            "learners": {"d": "dummy"},
+        }
+    }
+    marble = create_marble_from_config(overrides=overrides)
+    assert hasattr(marble, "unified_learner")
+    ul = marble.unified_learner
+    assert ul.gate[0].out_features == 5
+    assert ul.log_path == str(log_file)

--- a/unused_config_keys.txt
+++ b/unused_config_keys.txt
@@ -534,6 +534,3 @@ transfer_learning.batch_size
 transfer_learning.enabled
 transfer_learning.epochs
 transfer_learning.freeze_fraction
-unified_learning.enabled
-unified_learning.gating_hidden
-unified_learning.log_path


### PR DESCRIPTION
## Summary
- wire up `unified_learning` config to instantiate `UnifiedLearner`
- add CLI flags for UnifiedLearner parameters
- document usage by removing obsolete entries from unused_config_keys
- add regression test for unified learning configuration

## Testing
- `python -m py_compile config_loader.py cli.py tests/test_unified_learning_config.py`


------
https://chatgpt.com/codex/tasks/task_e_6898ea08a26c8327bc5556ceddbc5910