### PR TITLE
Enable predictive coding configuration support

### DIFF
--- a/config_schema.py
+++ b/config_schema.py
@@ -112,6 +112,14 @@ CONFIG_SCHEMA = {
                 "encoding": {"type": ["string", "null"]},
             },
         },
+        "predictive_coding": {
+            "type": "object",
+            "properties": {
+                "num_layers": {"type": "integer", "minimum": 1},
+                "latent_dim": {"type": "integer", "minimum": 1},
+                "learning_rate": {"type": "number", "minimum": 0},
+            },
+        },
         "pipeline": {
             "type": "object",
             "properties": {

--- a/unused_config_keys.txt
+++ b/unused_config_keys.txt
@@ -480,9 +480,6 @@ neuronenblitz.weight_limit
 pipeline.async_enabled
 pipeline.cache_dir
 pipeline.default_step_memory_limit_mb
-predictive_coding.latent_dim
-predictive_coding.learning_rate
-predictive_coding.num_layers
 preprocessing.workers
 quantum_flux_learning.enabled
 quantum_flux_learning.epochs


### PR DESCRIPTION
## Summary
- wire predictive_coding settings from config into MARBLE initialisation
- expand config schema and cleanup unused key list

## Testing
- `pre-commit run --files config_loader.py config_schema.py unused_config_keys.txt`


------
https://chatgpt.com/codex/tasks/task_e_6898f442d3e4832798e1741100ae7cfd