### PR TITLE
Implement config-driven SAC temperature and semi-supervised learner

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -487,6 +487,30 @@ def create_marble_from_config(
             )
         marble.transfer_learner = learner
 
+    ss_cfg = cfg.get("semi_supervised_learning", {})
+    if ss_cfg.get("enabled", False):
+        from dataset_loader import load_dataset
+        from semi_supervised_learning import SemiSupervisedLearner
+
+        examples = []
+        if dataset_path:
+            try:
+                examples = load_dataset(dataset_path)
+            except Exception:  # pragma: no cover - best effort loading
+                examples = []
+        learner = SemiSupervisedLearner(
+            marble.core,
+            marble.neuronenblitz,
+            unlabeled_weight=ss_cfg.get("unlabeled_weight", 0.5),
+        )
+        if examples:
+            learner.train(
+                examples,
+                epochs=int(ss_cfg.get("epochs", 1)),
+                batch_size=int(ss_cfg.get("batch_size", 1)),
+            )
+        marble.semi_supervised_learner = learner
+
     qf_cfg = cfg.get("quantum_flux_learning", {})
     if qf_cfg.get("enabled", False):
         from dataset_loader import load_dataset

--- a/marble_neuronenblitz/learning.py
+++ b/marble_neuronenblitz/learning.py
@@ -36,7 +36,7 @@ def enable_sac(
     device: str | None = None,
     actor_lr: float = 3e-4,
     critic_lr: float = 3e-4,
-    temperature: float = 0.2,
+    temperature: float | None = None,
     tune_entropy: bool = True,
 ) -> None:
     """Attach Soft Actor-Critic networks to ``nb`` on the requested device.
@@ -54,12 +54,20 @@ def enable_sac(
     actor_lr / critic_lr:
         Optimiser learning rates for actor and critic.
     temperature:
-        Initial entropy temperature controlling exploration.
+        Initial entropy temperature controlling exploration. When ``None`` the
+        value is loaded from ``sac.temperature`` in the YAML configuration
+        (default ``0.2``).
     tune_entropy:
         If ``True`` the temperature is automatically tuned toward a target
         entropy of ``-action_dim``. When ``False`` the supplied ``temperature``
         is kept fixed.
     """
+
+    if temperature is None:
+        from config_loader import load_config
+
+        cfg = load_config()
+        temperature = cfg.get("sac", {}).get("temperature", 0.2)
 
     actor, critic = create_sac_networks(state_dim, action_dim, device=device)
     actor_device = next(actor.parameters()).device

--- a/tests/test_config_trainers.py
+++ b/tests/test_config_trainers.py
@@ -21,6 +21,20 @@ def test_reinforcement_learning_section(tmp_path):
     assert hasattr(marble, "rl_agent")
 
 
+def test_semi_supervised_learning_section(tmp_path):
+    cfg = {
+        "semi_supervised_learning": {
+            "enabled": True,
+            "epochs": 1,
+            "batch_size": 1,
+            "unlabeled_weight": 0.5,
+        }
+    }
+    cfg_path = _write_cfg(tmp_path, cfg)
+    marble = create_marble_from_config(cfg_path)
+    assert hasattr(marble, "semi_supervised_learner")
+
+
 def test_quantum_flux_learning_section(tmp_path):
     cfg = {
         "quantum_flux_learning": {

--- a/tests/test_enable_sac.py
+++ b/tests/test_enable_sac.py
@@ -24,3 +24,16 @@ def test_enable_sac_instantiates_networks(device: str) -> None:
     assert log_prob.shape == (1, 1)
     assert q1.shape == (1, 1)
     assert q2.shape == (1, 1)
+
+
+def test_enable_sac_reads_temperature_from_config(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text("sac:\n  temperature: 0.05\n")
+    import config_loader
+
+    monkeypatch.setattr(config_loader, "DEFAULT_CONFIG_FILE", cfg_path)
+
+    core = Core({"width": 1, "height": 1})
+    nb = Neuronenblitz(core)
+    enable_sac(nb, state_dim=3, action_dim=2, tune_entropy=False)
+    assert float(nb.sac_alpha) == pytest.approx(0.05)

--- a/unused_config_keys.txt
+++ b/unused_config_keys.txt
@@ -477,12 +477,7 @@ remote_hardware.grpc.address
 remote_hardware.grpc.backoff_factor
 remote_hardware.grpc.max_retries
 remote_hardware.tier_plugin
-sac.temperature
 scheduler.plugin
-semi_supervised_learning.batch_size
-semi_supervised_learning.enabled
-semi_supervised_learning.epochs
-semi_supervised_learning.unlabeled_weight
 serve_model.host
 serve_model.port
 synaptic_echo_learning.echo_influence


### PR DESCRIPTION
## Summary
- Support enabling SemiSupervisedLearner via `semi_supervised_learning` config with batch size, epochs, and unlabeled weight
- Load Soft Actor-Critic temperature from `sac.temperature` when not specified
- Add regression tests for new configuration hooks

## Testing
- No tests run (QUICKMODE)

------
https://chatgpt.com/codex/tasks/task_e_6899844499a48327a28f36f989e71be4