### PR TITLE
docs: refine development plan and file count

### DIFF
--- a/analysedpyfiles.md
+++ b/analysedpyfiles.md
@@ -621,4 +621,4 @@ tests/test_model_quantization.py: lines=12, functions=1, classes=0, lines_read=1
 tests/test_monitor_rl_integration.py: lines=19, functions=1, classes=0, lines_read=19
 tests/test_multi_agent.py: lines=39, functions=3, classes=0, lines_read=39
 
-Total Python files analysed: 621
+Total Python files analysed: 619

--- a/developmentplan.md
+++ b/developmentplan.md
@@ -2,6 +2,8 @@
 
 This document enumerates every step required to rebuild MARBLE from scratch with full feature and algorithmic parity. All modules must be reimplemented without simplification and every configuration key must be exercised. No GUI components are to be created. **Every step and substep must be executed strictly in the order presented—skipping or reordering is forbidden.**
 
+This plan integrates information from all 619 Python modules enumerated in analysedpyfiles.md.
+
 ## 1. Repository Bootstrap
 ### 1.1 Initialize new Git repository
 - Create repository structure.
@@ -112,7 +114,7 @@ This document enumerates every step required to rebuild MARBLE from scratch with
 - Implement KuzuMemoryTier using KùzuGraphDatabase with MERGE-based inserts, cosine-similarity query over stored vectors and timestamp-driven `forget_old` trimming.
 - Include forgetfulness and consolidation algorithms.
 
-### 3.4 Plugin system
+### 3.4 Core plugin infrastructure
 - Recreate plugin_system with dynamic loading and registration of neuron, synapse and loss modules.
 - Implement pipeline, scheduler, tool and learning plugin registries.
 - Provide pipeline execution engine:


### PR DESCRIPTION
## Summary
- Clarify that the redevelopment plan integrates insights from all 619 Python modules
- Rename section to "Core plugin infrastructure" for consistency
- Correct total Python file count in analysedpyfiles.md

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_689ac61fbdec8327b5ce59285486d17f