### PR TITLE
Enable autoencoder config parameters

### DIFF
--- a/autoencoder_learning.py
+++ b/autoencoder_learning.py
@@ -32,8 +32,29 @@ class AutoencoderLearner:
         self.history.append({"input": value, "reconstructed": out, "loss": loss})
         return loss
 
-    def train(self, values: list[float], epochs: int = 1) -> None:
+    def train(
+        self, values: list[float], epochs: int = 1, batch_size: int = 1
+    ) -> None:
+        """Train the autoencoder over ``values``.
+
+        Parameters
+        ----------
+        values:
+            Sequence of numeric training examples.
+        epochs:
+            Number of passes over ``values``.
+        batch_size:
+            Quantity of samples processed before advancing to the next batch.
+            Each sample in the batch is processed sequentially as Neuronenblitz
+            currently operates on scalar inputs, but batching enables future
+            optimisations and exposes a consistent interface with other
+            learners.
+        """
+
+        bs = max(1, int(batch_size))
         for _ in range(int(epochs)):
-            for v in values:
-                self.train_step(float(v))
+            for i in range(0, len(values), bs):
+                batch = values[i : i + bs]
+                for v in batch:
+                    self.train_step(float(v))
             self.noise_std *= self.noise_decay

--- a/autoencoder_pipeline.py
+++ b/autoencoder_pipeline.py
@@ -10,6 +10,7 @@ from bit_tensor_dataset import BitTensorDataset
 from marble_core import DataLoader, Core
 from marble_neuronenblitz import Neuronenblitz
 from autoencoder_learning import AutoencoderLearner
+from config_loader import load_config
 from marble_imports import cp
 
 
@@ -24,7 +25,16 @@ class AutoencoderPipeline:
         dataloader: DataLoader | None = None,
         tokenizer: Tokenizer | None = None,
         use_vocab: bool = False,
+        noise_std: float | None = None,
+        noise_decay: float | None = None,
     ) -> None:
+        cfg = load_config()
+        defaults = cfg.get("autoencoder_learning", {})
+        if noise_std is None:
+            noise_std = defaults.get("noise_std", 0.1)
+        if noise_decay is None:
+            noise_decay = defaults.get("noise_decay", 0.99)
+
         self.core = core
         if dataloader is not None:
             self.loader = dataloader
@@ -36,7 +46,9 @@ class AutoencoderPipeline:
         self.use_vocab = use_vocab
         self.last_dataset: BitTensorDataset | None = None
         self.nb = Neuronenblitz(self.core)
-        self.learner = AutoencoderLearner(self.core, self.nb)
+        self.learner = AutoencoderLearner(
+            self.core, self.nb, noise_std=float(noise_std), noise_decay=float(noise_decay)
+        )
 
     def _to_float(self, obj: Any) -> float:
         tensor = self.loader.encode(obj)
@@ -44,7 +56,18 @@ class AutoencoderPipeline:
             return float(cp.asnumpy(tensor).astype(float).mean())
         return float(tensor)
 
-    def train(self, data: Iterable[Any] | Dataset, epochs: int = 1) -> str:
+    def train(
+        self,
+        data: Iterable[Any] | Dataset,
+        epochs: int | None = None,
+        batch_size: int | None = None,
+    ) -> str:
+        cfg = load_config()
+        defaults = cfg.get("autoencoder_learning", {})
+        if epochs is None:
+            epochs = defaults.get("epochs", 1)
+        if batch_size is None:
+            batch_size = defaults.get("batch_size", 1)
         if isinstance(data, Dataset):
             if isinstance(data, BitTensorDataset):
                 bit_ds = data
@@ -56,7 +79,7 @@ class AutoencoderPipeline:
         iter_values = (bit_ds.tensor_to_object(inp) for inp, _ in bit_ds)
         values = [self._to_float(v) for v in iter_values]
         self.last_dataset = bit_ds
-        self.learner.train(values, epochs=epochs)
+        self.learner.train(values, epochs=int(epochs), batch_size=int(batch_size))
         with open(self.save_path, "wb") as f:
             pickle.dump({"core": self.core, "neuronenblitz": self.nb}, f)
         return self.save_path

