### PR TITLE
Package repo and add import analysis script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,8 @@ readme = "README.md"
 requires-python = ">=3.10"
 authors = [{name = "Marble Contributors"}]
 license = {text = "MIT"}
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["*"]
+

--- a/scripts/analyze_imports.py
+++ b/scripts/analyze_imports.py
@@ -1,0 +1,54 @@
+import ast
+import importlib
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def collect_imports(path: Path) -> List[Tuple[str, int]]:
+    """Return list of (module, line) for imports in *path*."""
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    imports: List[Tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.append((alias.name, node.lineno))
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.append((node.module, node.lineno))
+    return imports
+
+
+def check_module(name: str) -> bool:
+    try:
+        importlib.import_module(name)
+        return True
+    except Exception:
+        return False
+
+
+def analyze_repository(root: Path) -> List[Dict[str, object]]:
+    results: List[Dict[str, object]] = []
+    for file in root.rglob("*.py"):
+        if any(part.startswith(".") for part in file.parts):
+            continue
+        imports = collect_imports(file)
+        if not imports:
+            continue
+        entries = []
+        for module, lineno in imports:
+            ok = check_module(module.split(".")[0])
+            entries.append({"module": module, "line": lineno, "ok": ok})
+        results.append({"file": str(file.relative_to(root)), "imports": entries})
+    return results
+
+
+def main() -> None:
+    data = analyze_repository(ROOT)
+    print(json.dumps(data, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,16 @@
-from setuptools import setup
+from pathlib import Path
+
+from setuptools import find_packages, setup
+
+root = Path(__file__).parent
+py_modules = [
+    p.stem for p in root.glob("*.py") if p.name not in {"setup.py", "install.py"}
+]
 
 setup(
     name="marble",
     version="0.1.0",
-    py_modules=[
-        "marble_core",
-        "marble_neuronenblitz",
-        "marble",
-        "marble_brain",
-        "reinforcement_learning",
-    ],
+    packages=find_packages(),
+    py_modules=py_modules,
     install_requires=[],
 )

--- a/tests/test_analyze_imports.py
+++ b/tests/test_analyze_imports.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from scripts.analyze_imports import analyze_repository, collect_imports
+
+
+def test_collect_imports(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    sample.write_text("import os\nfrom math import sqrt\n")
+    imports = collect_imports(sample)
+    assert ("os", 1) in imports
+    assert any(name == "math" for name, _ in imports)
+
+
+def test_analyze_repository_detects_file() -> None:
+    data = analyze_repository(Path("."))
+    assert any(entry["file"] == "scripts/analyze_imports.py" for entry in data)

--- a/unused_config_keys.txt
+++ b/unused_config_keys.txt
@@ -36,7 +36,6 @@ brain.initial_neurogenesis_factor
 brain.lobe_decay_rate
 brain.lobe_sync_interval
 brain.loss_growth_threshold
-brain.manual_seed
 brain.max_neurogenesis_factor
 brain.max_saved_models
 brain.max_training_epochs


### PR DESCRIPTION
## Summary
- include all modules in setup.py using dynamic discovery so the repo installs as a package
- add script to enumerate and test imports across repository
- provide basic tests for the import analysis helper
- remove `brain.manual_seed` from unused configuration list

## Testing
- `pre-commit run --files setup.py scripts/analyze_imports.py tests/test_analyze_imports.py pyproject.toml unused_config_keys.txt`
- `pytest tests/test_analyze_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_68a465d77eb483279ee02fc3a2368384