### PR TITLE
Integrate missing configuration handlers

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -177,7 +177,9 @@ def create_marble_from_config(
     autograd_params = cfg.get("autograd", {})
     gw_cfg = cfg.get("global_workspace", {})
     ac_cfg = cfg.get("attention_codelets", {})
+    ci_cfg = cfg.get("conceptual_integration", {})
     ul_cfg = cfg.get("unified_learning", {})
+    tom_cfg = cfg.get("theory_of_mind", {})
     pytorch_challenge_params = cfg.get("pytorch_challenge", {})
     gpt_cfg = cfg.get("gpt", {})
 
@@ -349,6 +351,29 @@ def create_marble_from_config(
         activate_codelets(
             coalition_size=ac_cfg.get("coalition_size", 1),
             salience_weight=core_params.get("salience_weight", 1.0),
+        )
+    if ci_cfg.get("enabled", False):
+        from conceptual_integration import ConceptualIntegrationLearner
+
+        nb_inst = marble.neuronenblitz if hasattr(marble, "neuronenblitz") else marble
+        marble.conceptual_integration = ConceptualIntegrationLearner(
+            marble.core,
+            nb_inst,
+            blend_probability=ci_cfg.get("blend_probability", 0.1),
+            similarity_threshold=ci_cfg.get("similarity_threshold", 0.3),
+        )
+    if tom_cfg:
+        from theory_of_mind import activate as activate_tom
+
+        nb_inst = marble.neuronenblitz if hasattr(marble, "neuronenblitz") else marble
+        marble.theory_of_mind = activate_tom(
+            nb_inst,
+            hidden_size=tom_cfg.get("hidden_size", 16),
+            num_layers=tom_cfg.get("num_layers", 1),
+            prediction_horizon=tom_cfg.get("prediction_horizon", 1),
+            memory_slots=tom_cfg.get("memory_slots", 16),
+            attention_hops=tom_cfg.get("attention_hops", 1),
+            mismatch_threshold=tom_cfg.get("mismatch_threshold", 0.1),
         )
     if qbits:
         from model_quantization import quantize_core_weights

--- a/unused_config_keys.txt
+++ b/unused_config_keys.txt
@@ -80,9 +80,6 @@ brain.tier_decision_params.vram_usage_threshold
 brain.torrent_offload_enabled
 brain.torrent_offload_threshold
 brain.vram_age_threshold
-conceptual_integration.blend_probability
-conceptual_integration.enabled
-conceptual_integration.similarity_threshold
 continual_learning.enabled
 continual_learning.epochs
 continual_learning.memory_size
@@ -500,12 +497,6 @@ synaptic_echo_learning.echo_influence
 synaptic_echo_learning.enabled
 synaptic_echo_learning.epochs
 sync.interval_ms
-theory_of_mind.attention_hops
-theory_of_mind.hidden_size
-theory_of_mind.memory_slots
-theory_of_mind.mismatch_threshold
-theory_of_mind.num_layers
-theory_of_mind.prediction_horizon
 transfer_learning.batch_size
 transfer_learning.enabled
 transfer_learning.epochs


### PR DESCRIPTION
## Summary
- wire up conceptual integration learner activation via `conceptual_integration` config
- enable Theory of Mind module through `theory_of_mind` config options
- prune outdated entries from `unused_config_keys.txt`

## Testing
- `python -m py_compile config_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_6899722fbfe48327a448ea05a4e92b9d