### PR TITLE
Integrate config-driven continual and dream reinforcement learners

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1645,10 +1645,9 @@ Run `python project15_transfer.py` after enabling transfer learning.
 **Goal:** Train sequential tasks while replaying previous examples.**
 
 1. **Enable continual learning** in the configuration by setting `continual_learning.enabled: true` and provide values for `epochs` and the replay `memory_size`.
-2. **Create the learner**:
+2. **Access the learner** created automatically during configuration loading:
    ```python
-   from continual_learning import ReplayContinualLearner
-   learner = ReplayContinualLearner(core, neuronenblitz)
+   learner = marble.continual_learner
    ```
 3. **Download a sequence of datasets** such as Digits, Iris and Wine from `sklearn.datasets`:
    ```python
@@ -1677,12 +1676,11 @@ Run `python project15_transfer.py` after enabling transfer learning.
 from config_loader import load_config
 from marble_main import MARBLE
 from marble import DataLoader
-from continual_learning import ReplayContinualLearner
 
 cfg = load_config()
 dataloader = DataLoader()  # pure numeric features
 marble = MARBLE(cfg['core'])
-learner = ReplayContinualLearner(marble.core, marble.neuronenblitz)
+learner = marble.continual_learner
 from sklearn.datasets import load_digits, load_iris, load_wine
 datasets = [
     [
@@ -1961,10 +1959,9 @@ Run `python project21_quantum_flux.py` to experiment with quantum flux updates.
 **Goal:** Combine dreaming with reinforcement-like updates.**
 
 1. **Enable dream reinforcement** by setting `dream_reinforcement_learning.enabled: true` in the YAML file and configure `episodes`, `dream_cycles`, `dream_strength`, `dream_interval` and `dream_cycle_duration`.
-2. **Instantiate the learner**:
+2. **Use the learner** automatically created when loading the configuration:
    ```python
-   from dream_reinforcement_learning import DreamReinforcementLearner
-   learner = DreamReinforcementLearner(core, neuronenblitz)
+   learner = marble.dream_rl_learner
    ```
 3. **Download a demonstration dataset** using the Hugging Face `datasets` library:
    ```python
@@ -1992,12 +1989,11 @@ Run `python project21_quantum_flux.py` to experiment with quantum flux updates.
 from config_loader import load_config
 from marble_main import MARBLE
 from marble import DataLoader
-from dream_reinforcement_learning import DreamReinforcementLearner
 
 cfg = load_config()
 dataloader = DataLoader()  # numeric RL data
 marble = MARBLE(cfg['core'])
-learner = DreamReinforcementLearner(marble.core, marble.neuronenblitz)
+learner = marble.dream_rl_learner
 from datasets import load_dataset
 dream_demo = load_dataset("deep-rl-datasets", "cartpole-expert-v1")
 import gymnasium as gym

--- a/tests/test_config_trainers.py
+++ b/tests/test_config_trainers.py
@@ -24,6 +24,20 @@ def test_reinforcement_learning_section(tmp_path):
     assert marble.rl_agent.lr == 0.2
 
 
+def test_continual_learning_section(tmp_path):
+    cfg = {
+        "continual_learning": {
+            "enabled": True,
+            "epochs": 1,
+            "memory_size": 2,
+        }
+    }
+    cfg_path = _write_cfg(tmp_path, cfg)
+    marble = create_marble_from_config(cfg_path)
+    assert hasattr(marble, "continual_learner")
+    assert marble.continual_learner.memory_size == 2
+
+
 def test_semi_supervised_learning_section(tmp_path):
     cfg = {
         "semi_supervised_learning": {
@@ -36,6 +50,20 @@ def test_semi_supervised_learning_section(tmp_path):
     cfg_path = _write_cfg(tmp_path, cfg)
     marble = create_marble_from_config(cfg_path)
     assert hasattr(marble, "semi_supervised_learner")
+
+
+def test_dream_reinforcement_learning_section(tmp_path):
+    cfg = {
+        "dream_reinforcement_learning": {
+            "enabled": True,
+            "episodes": 1,
+            "dream_cycles": 1,
+        }
+    }
+    cfg_path = _write_cfg(tmp_path, cfg)
+    marble = create_marble_from_config(cfg_path)
+    assert hasattr(marble, "dream_rl_learner")
+    assert marble.dream_rl_learner.dream_cycles == 1
 
 
 def test_quantum_flux_learning_section(tmp_path):

--- a/unused_config_keys.txt
+++ b/unused_config_keys.txt
@@ -66,9 +66,6 @@ brain.tier_decision_params.ram_usage_threshold
 brain.tier_decision_params.vram_usage_threshold
 brain.torrent_offload_enabled
 brain.torrent_offload_threshold
-continual_learning.enabled
-continual_learning.epochs
-continual_learning.memory_size
 continuous_weight_field_learning.bandwidth
 continuous_weight_field_learning.enabled
 continuous_weight_field_learning.epochs
@@ -198,12 +195,6 @@ dataset.version_registry
 distillation.alpha
 distillation.enabled
 distillation.teacher_model
-dream_reinforcement_learning.dream_cycle_duration
-dream_reinforcement_learning.dream_cycles
-dream_reinforcement_learning.dream_interval
-dream_reinforcement_learning.dream_strength
-dream_reinforcement_learning.enabled
-dream_reinforcement_learning.episodes
 evolution.generations
 evolution.mutation_rate
 evolution.parallelism


### PR DESCRIPTION
## Summary
- hook up `continual_learning` config to instantiate `ReplayContinualLearner`
- add `dream_reinforcement_learning` config support via `DreamReinforcementLearner`
- document new automatic learners in tutorial and tests

## Testing
- `python -m py_compile config_loader.py tests/test_config_trainers.py`


------
https://chatgpt.com/codex/tasks/task_e_689994ddda148327abdb6c94eeaaa537