--- a/marble_interface.py
+++ b/marble_interface.py
@@ -582,11 +582,22 @@ def count_marble_synapses(marble: MARBLE) -> int:
 def train_autoencoder(
     marble: MARBLE,
     values: Iterable[float],
-    epochs: int = 1,
-    noise_std: float = 0.1,
-    noise_decay: float = 0.99,
+    epochs: int | None = None,
+    noise_std: float | None = None,
+    noise_decay: float | None = None,
+    batch_size: int | None = None,
 ) -> float:
     """Train a denoising autoencoder and return the final loss."""
+    cfg = load_config()
+    defaults = cfg.get("autoencoder_learning", {})
+    if not defaults.get("enabled", False):
+        return 0.0
+    epochs = epochs if epochs is not None else defaults.get("epochs", 1)
+    noise_std = noise_std if noise_std is not None else defaults.get("noise_std", 0.1)
+    noise_decay = (
+        noise_decay if noise_decay is not None else defaults.get("noise_decay", 0.99)
+    )
+    batch_size = batch_size if batch_size is not None else defaults.get("batch_size", 1)
 
     learner = AutoencoderLearner(
         marble.get_core(),
@@ -594,7 +605,9 @@ def train_autoencoder(
         noise_std=float(noise_std),
         noise_decay=float(noise_decay),
     )
-    learner.train(list(map(float, values)), epochs=int(epochs))
+    learner.train(
+        list(map(float, values)), epochs=int(epochs), batch_size=int(batch_size)
+    )
     return float(learner.history[-1]["loss"]) if learner.history else 0.0
 
 

--- a/tests/test_autoencoder_config.py
+++ b/tests/test_autoencoder_config.py
@@ -1,0 +1,56 @@
+import marble_interface
+from types import SimpleNamespace
+
+
+def _dummy_marble():
+    return SimpleNamespace(
+        get_core=lambda: object(),
+        get_neuronenblitz=lambda: object(),
+    )
+
+
+def test_train_autoencoder_uses_config_defaults(monkeypatch):
+    cfg = {
+        "autoencoder_learning": {
+            "enabled": True,
+            "epochs": 2,
+            "batch_size": 3,
+            "noise_std": 0.2,
+            "noise_decay": 0.5,
+        }
+    }
+    monkeypatch.setattr(marble_interface, "load_config", lambda: cfg)
+
+    captured = {}
+
+    class DummyLearner:
+        def __init__(self, core, nb, noise_std, noise_decay):
+            captured["noise_std"] = noise_std
+            captured["noise_decay"] = noise_decay
+            self.history = [{"loss": 0.0}]
+
+        def train(self, values, epochs=1, batch_size=1):
+            captured["epochs"] = epochs
+            captured["batch_size"] = batch_size
+
+    monkeypatch.setattr(marble_interface, "AutoencoderLearner", DummyLearner)
+    marble_interface.train_autoencoder(_dummy_marble(), [0.1, 0.2, 0.3])
+    assert captured == {
+        "noise_std": 0.2,
+        "noise_decay": 0.5,
+        "epochs": 2,
+        "batch_size": 3,
+    }
+
+
+def test_train_autoencoder_disabled(monkeypatch):
+    cfg = {"autoencoder_learning": {"enabled": False}}
+    monkeypatch.setattr(marble_interface, "load_config", lambda: cfg)
+
+    class DummyLearner:
+        def __init__(self, *a, **k):  # pragma: no cover - should not be called
+            raise AssertionError("should not instantiate when disabled")
+
+    monkeypatch.setattr(marble_interface, "AutoencoderLearner", DummyLearner)
+    assert marble_interface.train_autoencoder(_dummy_marble(), [0.1]) == 0.0
+

--- a/unused_config_keys.txt
+++ b/unused_config_keys.txt
@@ -4,11 +4,6 @@ adversarial_learning.epochs
 adversarial_learning.noise_dim
 attention_codelets.coalition_size
 attention_codelets.enabled
-autoencoder_learning.batch_size
-autoencoder_learning.enabled
-autoencoder_learning.epochs
-autoencoder_learning.noise_decay
-autoencoder_learning.noise_std
 brain.auto_firing_enabled
 brain.auto_neurogenesis_prob
 brain.auto_offload


### PR DESCRIPTION
## Summary
- respect autoencoder_learning settings from config.yaml
- batch training and configurable defaults for autoencoder pipeline and interface
- remove autoencoder entries from unused_config_keys and add regression tests

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_6898ece33ba8832790de132c75dcf0ce