### PR TITLE
Enhance MetricsVisualizer with style and annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,10 @@ tracked using ``memory_manager.MemoryManager`` while
 ``metrics_dashboard.MetricsDashboard`` provides live charts of loss, VRAM
 consumption and other metrics. When the Global Workspace plugin is active, the
 dashboard also visualises the workspace queue length to monitor cognitive load.
+The underlying ``MetricsVisualizer`` can be customised via the ``metrics_visualizer``
+section in ``config.yaml``. Options such as ``color_scheme`` apply any Matplotlib
+style, ``dpi`` controls rendering resolution and ``show_neuron_ids`` annotates
+each data point with its step index for detailed inspection.
 
 ### Multiprocessing Pipeline Execution
 

--- a/marble_base.py
+++ b/marble_base.py
@@ -182,7 +182,15 @@ class MetricsVisualizer:
         self.setup_plot()
 
     def setup_plot(self):
-        self.fig, self.ax = plt.subplots(figsize=(self.fig_width, self.fig_height))
+        """Initialise Matplotlib figure using configured style and DPI."""
+        try:
+            if self.color_scheme and self.color_scheme != "default":
+                plt.style.use(self.color_scheme)
+        except OSError:  # pragma: no cover - invalid style fallback
+            plt.style.use("default")
+        self.fig, self.ax = plt.subplots(
+            figsize=(self.fig_width, self.fig_height), dpi=self.dpi
+        )
         self.ax.set_title("MARBLE Training Metrics Live View")
         self.ax.set_xlabel("Batches")
         self.ax.set_ylabel("Loss / VRAM Usage")
@@ -257,6 +265,16 @@ class MetricsVisualizer:
         self.ax.grid(True)
         self.ax.legend(loc="upper left")
         self.ax_twin.legend(loc="upper right")
+        if self.show_neuron_ids and self.metrics["loss"]:
+            for idx, loss in enumerate(self.metrics["loss"]):
+                self.ax.annotate(
+                    str(idx),
+                    (idx, loss),
+                    textcoords="offset points",
+                    xytext=(0, 2),
+                    fontsize=6,
+                    color="gray",
+                )
         plt.tight_layout()
         plt.show()
 

--- a/tests/test_metrics_visualizer_options.py
+++ b/tests/test_metrics_visualizer_options.py
@@ -1,0 +1,13 @@
+import matplotlib.pyplot as plt
+from marble_base import MetricsVisualizer
+
+
+def test_metrics_visualizer_style_and_annotations():
+    mv = MetricsVisualizer(color_scheme="dark_background", dpi=123, show_neuron_ids=True)
+    assert mv.fig.get_dpi() == 123
+    mv.update({"loss": 1.0, "vram_usage": 0.5})
+    # Show neuron ids should annotate the plot with text labels
+    assert mv.ax.texts, "Expected annotations when show_neuron_ids is True"
+    # Dark style applies a black axes facecolor
+    assert plt.rcParams["axes.facecolor"] == "black"
+    mv.close()


### PR DESCRIPTION
## Summary
- Enable color scheme and DPI configuration for MetricsVisualizer
- Add optional neuron ID annotations for plotted metrics
- Document customization options and cover them with a unit test

## Testing
- No tests were run (QUICKMODE)


------
https://chatgpt.com/codex/tasks/task_e_689996b7672c8327b7d53fe26f8cc567