### PR TITLE
Refine redevelopment plan and update analysis tracking

### DIFF
--- a/analysedpyfiles.md
+++ b/analysedpyfiles.md
@@ -153,7 +153,7 @@ marble_neuronenblitz.py: lines=2, functions=0, classes=0, lines_read=2
 marble_neuronenblitz/__init__.py: lines=40, functions=0, classes=0, lines_read=40
 marble_neuronenblitz/attention_span.py: lines=49, functions=0, classes=1, lines_read=49
 marble_neuronenblitz/context_attention.py: lines=86, functions=0, classes=1, lines_read=86
-marble_neuronenblitz/core.py: lines=2465, functions=8, classes=1, lines_read=800, lines_remaining=1665
+marble_neuronenblitz/core.py: lines=2465, functions=8, classes=1, lines_read=2465
 marble_neuronenblitz/learning.py: lines=219, functions=8, classes=0, lines_read=219
 marble_neuronenblitz/memory.py: lines=79, functions=2, classes=0, lines_read=79
 marble_registry.py: lines=88, functions=0, classes=1, lines_read=88
@@ -226,7 +226,7 @@ shared_vocab.py: lines=48, functions=1, classes=0, lines_read=48
 soft_actor_critic.py: lines=99, functions=2, classes=2, lines_read=99
 sparse_utils.py: lines=49, functions=4, classes=0, lines_read=49
 streaming_dataset_step.py: lines=120, functions=0, classes=1, lines_read=120
-streamlit_playground.py: lines=3246, functions=104, classes=0, lines_read=1000, lines_remaining=2246
+streamlit_playground.py: lines=3246, functions=104, classes=0, lines_read=3246
 super_evolution_controller.py: lines=158, functions=0, classes=1, lines_read=158
 synaptic_echo_learning.py: lines=26, functions=0, classes=1, lines_read=26
 synthetic_dataset.py: lines=31, functions=2, classes=0, lines_read=31
@@ -290,7 +290,7 @@ tests/test_cli_quantize.py: lines=28, functions=1, classes=2, lines_read=28, lin
 tests/test_concept_association.py: lines=22, functions=1, classes=0, lines_read=22, lines_remaining=0
 tests/test_conceptual_integration.py: lines=18, functions=1, classes=0, lines_read=18, lines_remaining=0
 tests/test_conceptual_integration_pipeline.py: lines=67, functions=5, classes=0, lines_read=67, lines_remaining=0
-tests/test_config.py: lines=293, functions=11, classes=0, lines_read=0, lines_remaining=293
+tests/test_config.py: lines=293, functions=11, classes=0, lines_read=293
 tests/test_config_additional.py: lines=15, functions=1, classes=0, lines_read=15, lines_remaining=0
 tests/test_config_editor.py: lines=27, functions=3, classes=0, lines_read=27, lines_remaining=0
 tests/test_config_federated_learning.py: lines=12, functions=1, classes=0, lines_read=12, lines_remaining=0

--- a/developmentplan.md
+++ b/developmentplan.md
@@ -22,6 +22,7 @@ This document enumerates every step required to rebuild MARBLE from scratch with
 - Enumerate every key from config.yaml and ensure each is mapped to real code paths.
 - Implement validation ensuring no unused keys.
 - Add unit tests verifying that every parameter is exercised at least once.
+- Mirror `tests/test_config.py` to assert default values for core, neuronenblitz and network sections, and extend tests whenever new keys (e.g., `weight_limit`, `wander_cache_size`, `rmsprop_beta`, `grad_epsilon`) are introduced.
 
 
 ### 2.3 Configuration-driven module instantiation
@@ -761,6 +762,10 @@ For each learning paradigm below, reimplement training loops, loss functions, ev
 - `cli.py` exposes `--config` to supply a YAML file and `--pipeline` to run a JSON function sequence created by `save_pipeline_to_json`.
 - `--quantize <bits>` overrides `core.quantization_bits` before model creation, allowing on-the-fly weight quantization.
 - Provide config utilities for headless workflows: `load_config_text`/`save_config_text` with backups, interactive `render_config_editor`, pipeline step serialization (`step_to_json`, `step_to_csv`), graph visualisation (`core_to_networkx`, `core_figure`), metrics inspectors (`metrics_dataframe`, `metrics_figure`, `system_stats`, `core_statistics`, `core_weight_matrix`).
+- Supply dataset inspection and browsing commands mirroring the former playground's "Dataset Browser"; preview CSV/JSON/zip files, inspect individual samples, render bit-level visualisations and expose dataset history operations (`list_history`, `undo_cmd`, `redo_cmd`, `revert_cmd`).
+- Provide commands to list documentation files, show README/TUTORIAL sections and display module source code.
+- Expose utilities to run example project scripts, execute arbitrary code snippets with a `marble` object in scope, construct and persist function pipelines via JSON, and start remote servers or clients with configurable compression and authentication options.
+- Offer training helpers for learners and autoencoders, evaluation against uploaded datasets, RL sandbox controls and neuron activation plotting (`activation_figure`).
 - Tests validate that a minimal configuration executes `count_marble_synapses` and that quantization flags are forwarded correctly.
 - The former Streamlit playground is intentionally omitted; all interaction occurs through CLI and APIs.
 


### PR DESCRIPTION
## Summary
- mark remaining Python files as fully analysed in `analysedpyfiles.md`
- expand redevelopment plan with config default checks and detailed CLI utilities

## Testing
- no tests run (QUICKMODE)


------
https://chatgpt.com/codex/tasks/task_e_689a3fa752e883278313986761b55e3d