### PR TITLE
Implement MCP server authentication

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -71,9 +71,11 @@ Each entry is listed under its section heading.
 ## mcp_server
 - host
 - port
-- auth.token: Bearer token clients must present.
-- auth.username: Basic auth username.
-- auth.password: Basic auth password.
+- auth.token: Bearer token clients must present. Missing or incorrect tokens
+  produce ``401 Unauthorized`` responses.
+- auth.username: Basic auth username required when ``auth.password`` is set.
+- auth.password: Basic auth password. Requests with wrong credentials result in
+  ``401 Unauthorized``.
 ## sync
 - interval_ms: Interval in milliseconds between cross-device tensor
   synchronisation cycles. Recommended 100–10_000 depending on network speed.

--- a/README.md
+++ b/README.md
@@ -716,8 +716,9 @@ python mcp_server.py --config config.yaml
 
 The server listens on the interface and port specified in ``mcp_server`` of
 ``config.yaml``. Define ``mcp_server.auth.token`` or a ``username``/``password``
-pair to require client authentication. The ``serve_model_mcp`` pipeline plugin
-can also start the MCP server as part of a pipeline.
+pair to require client authentication. Requests lacking valid credentials are
+rejected with ``401 Unauthorized``. The ``serve_model_mcp`` pipeline plugin can
+also start the MCP server as part of a pipeline.
 
 
 ### System Metrics and Profiling

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -3448,7 +3448,9 @@ device used during execution.
 
    When ``host`` or ``port`` are omitted the plugin reads defaults from the
    ``mcp_server`` section of ``config.yaml``. Set ``mcp_server.auth.token`` to
-   require clients to present a bearer token.
+   require clients to present a bearer token or define ``mcp_server.auth.username``
+   and ``mcp_server.auth.password`` for HTTP basic authentication. Requests
+   missing the proper credentials receive a ``401`` status code.
 
 ## Project: Tracking the MARBLE Topology in Kùzu
 

--- a/unused_config_keys.txt
+++ b/unused_config_keys.txt
@@ -282,12 +282,6 @@ logging.max_bytes
 logging.propagate
 logging.rotate
 logging.structured
-mcp_server.auth
-mcp_server.auth.password
-mcp_server.auth.token
-mcp_server.auth.username
-mcp_server.host
-mcp_server.port
 memory_system.consolidation_interval
 memory_system.long_term_path
 memory_system.threshold

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -221,15 +221,17 @@ mcp_server:
   auth:
     token: Optional bearer token that clients must include in the
       ``Authorization`` header. When ``null`` the server does not require token
-      authentication. Tokens allow simple shared-secret authentication without
-      managing user accounts.
+      authentication. Requests missing or presenting an incorrect token receive
+      an HTTP ``401 Unauthorized`` response. Tokens allow simple shared-secret
+      authentication without managing user accounts.
     username: Optional username for HTTP basic authentication. If set, a
       matching ``password`` must also be provided. Both fields may be ``null``
       to disable basic authentication.
     password: Password paired with ``username`` when basic authentication is in
       use. Choose strong, random values when exposing the server on untrusted
       networks. When both ``username`` and ``password`` are ``null`` basic
-      authentication is disabled.
+      authentication is disabled. Clients with missing or invalid credentials
+      receive an HTTP ``401 Unauthorized`` response.
 
 sync:
   interval_ms: Number of milliseconds between background tensor synchronization cycles


### PR DESCRIPTION
## Summary
- add token and basic auth to MCPServer with request validation
- expose auth options through MCPServeModelPlugin and document usage
- add tests covering token and basic authentication paths

## Testing
- `python -m py_compile mcp_server.py pipeline_plugins.py tests/test_mcp_server.py`


------
https://chatgpt.com/codex/tasks/task_e_6898f6d7c4ec832784952aac32d15b0d