### PR TITLE
Expose reinforcement learning tuning parameters

### DIFF
--- a/CONFIGURABLE_PARAMETERS.md
+++ b/CONFIGURABLE_PARAMETERS.md
@@ -555,6 +555,9 @@ Each entry is listed under its section heading.
 - epsilon_min
 - seed
 - double_q
+- learning_rate: Step size applied to Q-value updates.
+- policy_hidden_dim: Width of the hidden layer in the policy gradient network.
+- policy_lr: Optimiser learning rate for the policy gradient agent.
 
 ## sac
 - temperature: Entropy temperature coefficient for Soft Actor-Critic. Default

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1198,11 +1198,14 @@ Run `python project05b_rnn_sequence_modeling.py` to train the simple RNN example
    ```
    This uses helper functions that drive the environment and update the Q-table stored inside the Neuronenblitz object.
 4. **Check rewards** in `history` after each episode to verify that the policy improves over time.
+5. **Tune the learning behaviour** by adjusting `reinforcement_learning.learning_rate` in the YAML file. Smaller values make the agent learn more cautiously while larger ones accelerate updates.
 
 To experiment with a differentiable approach set ``reinforcement_learning.algorithm``
 to ``"policy_gradient"`` and run ``project06b_policy_gradient.py``. This file
 trains ``MarblePolicyGradientAgent`` using a policy network wrapped with
-``MarbleAutogradLayer``. Rewards should steadily increase across episodes.
+``MarbleAutogradLayer``. Configure `policy_hidden_dim` to change the network size
+and `policy_lr` to control the optimiser's step size. Rewards should steadily
+increase across episodes.
 
 For entropy-regularised control, switch ``reinforcement_learning.algorithm`` to
 ``"sac"`` and adjust the ``sac.temperature`` value in ``config.yaml``. Higher

--- a/config.yaml
+++ b/config.yaml
@@ -528,6 +528,9 @@ reinforcement_learning:
   epsilon_min: 0.1
   seed: 0
   double_q: false
+  learning_rate: 0.1       # Step size for Q-learning updates
+  policy_hidden_dim: 16    # Hidden layer width for policy gradient agent
+  policy_lr: 0.01          # Learning rate for policy gradient agent
 
 sac:
   temperature: 0.1  # Entropy temperature coefficient for Soft Actor-Critic

--- a/config_loader.py
+++ b/config_loader.py
@@ -406,9 +406,9 @@ def create_marble_from_config(
     rl_cfg = cfg.get("reinforcement_learning", {})
     if rl_cfg.get("enabled", False):
         from reinforcement_learning import (
-            MarbleQLearningAgent,
-            MarblePolicyGradientAgent,
             GridWorld,
+            MarblePolicyGradientAgent,
+            MarbleQLearningAgent,
             train_gridworld,
             train_policy_gradient,
         )
@@ -419,7 +419,12 @@ def create_marble_from_config(
         max_steps = int(rl_cfg.get("max_steps", 50))
         seed = rl_cfg.get("seed", 0)
         if algorithm == "policy_gradient":
-            agent = MarblePolicyGradientAgent(marble.core, marble.neuronenblitz)
+            agent = MarblePolicyGradientAgent(
+                marble.core,
+                marble.neuronenblitz,
+                hidden_dim=int(rl_cfg.get("policy_hidden_dim", 16)),
+                lr=rl_cfg.get("policy_lr", 0.01),
+            )
             train_policy_gradient(agent, env, episodes, max_steps=max_steps, seed=seed)
         else:
             agent = MarbleQLearningAgent(
@@ -430,14 +435,15 @@ def create_marble_from_config(
                 epsilon_decay=rl_cfg.get("epsilon_decay", 0.95),
                 min_epsilon=rl_cfg.get("epsilon_min", 0.1),
                 double_q=rl_cfg.get("double_q", False),
+                learning_rate=rl_cfg.get("learning_rate", 0.1),
             )
             train_gridworld(agent, env, episodes, max_steps=max_steps, seed=seed)
         marble.rl_agent = agent
 
     adv_cfg = cfg.get("adversarial_learning", {})
     if adv_cfg.get("enabled", False):
-        from dataset_loader import load_dataset
         from adversarial_learning import AdversarialLearner
+        from dataset_loader import load_dataset
         from marble_neuronenblitz import Neuronenblitz
 
         examples = []

--- a/config_schema.py
+++ b/config_schema.py
@@ -160,6 +160,24 @@ CONFIG_SCHEMA = {
                 "tokenizer_vocab_size": {"type": "integer", "minimum": 1},
             },
         },
+        "reinforcement_learning": {
+            "type": "object",
+            "properties": {
+                "enabled": {"type": "boolean"},
+                "algorithm": {"type": "string"},
+                "episodes": {"type": "integer", "minimum": 1},
+                "max_steps": {"type": "integer", "minimum": 1},
+                "discount_factor": {"type": "number"},
+                "epsilon_start": {"type": "number"},
+                "epsilon_decay": {"type": "number"},
+                "epsilon_min": {"type": "number"},
+                "seed": {"type": ["integer", "null"]},
+                "double_q": {"type": "boolean"},
+                "learning_rate": {"type": "number", "minimum": 0},
+                "policy_hidden_dim": {"type": "integer", "minimum": 1},
+                "policy_lr": {"type": "number", "minimum": 0},
+            },
+        },
         "sync": {
             "type": "object",
             "properties": {

--- a/tests/test_config_trainers.py
+++ b/tests/test_config_trainers.py
@@ -1,4 +1,5 @@
 import yaml
+
 from config_loader import create_marble_from_config
 
 
@@ -14,11 +15,13 @@ def test_reinforcement_learning_section(tmp_path):
             "enabled": True,
             "episodes": 1,
             "max_steps": 1,
+            "learning_rate": 0.2,
         }
     }
     cfg_path = _write_cfg(tmp_path, cfg)
     marble = create_marble_from_config(cfg_path)
     assert hasattr(marble, "rl_agent")
+    assert marble.rl_agent.lr == 0.2
 
 
 def test_semi_supervised_learning_section(tmp_path):

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -1434,6 +1434,15 @@ reinforcement_learning:
   double_q: Enable Double Q-learning which maintains two separate Q-tables.
     During updates one table selects the greedy action while the other
     evaluates it. This reduces overestimation bias at the cost of extra memory.
+  learning_rate: Step size for Q-value updates. Larger values make the agent
+    adapt faster but can cause instability. Values should lie between ``0`` and
+    ``1`` with ``0.1`` being a typical choice.
+  policy_hidden_dim: Number of neurons in the hidden layer of the policy
+    gradient agent's network. Increasing this allows more expressive policies at
+    the cost of extra computation. Common values range from ``8`` to ``64``.
+  policy_lr: Learning rate for the policy gradient optimiser. Higher values
+    speed up convergence but risk divergence. Values in ``[1e-4, 1e-1]`` are
+    recommended; the default is ``0.01``.
 
 sac:
   temperature: Entropy temperature coefficient for Soft Actor-Critic. This


### PR DESCRIPTION
## Summary
- allow configuring Q-learning step size via `reinforcement_learning.learning_rate`
- add configurable network size and optimizer rate for policy-gradient agent
- document new reinforcement learning parameters and extend schema/tests

## Testing
- `pre-commit run --files reinforcement_learning.py config_loader.py config.yaml CONFIGURABLE_PARAMETERS.md yaml-manual.txt TUTORIAL.md config_schema.py tests/test_reinforcement_learning.py tests/test_config_trainers.py`

------
https://chatgpt.com/codex/tasks/task_e_6899863452148327b8bf74507e31e997