### PR TITLE
Integrate PyTorch challenge config

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -983,6 +983,20 @@ a minimal web API.
    pytorch_challenge.run_challenge(digits, pretrained_model=pretrained, cfg=cfg)
    ```
    This trains MARBLE and the PyTorch model side by side while increasing neuromodulatory stress whenever MARBLE performs worse.
+   You can also activate the comparison directly via configuration:
+
+   ```yaml
+   pytorch_challenge:
+     enabled: true
+     loss_penalty: 0.1
+     speed_penalty: 0.1
+     size_penalty: 0.1
+   ```
+
+   With `pytorch_challenge.enabled` set to true, `MARBLE` automatically
+   launches the challenge at startup and adjusts neuromodulatory stress after
+   each example when its loss, inference speed or model size trail the
+   pretrained baseline.
 4. **Direct autograd integration** is possible by wrapping the brain with `MarbleAutogradLayer` so PyTorch optimizers can be applied directly:
    ```python
    from marble_autograd import MarbleAutogradLayer

--- a/unused_config_keys.txt
+++ b/unused_config_keys.txt
@@ -485,10 +485,6 @@ predictive_coding.latent_dim
 predictive_coding.learning_rate
 predictive_coding.num_layers
 preprocessing.workers
-pytorch_challenge.enabled
-pytorch_challenge.loss_penalty
-pytorch_challenge.size_penalty
-pytorch_challenge.speed_penalty
 quantum_flux_learning.enabled
 quantum_flux_learning.epochs
 quantum_flux_learning.phase_rate


### PR DESCRIPTION
## Summary
- Add automatic PyTorch challenge runner hooked into configuration
- Document enabling the PyTorch challenge in tutorial
- Remove PyTorch challenge keys from unused list

## Testing
- `python -m py_compile marble_main.py`


------
https://chatgpt.com/codex/tasks/task_e_6898ef6143188327bc904ebf2f9c9bf2