### PR TITLE
Wire up unused config parameters

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -429,4 +429,44 @@ def create_marble_from_config(
             learner.train(examples, epochs=int(qf_cfg.get("epochs", 1)))
         marble.quantum_flux_learner = learner
 
+    se_cfg = cfg.get("synaptic_echo_learning", {})
+    if se_cfg.get("enabled", False):
+        from dataset_loader import load_dataset
+        from synaptic_echo_learning import SynapticEchoLearner
+
+        examples = []
+        if dataset_path:
+            try:
+                examples = load_dataset(dataset_path)
+            except Exception:  # pragma: no cover - best effort loading
+                examples = []
+        learner = SynapticEchoLearner(
+            marble.core,
+            marble.neuronenblitz,
+            echo_influence=se_cfg.get("echo_influence", 1.0),
+        )
+        if examples:
+            learner.train(examples, epochs=int(se_cfg.get("epochs", 1)))
+        marble.synaptic_echo_learner = learner
+
+    fd_cfg = cfg.get("fractal_dimension_learning", {})
+    if fd_cfg.get("enabled", False):
+        from dataset_loader import load_dataset
+        from fractal_dimension_learning import FractalDimensionLearner
+
+        examples = []
+        if dataset_path:
+            try:
+                examples = load_dataset(dataset_path)
+            except Exception:  # pragma: no cover - best effort loading
+                examples = []
+        learner = FractalDimensionLearner(
+            marble.core,
+            marble.neuronenblitz,
+            target_dimension=fd_cfg.get("target_dimension", 4.0),
+        )
+        if examples:
+            learner.train(examples, epochs=int(fd_cfg.get("epochs", 1)))
+        marble.fractal_dimension_learner = learner
+
     return marble

--- a/pipeline_cli.py
+++ b/pipeline_cli.py
@@ -1,6 +1,6 @@
 import argparse
 from pipeline import Pipeline
-from config_loader import create_marble_from_config
+from config_loader import create_marble_from_config, load_config
 
 
 def main() -> None:
@@ -10,9 +10,17 @@ def main() -> None:
     args = parser.parse_args()
 
     marble = create_marble_from_config(args.config)
+    cfg = load_config(args.config)
+    pipeline_cfg = cfg.get("pipeline", {})
+    cache_dir = pipeline_cfg.get("cache_dir")
+    default_limit = pipeline_cfg.get("default_step_memory_limit_mb")
     with open(args.pipeline, "r", encoding="utf-8") as f:
         pipe = Pipeline.load_json(f)
-    pipe.execute(marble)
+    pipe.execute(
+        marble,
+        cache_dir=cache_dir,
+        default_memory_limit_mb=default_limit,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_config_trainers.py
+++ b/tests/test_config_trainers.py
@@ -1,4 +1,3 @@
-import os
 import yaml
 from config_loader import create_marble_from_config
 
@@ -32,3 +31,29 @@ def test_quantum_flux_learning_section(tmp_path):
     cfg_path = _write_cfg(tmp_path, cfg)
     marble = create_marble_from_config(cfg_path)
     assert hasattr(marble, "quantum_flux_learner")
+
+
+def test_synaptic_echo_learning_section(tmp_path):
+    cfg = {
+        "synaptic_echo_learning": {
+            "enabled": True,
+            "epochs": 1,
+            "echo_influence": 1.0,
+        }
+    }
+    cfg_path = _write_cfg(tmp_path, cfg)
+    marble = create_marble_from_config(cfg_path)
+    assert hasattr(marble, "synaptic_echo_learner")
+
+
+def test_fractal_dimension_learning_section(tmp_path):
+    cfg = {
+        "fractal_dimension_learning": {
+            "enabled": True,
+            "epochs": 1,
+            "target_dimension": 1.0,
+        }
+    }
+    cfg_path = _write_cfg(tmp_path, cfg)
+    marble = create_marble_from_config(cfg_path)
+    assert hasattr(marble, "fractal_dimension_learner")

--- a/tests/test_pipeline_cli_config.py
+++ b/tests/test_pipeline_cli_config.py
@@ -1,0 +1,30 @@
+import sys
+import yaml
+import pipeline_cli
+from pipeline import Pipeline
+
+
+def _run(tmp_path, monkeypatch):
+    pipe = Pipeline([])
+    pipe_path = tmp_path / "pipe.json"
+    pipe_path.write_text(pipe.to_json())
+    cfg = {"pipeline": {"cache_dir": "cache_test", "default_step_memory_limit_mb": 123}}
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.dump(cfg))
+    captured = {}
+
+    def fake_execute(self, marble, *, cache_dir=None, default_memory_limit_mb=None, **kwargs):
+        captured["cache_dir"] = cache_dir
+        captured["default"] = default_memory_limit_mb
+
+    monkeypatch.setattr(Pipeline, "execute", fake_execute)
+    monkeypatch.setattr(pipeline_cli, "create_marble_from_config", lambda path: object())
+    monkeypatch.setattr(sys, "argv", ["pipeline_cli.py", str(pipe_path), "--config", str(cfg_path)])
+    pipeline_cli.main()
+    return captured
+
+
+def test_pipeline_cli_uses_config(tmp_path, monkeypatch):
+    out = _run(tmp_path, monkeypatch)
+    assert out["cache_dir"] == "cache_test"
+    assert out["default"] == 123


### PR DESCRIPTION
## Summary
- enable synaptic echo and fractal dimension learners via configuration
- allow pipeline CLI to consume cache and memory limit settings
- test config sections for synaptic echo & fractal dimension learners and pipeline CLI cache settings

## Testing
- no tests run (QUICKMODE)


------
https://chatgpt.com/codex/tasks/task_e_68990370fcc48327b5ded3c1ed9f5454